### PR TITLE
Removed deprecated 'register' storage class specifier.

### DIFF
--- a/doc/flex.texi
+++ b/doc/flex.texi
@@ -1404,7 +1404,7 @@ example, the following is one way to eat up C comments:
 @verbatim
     %%
     "/*"        {
-                register int c;
+                int c;
 
                 for ( ; ; )
                     {

--- a/examples/fastwc/mywc.c
+++ b/examples/fastwc/mywc.c
@@ -5,7 +5,7 @@
 
 main()
 {
-	register int c, cc = 0, wc = 0, lc = 0;
+	int c, cc = 0, wc = 0, lc = 0;
 	FILE *f = stdin;
 
 	while ((c = getc(f)) != EOF) {

--- a/src/ccl.c
+++ b/src/ccl.c
@@ -92,13 +92,13 @@ void    ccladd (cclp, ch)
 
 static void    dump_cclp (FILE* file, int cclp)
 {
-	register int i;
+	int i;
 
 	putc ('[', file);
 
 	for (i = 0; i < csize; ++i) {
 		if (ccl_contains(cclp, i)){
-			register int start_char = i;
+			int start_char = i;
 
 			putc (' ', file);
 
@@ -244,13 +244,13 @@ void    list_character_set (file, cset)
      FILE   *file;
      int     cset[];
 {
-	register int i;
+	int i;
 
 	putc ('[', file);
 
 	for (i = 0; i < csize; ++i) {
 		if (cset[i]) {
-			register int start_char = i;
+			int start_char = i;
 
 			putc (' ', file);
 

--- a/src/dfa.c
+++ b/src/dfa.c
@@ -101,12 +101,12 @@ void check_trailing_context (nfa_states, num_states, accset, nacc)
      int    *accset;
      int nacc;
 {
-	register int i, j;
+	int i, j;
 
 	for (i = 1; i <= num_states; ++i) {
 		int     ns = nfa_states[i];
-		register int type = state_type[ns];
-		register int ar = assoc_rule[ns];
+		int type = state_type[ns];
+		int ar = assoc_rule[ns];
 
 		if (type == STATE_NORMAL || rule_type[ar] != RULE_VARIABLE) {	/* do nothing */
 		}
@@ -141,14 +141,14 @@ void dump_associated_rules (file, ds)
      FILE   *file;
      int ds;
 {
-	register int i, j;
-	register int num_associated_rules = 0;
-	int     rule_set[MAX_ASSOC_RULES + 1];
-	int    *dset = dss[ds];
-	int     size = dfasiz[ds];
+	int i, j;
+	int num_associated_rules = 0;
+	int rule_set[MAX_ASSOC_RULES + 1];
+	int *dset = dss[ds];
+	int size = dfasiz[ds];
 
 	for (i = 1; i <= size; ++i) {
-		register int rule_num = rule_linenum[assoc_rule[dset[i]]];
+		int rule_num = rule_linenum[assoc_rule[dset[i]]];
 
 		for (j = 1; j <= num_associated_rules; ++j)
 			if (rule_num == rule_set[j])
@@ -191,8 +191,8 @@ void dump_transitions (file, state)
      FILE   *file;
      int state[];
 {
-	register int i, ec;
-	int     out_char_set[CSIZE];
+	int i, ec;
+	int out_char_set[CSIZE];
 
 	for (i = 0; i < csize; ++i) {
 		ec = ABS (ecgroup[i]);
@@ -238,7 +238,7 @@ void dump_transitions (file, state)
 int    *epsclosure (t, ns_addr, accset, nacc_addr, hv_addr)
      int    *t, *ns_addr, accset[], *nacc_addr, *hv_addr;
 {
-	register int stkpos, ns, tsp;
+	int     stkpos, ns, tsp;
 	int     numstates = *ns_addr, nacc, hashval, transsym, nfaccnum;
 	int     stkend, nstate;
 	static int did_stk_init = false, *stk;
@@ -823,9 +823,9 @@ void ntod ()
 int snstods (sns, numstates, accset, nacc, hashval, newds_addr)
      int sns[], numstates, accset[], nacc, hashval, *newds_addr;
 {
-	int     didsort = 0;
-	register int i, j;
-	int     newds, *oldsns;
+	int didsort = 0;
+	int i, j;
+	int newds, *oldsns;
 
 	for (i = 1; i <= lastdfa; ++i)
 		if (hashval == dhash[i]) {

--- a/src/ecs.c
+++ b/src/ecs.c
@@ -139,7 +139,7 @@ void    mkeccl (ccls, lenccl, fwd, bck, llsiz, NUL_mapping)
 
 		for (i = fwd[cclm]; i != NIL && i <= llsiz; i = fwd[i]) {	/* look for the symbol in the character class */
 			for (; j < lenccl; ++j) {
-				register int ccl_char;
+				int ccl_char;
 
 				if (NUL_mapping && ccls[j] == 0)
 					ccl_char = NUL_mapping;

--- a/src/flex.skl
+++ b/src/flex.skl
@@ -1281,9 +1281,9 @@ m4_ifdef( [[M4_YY_NOT_IN_HEADER]],
  */
 YY_DECL
 {
-	register yy_state_type yy_current_state;
-	register char *yy_cp, *yy_bp;
-	register int yy_act;
+	yy_state_type yy_current_state;
+	char *yy_cp, *yy_bp;
+	int yy_act;
     M4_YY_DECL_GUTS_VAR();
 
 m4_ifdef( [[M4_YY_NOT_REENTRANT]],
@@ -1633,9 +1633,9 @@ int yyFlexLexer::yy_get_next_buffer()
 %endif
 {
     M4_YY_DECL_GUTS_VAR();
-	register char *dest = YY_CURRENT_BUFFER_LVALUE->yy_ch_buf;
-	register char *source = YY_G(yytext_ptr);
-	register int number_to_move, i;
+	char *dest = YY_CURRENT_BUFFER_LVALUE->yy_ch_buf;
+	char *source = YY_G(yytext_ptr);
+	int number_to_move, i;
 	int ret_val;
 
 	if ( YY_G(yy_c_buf_p) > &YY_CURRENT_BUFFER_LVALUE->yy_ch_buf[YY_G(yy_n_chars) + 1] )
@@ -1781,8 +1781,8 @@ m4_ifdef( [[M4_YY_USES_REJECT]],
     yy_state_type yyFlexLexer::yy_get_previous_state()
 %endif
 {
-	register yy_state_type yy_current_state;
-	register char *yy_cp;
+	yy_state_type yy_current_state;
+	char *yy_cp;
     M4_YY_DECL_GUTS_VAR();
 
 %% [15.0] code to get the start state into yy_current_state goes here
@@ -1808,7 +1808,7 @@ m4_ifdef( [[M4_YY_USES_REJECT]],
     yy_state_type yyFlexLexer::yy_try_NUL_trans( yy_state_type yy_current_state )
 %endif
 {
-	register int yy_is_jam;
+	int yy_is_jam;
     M4_YY_DECL_GUTS_VAR(); /* This var may be unused depending upon options. */
 %% [17.0] code to find the next state, and perhaps do backing up, goes here
 
@@ -1820,13 +1820,13 @@ m4_ifdef( [[M4_YY_USES_REJECT]],
 %if-c-only
 m4_ifdef( [[M4_YY_NO_UNPUT]],,
 [[
-    static void yyunput YYFARGS2( int,c, register char *,yy_bp)
+    static void yyunput YYFARGS2( int,c, char *,yy_bp)
 %endif
 %if-c++-only
-    void yyFlexLexer::yyunput( int c, register char* yy_bp)
+    void yyFlexLexer::yyunput( int c, char* yy_bp)
 %endif
 {
-	register char *yy_cp;
+	char *yy_cp;
     M4_YY_DECL_GUTS_VAR();
 
     yy_cp = YY_G(yy_c_buf_p);
@@ -1837,10 +1837,10 @@ m4_ifdef( [[M4_YY_NO_UNPUT]],,
 	if ( yy_cp < YY_CURRENT_BUFFER_LVALUE->yy_ch_buf + 2 )
 		{ /* need to shift things up to make room */
 		/* +2 for EOB chars. */
-		register yy_size_t number_to_move = YY_G(yy_n_chars) + 2;
-		register char *dest = &YY_CURRENT_BUFFER_LVALUE->yy_ch_buf[
+		yy_size_t number_to_move = YY_G(yy_n_chars) + 2;
+		char *dest = &YY_CURRENT_BUFFER_LVALUE->yy_ch_buf[
 					YY_CURRENT_BUFFER_LVALUE->yy_buf_size + 2];
-		register char *source =
+		char *source =
 				&YY_CURRENT_BUFFER_LVALUE->yy_ch_buf[number_to_move];
 
 		while ( source > YY_CURRENT_BUFFER_LVALUE->yy_ch_buf )
@@ -2974,7 +2974,7 @@ m4_ifdef( [[M4_YY_NOT_IN_HEADER]],
 #ifndef yytext_ptr
 static void yy_flex_strncpy YYFARGS3( char*,s1, yyconst char *,s2, int,n)
 {
-	register int i;
+	int i;
 	for ( i = 0; i < n; ++i )
 		s1[i] = s2[i];
 }
@@ -2986,7 +2986,7 @@ m4_ifdef( [[M4_YY_NOT_IN_HEADER]],
 #ifdef YY_NEED_STRLEN
 static int yy_flex_strlen YYFARGS1( yyconst char *,s)
 {
-	register int n;
+	int n;
 	for ( n = 0; s[n]; ++n )
 		;
 

--- a/src/flexdef.h
+++ b/src/flexdef.h
@@ -844,10 +844,10 @@ extern void action_define PROTO ((const char *defname, int value));
 extern void add_action PROTO ((const char *new_text));
 
 /* True if a string is all lower case. */
-extern int all_lower PROTO ((register char *));
+extern int all_lower PROTO ((char *));
 
 /* True if a string is all upper case. */
-extern int all_upper PROTO ((register char *));
+extern int all_upper PROTO ((char *));
 
 /* Compare two integers for use by qsort. */
 extern int intcmp PROTO ((const void *, const void *));
@@ -859,10 +859,10 @@ extern void check_char PROTO ((int c));
 extern Char clower PROTO ((int));
 
 /* Returns a dynamically allocated copy of a string. */
-extern char *copy_string PROTO ((register const char *));
+extern char *copy_string PROTO ((const char *));
 
 /* Returns a dynamically allocated copy of a (potentially) unsigned string. */
-extern Char *copy_unsigned_string PROTO ((register Char *));
+extern Char *copy_unsigned_string PROTO ((Char *));
 
 /* Compare two characters for use by qsort with '\0' sorting last. */
 extern int cclcmp PROTO ((const void *, const void *));
@@ -988,7 +988,7 @@ extern int link_machines PROTO ((int, int));
 /* Mark each "beginning" state in a machine as being a "normal" (i.e.,
  * not trailing context associated) state.
  */
-extern void mark_beginning_as_normal PROTO ((register int));
+extern void mark_beginning_as_normal PROTO ((int));
 
 /* Make a machine that branches to two machines. */
 extern int mkbranch PROTO ((int, int));

--- a/src/gen.c
+++ b/src/gen.c
@@ -81,7 +81,7 @@ static const char *get_state_decl (void)
 
 void do_indent ()
 {
-	register int i = indent_level * 8;
+	int i = indent_level * 8;
 
 	while (i >= 8) {
 		outc ('\t');
@@ -201,7 +201,7 @@ void gen_bu_action ()
 
 static struct yytbl_data *mkctbl (void)
 {
-	register int i;
+	int i;
 	struct yytbl_data *tbl = 0;
 	flex_int32_t *tdata = 0, curr = 0;
 	int     end_of_buffer_action = num_rules + 1;
@@ -332,7 +332,7 @@ static struct yytbl_data *mkssltbl (void)
 
 void genctbl ()
 {
-	register int i;
+	int i;
 	int     end_of_buffer_action = num_rules + 1;
 
 	/* Table of verify for transition and offset to next state. */
@@ -433,7 +433,7 @@ void genctbl ()
 
 struct yytbl_data *mkecstbl (void)
 {
-	register int i;
+	int i;
 	struct yytbl_data *tbl = 0;
 	flex_int32_t *tdata = 0;
 
@@ -462,7 +462,7 @@ struct yytbl_data *mkecstbl (void)
 
 void genecs ()
 {
-	register int i, j;
+	int i, j;
 	int     numrows;
 
 	out_str_dec (get_int32_decl (), "yy_ec", csize);
@@ -637,7 +637,7 @@ void gen_find_action ()
 
 struct yytbl_data *mkftbl (void)
 {
-	register int i;
+	int i;
 	int     end_of_buffer_action = num_rules + 1;
 	struct yytbl_data *tbl;
 	flex_int32_t *tdata = 0;
@@ -654,7 +654,7 @@ struct yytbl_data *mkftbl (void)
 	dfaacc[end_of_buffer_state].dfaacc_state = end_of_buffer_action;
 
 	for (i = 1; i <= lastdfa; ++i) {
-		register int anum = dfaacc[i].dfaacc_state;
+		int anum = dfaacc[i].dfaacc_state;
 
 		tdata[i] = anum;
 
@@ -674,7 +674,7 @@ struct yytbl_data *mkftbl (void)
 
 void genftbl ()
 {
-	register int i;
+	int i;
 	int     end_of_buffer_action = num_rules + 1;
 
 	out_str_dec (long_align ? get_int32_decl () : get_int16_decl (),
@@ -683,7 +683,7 @@ void genftbl ()
 	dfaacc[end_of_buffer_state].dfaacc_state = end_of_buffer_action;
 
 	for (i = 1; i <= lastdfa; ++i) {
-		register int anum = dfaacc[i].dfaacc_state;
+		int anum = dfaacc[i].dfaacc_state;
 
 		mkdata (anum);
 
@@ -708,7 +708,7 @@ void genftbl ()
 void gen_next_compressed_state (char_map)
      char   *char_map;
 {
-	indent_put2s ("register YY_CHAR yy_c = %s;", char_map);
+	indent_put2s ("YY_CHAR yy_c = %s;", char_map);
 
 	/* Save the backing-up info \before/ computing the next state
 	 * because we always compute one more state than needed - we
@@ -794,8 +794,8 @@ void gen_next_match ()
 	else if (fullspd) {
 		indent_puts ("{");
 		indent_puts
-			("register yyconst struct yy_trans_info *yy_trans_info;\n");
-		indent_puts ("register YY_CHAR yy_c;\n");
+			("yyconst struct yy_trans_info *yy_trans_info;\n");
+		indent_puts ("YY_CHAR yy_c;\n");
 		indent_put2s ("for ( yy_c = %s;", char_map);
 		indent_puts
 			("      (yy_trans_info = &yy_current_state[(unsigned int) yy_c])->");
@@ -938,7 +938,7 @@ void gen_NUL_trans ()
 		/* We're going to need yy_cp lying around for the call
 		 * below to gen_backing_up().
 		 */
-		indent_puts ("register char *yy_cp = YY_G(yy_c_buf_p);");
+		indent_puts ("char *yy_cp = YY_G(yy_c_buf_p);");
 
 	outc ('\n');
 
@@ -959,10 +959,10 @@ void gen_NUL_trans ()
 
 	else if (fullspd) {
 		do_indent ();
-		out_dec ("register int yy_c = %d;\n", NUL_ec);
+		out_dec ("int yy_c = %d;\n", NUL_ec);
 
 		indent_puts
-			("register yyconst struct yy_trans_info *yy_trans_info;\n");
+			("yyconst struct yy_trans_info *yy_trans_info;\n");
 		indent_puts
 			("yy_trans_info = &yy_current_state[(unsigned int) yy_c];");
 		indent_puts ("yy_current_state += yy_trans_info->yy_nxt;");
@@ -1319,7 +1319,7 @@ void gentabs ()
 	yybase_curr = 1;
 
 	for (i = 1; i <= lastdfa; ++i) {
-		register int d = def[i];
+		int d = def[i];
 
 		if (base[i] == JAMSTATE)
 			base[i] = jambase;
@@ -1501,8 +1501,8 @@ void indent_puts (str)
 
 void make_tables ()
 {
-	register int i;
-	int     did_eof_rule = false;
+	int i;
+	int did_eof_rule = false;
 	struct yytbl_data *yynultrans_tbl;
 
 

--- a/src/misc.c
+++ b/src/misc.c
@@ -168,7 +168,7 @@ void   *allocate_array (size, element_size)
      int size;
      size_t element_size;
 {
-	register void *mem;
+	void *mem;
 	size_t  num_bytes = element_size * size;
 
 	mem = flex_alloc (num_bytes);
@@ -183,7 +183,7 @@ void   *allocate_array (size, element_size)
 /* all_lower - true if a string is all lower-case */
 
 int all_lower (str)
-     register char *str;
+     char *str;
 {
 	while (*str) {
 		if (!isascii ((Char) * str) || !islower ((Char) * str))
@@ -198,7 +198,7 @@ int all_lower (str)
 /* all_upper - true if a string is all upper-case */
 
 int all_upper (str)
-     register char *str;
+     char *str;
 {
 	while (*str) {
 		if (!isascii ((Char) * str) || !isupper ((Char) * str))
@@ -241,7 +241,7 @@ void check_char (c)
 /* clower - replace upper-case letter to lower-case */
 
 Char clower (c)
-     register int c;
+     int c;
 {
 	return (Char) ((isascii (c) && isupper (c)) ? tolower (c) : c);
 }
@@ -250,10 +250,10 @@ Char clower (c)
 /* copy_string - returns a dynamically allocated copy of a string */
 
 char   *copy_string (str)
-     register const char *str;
+     const char *str;
 {
-	register const char *c1;
-	register char *c2;
+	const char *c1;
+	char *c2;
 	char   *copy;
 	unsigned int size;
 
@@ -278,9 +278,9 @@ char   *copy_string (str)
  */
 
 Char   *copy_unsigned_string (str)
-     register Char *str;
+     Char *str;
 {
-	register Char *c;
+	Char *c;
 	Char   *copy;
 
 	/* find length */
@@ -746,7 +746,7 @@ void out_m4_define (const char* def, const char* val)
  */
 
 char   *readable_form (c)
-     register int c;
+     int c;
 {
 	static char rform[20];
 
@@ -798,7 +798,7 @@ void   *reallocate_array (array, size, element_size)
      int size;
      size_t element_size;
 {
-	register void *new_array;
+	void *new_array;
 	size_t  num_bytes = element_size * size;
 
 	new_array = flex_realloc (array, num_bytes);
@@ -994,7 +994,7 @@ void zero_out (region_ptr, size_in_bytes)
      char   *region_ptr;
      size_t size_in_bytes;
 {
-	register char *rp, *rp_end;
+	char *rp, *rp_end;
 
 	rp = region_ptr;
 	rp_end = region_ptr + size_in_bytes;

--- a/src/nfa.c
+++ b/src/nfa.c
@@ -340,7 +340,7 @@ int     link_machines (first, last)
  */
 
 void    mark_beginning_as_normal (mach)
-     register int mach;
+     int mach;
 {
 	switch (state_type[mach]) {
 	case STATE_NORMAL:

--- a/src/parse.y
+++ b/src/parse.y
@@ -953,7 +953,7 @@ string		:  string CHAR
 
 void build_eof_action()
 	{
-	register int i;
+	int i;
 	char action_text[MAXLINE];
 
 	for ( i = 1; i <= scon_stk_ptr; ++i )

--- a/src/scan.l
+++ b/src/scan.l
@@ -661,7 +661,7 @@ M4QEND      "]]"
      * context.
      */
 	"{"{NAME}"}"[[:space:]]?	 {
-			register Char *nmdefptr;
+			Char *nmdefptr;
             int end_is_ws, end_ch;
 
             end_ch = yytext[yyleng-1];

--- a/src/sym.c
+++ b/src/sym.c
@@ -59,12 +59,12 @@ static struct hash_entry *ccltab[CCL_HASH_SIZE];
 
 /* declare functions that have forward references */
 
-static int addsym PROTO ((register char[], char *, int, hash_table, int));
-static struct hash_entry *findsym PROTO ((register const char *sym,
+static int addsym PROTO ((char[], char *, int, hash_table, int));
+static struct hash_entry *findsym PROTO ((const char *sym,
 					  hash_table table,
 
 					  int table_size));
-static int hashfunct PROTO ((register const char *, int));
+static int hashfunct PROTO ((const char *, int));
 
 
 /* addsym - add symbol and definitions to symbol table
@@ -73,16 +73,16 @@ static int hashfunct PROTO ((register const char *, int));
  */
 
 static int addsym (sym, str_def, int_def, table, table_size)
-     register char sym[];
+     char sym[];
      char   *str_def;
      int     int_def;
      hash_table table;
      int     table_size;
 {
-	int     hash_val = hashfunct (sym, table_size);
-	register struct hash_entry *sym_entry = table[hash_val];
-	register struct hash_entry *new_entry;
-	register struct hash_entry *successor;
+	int    hash_val = hashfunct (sym, table_size);
+	struct hash_entry *sym_entry = table[hash_val];
+	struct hash_entry *new_entry;
+	struct hash_entry *successor;
 
 	while (sym_entry) {
 		if (!strcmp (sym, sym_entry->name)) {	/* entry already exists */
@@ -147,7 +147,7 @@ int     ccllookup (ccltxt)
 /* findsym - find symbol in symbol table */
 
 static struct hash_entry *findsym (sym, table, table_size)
-     register const char *sym;
+     const char *sym;
      hash_table table;
      int     table_size;
 {
@@ -155,7 +155,7 @@ static struct hash_entry *findsym (sym, table, table_size)
 		(struct hash_entry *) 0, (struct hash_entry *) 0,
 		(char *) 0, (char *) 0, 0,
 	};
-	register struct hash_entry *sym_entry =
+	struct hash_entry *sym_entry =
 
 		table[hashfunct (sym, table_size)];
 
@@ -171,11 +171,11 @@ static struct hash_entry *findsym (sym, table, table_size)
 /* hashfunct - compute the hash value for "str" and hash size "hash_size" */
 
 static int hashfunct (str, hash_size)
-     register const char *str;
+     const char *str;
      int     hash_size;
 {
-	register int hashval;
-	register int locstr;
+	int hashval;
+	int locstr;
 
 	hashval = 0;
 	locstr = 0;

--- a/src/tblcmp.c
+++ b/src/tblcmp.c
@@ -36,7 +36,7 @@
 
 /* declarations for functions that have forward references */
 
-void mkentry PROTO ((register int *, int, int, int, int));
+void mkentry PROTO ((int *, int, int, int, int));
 void mkprot PROTO ((int[], int, int));
 void mktemplate PROTO ((int[], int, int));
 void mv2front PROTO ((int));
@@ -223,9 +223,9 @@ void    bldtbl (state, statenum, totaltrans, comstate, comfreq)
 
 void    cmptmps ()
 {
-	int     tmpstorage[CSIZE + 1];
-	register int *tmp = tmpstorage, i, j;
-	int     totaltrans, trans;
+	int tmpstorage[CSIZE + 1];
+	int *tmp = tmpstorage, i, j;
+	int totaltrans, trans;
 
 	peakpairs = numtemps * numecs + tblend;
 
@@ -291,7 +291,7 @@ void    cmptmps ()
 
 void    expand_nxt_chk ()
 {
-	register int old_max = current_max_xpairs;
+	int old_max = current_max_xpairs;
 
 	current_max_xpairs += MAX_XPAIRS_INCREMENT;
 
@@ -330,9 +330,9 @@ int     find_table_space (state, numtrans)
 	/* Firstfree is the position of the first possible occurrence of two
 	 * consecutive unused records in the chk and nxt arrays.
 	 */
-	register int i;
-	register int *state_ptr, *chk_ptr;
-	register int *ptr_to_last_entry_in_state;
+	int i;
+	int *state_ptr, *chk_ptr;
+	int *ptr_to_last_entry_in_state;
 
 	/* If there are too many out-transitions, put the state at the end of
 	 * nxt and chk.
@@ -421,7 +421,7 @@ int     find_table_space (state, numtrans)
  */
 void    inittbl ()
 {
-	register int i;
+	int i;
 
 	zero_out ((char *) chk,
 
@@ -501,11 +501,11 @@ void    mkdeftbl ()
  */
 
 void    mkentry (state, numchars, statenum, deflink, totaltrans)
-     register int *state;
-     int     numchars, statenum, deflink, totaltrans;
+     int *state;
+     int numchars, statenum, deflink, totaltrans;
 {
-	register int minec, maxec, i, baseaddr;
-	int     tblbase, tbllast;
+	int minec, maxec, i, baseaddr;
+	int tblbase, tbllast;
 
 	if (totaltrans == 0) {	/* there are no out-transitions */
 		if (deflink == JAMSTATE)
@@ -762,9 +762,9 @@ void    mv2front (qelm)
 void    place_state (state, statenum, transnum)
      int    *state, statenum, transnum;
 {
-	register int i;
-	register int *state_ptr;
-	int     position = find_table_space (state, transnum);
+	int i;
+	int *state_ptr;
+	int position = find_table_space (state, transnum);
 
 	/* "base" is the table of start positions. */
 	base[statenum] = position;
@@ -835,8 +835,8 @@ void    stack1 (statenum, sym, nextstate, deflink)
 int     tbldiff (state, pr, ext)
      int     state[], pr, ext[];
 {
-	register int i, *sp = state, *ep = ext, *protp;
-	register int numdiff = 0;
+	int i, *sp = state, *ep = ext, *protp;
+	int numdiff = 0;
 
 	protp = &protsave[numecs * (pr - 1)];
 

--- a/to.do/Wilhelms.todo
+++ b/to.do/Wilhelms.todo
@@ -323,7 +323,7 @@ GEN.C 632: (gen_NUL_trans(): I have rewritten 'yy_try_NUL_trans()'. The new
 
     if ( need_backtracking )
 	/ * we'll need yy_cp lying around for the gen_backtracking() * /
-	indent_puts( "register YY_CHAR *yy_cp = yy_c_buf_p;" ); */
+	indent_puts( "YY_CHAR *yy_cp = yy_c_buf_p;" ); */
 
     GEN.C, line 674ff:
 /*	if ( reject )
@@ -458,7 +458,7 @@ GEN.C 1317: (make_tables(): In the generation of 'yy_get_previous_state()' the
     yymore-prefix instead of the current run.)
 
     if ( bol_needed )
-	indent_puts( "register YY_CHAR *yy_bp = yytext + YY_MORE_ADJ;\n" );
+	indent_puts( "YY_CHAR *yy_bp = yytext + YY_MORE_ADJ;\n" );
 
 FLEX.SKEL 589ff: (yyunput(): The function 'yyunput()' should be rewritten.
     First of all the example for 'unput()' in file flexdoc doesn't work:
@@ -492,7 +492,7 @@ FLEX.SKEL 589ff: (yyunput(): The function 'yyunput()' should be rewritten.
 
     Remark: The parameter 'yytext' in " yyunput( c, yytext ) " is not really
     necessary since 'yytext' is a global variable. You could also set
-    " register YY_CHAR *yy_bp = yytext; " at the beginning of 'yyunput()'.)
+    " YY_CHAR *yy_bp = yytext; " at the beginning of 'yyunput()'.)
 
     Replace lines 622 - 623 in FLEX.SKEL:
 

--- a/to.do/flex.rmail
+++ b/to.do/flex.rmail
@@ -457,9 +457,9 @@ from ftp://ftp.ee.lbl.gov/.vp-flex-reentrant.tar.gz .
 > flex -t -Pcap_string_ cap_string.flex > cap_string.c
 > cc -Wall   -c -o cap_string.o cap_string.c
 > cap_string.flex:163: parse error before `{'
-> cap_string.flex:165: register name not specified for `yy_cp'
-> cap_string.flex:165: register name not specified for `yy_bp'
-> cap_string.flex:166: register name not specified for `yy_act'
+> cap_string.flex:165: name not specified for `yy_cp'
+> cap_string.flex:165: name not specified for `yy_bp'
+> cap_string.flex:166: name not specified for `yy_act'
 > cap_string.flex:39: parse error before `if'
 > ...
 

--- a/to.do/streams.mail
+++ b/to.do/streams.mail
@@ -136,8 +136,8 @@ diff -c flex-2.5.4.orig/flex.skl flex-2.5.4/flex.skl
 *** 881,886 ****
 --- 912,918 ----
   	{
-  	register yy_state_type yy_current_state;
-  	register char *yy_cp;
+  	yy_state_type yy_current_state;
+  	char *yy_cp;
 + 	char *yy_bp;
   
   %% code to get the start state into yy_current_state goes here

--- a/to.do/unicode/ccl.c
+++ b/to.do/unicode/ccl.c
@@ -120,7 +120,7 @@ void list_character_set( file, cset )
 FILE *file;
 int cset[];
 	{
-	register int i;
+	int i;
 
 	putc( '[', file );
 
@@ -128,7 +128,7 @@ int cset[];
 		{
 		if ( cset[i] )
 			{
-			register int start_char = i;
+			int start_char = i;
 
 			putc( ' ', file );
 

--- a/to.do/unicode/ecs.c
+++ b/to.do/unicode/ecs.c
@@ -142,7 +142,7 @@ int lenccl, fwd[], bck[], llsiz, NUL_mapping;
 			{ /* look for the symbol in the character class */
 			for ( ; j < lenccl; ++j )
 				{
-				register int ccl_char;
+				int ccl_char;
 
 				if ( NUL_mapping && ccls[j] == 0 )
 					ccl_char = NUL_mapping;

--- a/to.do/unicode/flex.1
+++ b/to.do/unicode/flex.1
@@ -942,7 +942,7 @@ the following is one way to eat up C comments:
 
     %%
     "/*"        {
-                register int c;
+                int c;
 
                 for ( ; ; )
                     {

--- a/to.do/unicode/flex.skl
+++ b/to.do/unicode/flex.skl
@@ -447,9 +447,9 @@ YY_MALLOC_DECL
 
 YY_DECL
 	{
-	register yy_state_type yy_current_state;
-	register YY_CHAR *yy_cp, *yy_bp;
-	register int yy_act;
+	yy_state_type yy_current_state;
+	YY_CHAR *yy_cp, *yy_bp;
+	int yy_act;
 
 %% user's declarations go here
 
@@ -742,9 +742,9 @@ static int yy_get_next_buffer()
 int yyFlexLexer::yy_get_next_buffer()
 %*
 	{
-	register YY_CHAR *dest = yy_current_buffer->yy_ch_buf;
-	register YY_CHAR *source = yytext_ptr;
-	register int number_to_move, i;
+	YY_CHAR *dest = yy_current_buffer->yy_ch_buf;
+	YY_CHAR *source = yytext_ptr;
+	int number_to_move, i;
 	int ret_val;
 
 	if ( yy_c_buf_p > &yy_current_buffer->yy_ch_buf[yy_n_chars + 1] )
@@ -879,8 +879,8 @@ static yy_state_type yy_get_previous_state()
 yy_state_type yyFlexLexer::yy_get_previous_state()
 %*
 	{
-	register yy_state_type yy_current_state;
-	register YY_CHAR *yy_cp;
+	yy_state_type yy_current_state;
+	YY_CHAR *yy_cp;
 
 %% code to get the start state into yy_current_state goes here
 
@@ -910,7 +910,7 @@ yy_state_type yy_current_state;
 yy_state_type yyFlexLexer::yy_try_NUL_trans( yy_state_type yy_current_state )
 %*
 	{
-	register int yy_is_jam;
+	int yy_is_jam;
 %% code to find the next state, and perhaps do backing up, goes here
 
 	return yy_is_jam ? 0 : yy_current_state;
@@ -920,17 +920,17 @@ yy_state_type yyFlexLexer::yy_try_NUL_trans( yy_state_type yy_current_state )
 %-
 #ifndef YY_NO_UNPUT
 #ifdef YY_USE_PROTOS
-static void yyunput( int c, register YY_CHAR *yy_bp )
+static void yyunput( int c, YY_CHAR *yy_bp )
 #else
 static void yyunput( c, yy_bp )
 int c;
-register YY_CHAR *yy_bp;
+YY_CHAR *yy_bp;
 #endif
 %+
-void yyFlexLexer::yyunput( int c, register YY_CHAR* yy_bp )
+void yyFlexLexer::yyunput( int c, YY_CHAR* yy_bp )
 %*
 	{
-	register YY_CHAR *yy_cp = yy_c_buf_p;
+	YY_CHAR *yy_cp = yy_c_buf_p;
 
 	/* undo effects of setting up yytext */
 	*yy_cp = yy_hold_char;
@@ -938,10 +938,10 @@ void yyFlexLexer::yyunput( int c, register YY_CHAR* yy_bp )
 	if ( yy_cp < yy_current_buffer->yy_ch_buf + 2 )
 		{ /* need to shift things up to make room */
 		/* +2 for EOB chars. */
-		register int number_to_move = yy_n_chars + 2;
-		register YY_CHAR *dest = &yy_current_buffer->yy_ch_buf[
+		int number_to_move = yy_n_chars + 2;
+		YY_CHAR *dest = &yy_current_buffer->yy_ch_buf[
 					yy_current_buffer->yy_buf_size + 2];
-		register YY_CHAR *source =
+		YY_CHAR *source =
 				&yy_current_buffer->yy_ch_buf[number_to_move];
 
 		while ( source > yy_current_buffer->yy_ch_buf )
@@ -1472,7 +1472,7 @@ yyconst YY_CHAR *s2;
 int n;
 #endif
 	{
-	register int i;
+	int i;
 	for ( i = 0; i < n; ++i )
 		s1[i] = s2[i];
 	}
@@ -1486,7 +1486,7 @@ static int yy_flex_strlen( s )
 yyconst YY_CHAR *s;
 #endif
 	{
-	register int n;
+	int n;
 	for ( n = 0; s[n]; ++n )
 		;
 

--- a/to.do/unicode/flexdef.h
+++ b/to.do/unicode/flexdef.h
@@ -827,10 +827,10 @@ extern void action_define PROTO(( char *defname, int value ));
 extern void add_action PROTO(( char *new_text ));
 
 /* True if a string is all lower case. */
-extern int all_lower PROTO((register char *));
+extern int all_lower PROTO((char *));
 
 /* True if a string is all upper case. */
-extern int all_upper PROTO((register char *));
+extern int all_upper PROTO((char *));
 
 /* Bubble sort an integer array. */
 extern void bubble PROTO((int [], int));
@@ -842,10 +842,10 @@ extern void check_char PROTO((int c));
 extern Char clower PROTO((int));
 
 /* Returns a dynamically allocated copy of a string. */
-extern char *copy_string PROTO((register const char *));
+extern char *copy_string PROTO((const char *));
 
 /* Returns a dynamically allocated copy of a (potentially) unsigned string. */
-extern Char *copy_unsigned_string PROTO((register Char *));
+extern Char *copy_unsigned_string PROTO((Char *));
 
 /* Shell sort a character array. */
 extern void cshell PROTO((wchar_t[], int, int));
@@ -947,7 +947,7 @@ extern int link_machines PROTO((int, int));
 /* Mark each "beginning" state in a machine as being a "normal" (i.e.,
  * not trailing context associated) state.
  */
-extern void mark_beginning_as_normal PROTO((register int));
+extern void mark_beginning_as_normal PROTO((int));
 
 /* Make a machine that branches to two machines. */
 extern int mkbranch PROTO((int, int));
@@ -1010,7 +1010,7 @@ extern int yywrap PROTO((void));
 /* from file sym.c */
 
 /* Add symbol and definitions to symbol table. */
-extern int addsym PROTO((register char[], char*, int, hash_table, int));
+extern int addsym PROTO((char[], char*, int, hash_table, int));
 
 /* Save the text of a character class. */
 extern void cclinstal PROTO ((Char [], int));
@@ -1019,7 +1019,7 @@ extern void cclinstal PROTO ((Char [], int));
 extern int ccllookup PROTO((Char []));
 
 /* Find symbol in symbol table. */
-extern struct hash_entry *findsym PROTO((register char[], hash_table, int ));
+extern struct hash_entry *findsym PROTO((char[], hash_table, int ));
 
 extern void ndinstal PROTO((char[], Char[]));	/* install a name definition */
 extern Char *ndlookup PROTO((char[]));	/* lookup a name definition */

--- a/to.do/unicode/gen.c
+++ b/to.do/unicode/gen.c
@@ -65,7 +65,7 @@ static char C_ushort_decl[] =
 
 void do_indent()
 	{
-	register int i = indent_level * 8;
+	int i = indent_level * 8;
 
 	while ( i >= 8 )
 		{
@@ -135,7 +135,7 @@ void gen_bu_action()
 
 void genctbl()
 	{
-	register int i;
+	int i;
 	int end_of_buffer_action = num_rules + 1;
 
 	/* Table of verify for transition and offset to next state. */
@@ -231,7 +231,7 @@ void genctbl()
 
 void genecs()
 	{
-	register int i, j;
+	int i, j;
 	int numrows;
 
 	if ( csize == 65536 && long_align )
@@ -419,7 +419,7 @@ void gen_find_action()
 
 void genftbl()
 	{
-	register int i;
+	int i;
 	int end_of_buffer_action = num_rules + 1;
 
 	out_str_dec( long_align ? C_long_decl : C_short_decl,
@@ -429,7 +429,7 @@ void genftbl()
 
 	for ( i = 1; i <= lastdfa; ++i )
 		{
-		register int anum = dfaacc[i].dfaacc_state;
+		int anum = dfaacc[i].dfaacc_state;
 
 		mkdata( anum );
 
@@ -454,7 +454,7 @@ void genftbl()
 void gen_next_compressed_state( char_map )
 char *char_map;
 	{
-	indent_put2s( "register YY_CHAR yy_c = %s;", char_map );
+	indent_put2s( "YY_CHAR yy_c = %s;", char_map );
 
 	/* Save the backing-up info \before/ computing the next state
 	 * because we always compute one more state than needed - we
@@ -541,8 +541,8 @@ void gen_next_match()
 		{
 		indent_puts( "{" );	/* } for vi */
 		indent_puts(
-		"register yyconst struct yy_trans_info *yy_trans_info;\n" );
-		indent_puts( "register YY_CHAR yy_c;\n" );
+		"yyconst struct yy_trans_info *yy_trans_info;\n" );
+		indent_puts( "YY_CHAR yy_c;\n" );
 		indent_put2s( "for ( yy_c = %s;", char_map );
 		indent_puts(
 	"      (yy_trans_info = &yy_current_state[(unsigned int) yy_c])->" );
@@ -683,7 +683,7 @@ void gen_NUL_trans()
 		/* We're going to need yy_cp lying around for the call
 		 * below to gen_backing_up().
 		 */
-		indent_puts( "register YY_CHAR *yy_cp = yy_c_buf_p;" );
+		indent_puts( "YY_CHAR *yy_cp = yy_c_buf_p;" );
 
 	outc( '\n' );
 
@@ -705,10 +705,10 @@ void gen_NUL_trans()
 	else if ( fullspd )
 		{
 		do_indent();
-		out_dec( "register int yy_c = %d;\n", NUL_ec );
+		out_dec( "int yy_c = %d;\n", NUL_ec );
 
 		indent_puts(
-		"register yyconst struct yy_trans_info *yy_trans_info;\n" );
+		"yyconst struct yy_trans_info *yy_trans_info;\n" );
 		indent_puts(
 		"yy_trans_info = &yy_current_state[(unsigned int) yy_c];" );
 		indent_puts( "yy_current_state += yy_trans_info->yy_nxt;" );
@@ -966,7 +966,7 @@ void gentabs()
 
 	for ( i = 1; i <= lastdfa; ++i )
 		{
-		register int d = def[i];
+		int d = def[i];
 
 		if ( base[i] == JAMSTATE )
 			base[i] = jambase;
@@ -1067,7 +1067,7 @@ char str[];
 
 void make_tables()
 	{
-	register int i;
+	int i;
 	int did_eof_rule = false;
 
 	skelout();

--- a/to.do/unicode/misc.c
+++ b/to.do/unicode/misc.c
@@ -82,7 +82,7 @@ void *allocate_array( size, element_size )
 int size;
 size_t element_size;
 	{
-	register void *mem;
+	void *mem;
 	size_t num_bytes = element_size * size;
 
 	mem = flex_alloc( num_bytes );
@@ -97,7 +97,7 @@ size_t element_size;
 /* all_lower - true if a string is all lower-case */
 
 int all_lower( str )
-register char *str;
+char *str;
 	{
 	while ( *str )
 		{
@@ -113,7 +113,7 @@ register char *str;
 /* all_upper - true if a string is all upper-case */
 
 int all_upper( str )
-register char *str;
+char *str;
 	{
 	while ( *str )
 		{
@@ -144,7 +144,7 @@ register char *str;
 void bubble( v, n )
 int v[], n;
 	{
-	register int i, j, k;
+	int i, j, k;
 
 	for ( i = n; i > 1; --i )
 		for ( j = 1; j < i; ++j )
@@ -187,7 +187,7 @@ int c;
 /* clower - replace upper-case letter to lower-case */
 
 Char clower( c )
-register int c;
+int c;
 	{
 	return (Char) ((isascii( c ) && isupper( c )) ? tolower( c ) : c);
 	}
@@ -196,10 +196,10 @@ register int c;
 /* copy_string - returns a dynamically allocated copy of a string */
 
 char *copy_string( str )
-register const char *str;
+const char *str;
 	{
-	register const char *c1;
-	register char *c2;
+	const char *c1;
+	char *c2;
 	char *copy;
 	unsigned int size;
 
@@ -225,9 +225,9 @@ register const char *str;
  */
 
 Char *copy_unsigned_string( str )
-register Char *str;
+Char *str;
 	{
-	register Char *c;
+	Char *c;
 	Char *copy;
 
 	/* find length */
@@ -661,7 +661,7 @@ unsigned int x;
 void out_line_count( str )
 const char str[];
 	{
-	register int i;
+	int i;
 
 	for ( i = 0; str[i]; ++i )
 		if ( str[i] == '\n' )
@@ -719,7 +719,7 @@ const char str[];
  */
 
 char *readable_form( c )
-register int c;
+int c;
 	{
 	static char rform[10];
 
@@ -765,7 +765,7 @@ void *array;
 int size;
 size_t element_size;
 	{
-	register void *new_array;
+	void *new_array;
 	size_t num_bytes = element_size * size;
 
 	new_array = flex_realloc( array, num_bytes );
@@ -884,7 +884,7 @@ void zero_out( region_ptr, size_in_bytes )
 char *region_ptr;
 size_t size_in_bytes;
 	{
-	register char *rp, *rp_end;
+	char *rp, *rp_end;
 
 	rp = region_ptr;
 	rp_end = region_ptr + size_in_bytes;

--- a/to.do/unicode/scan.l
+++ b/to.do/unicode/scan.l
@@ -434,7 +434,7 @@ LEXOPT		[aceknopr]
 			}
 
 	"{"{NAME}"}"	{
-			register Char *nmdefptr;
+			Char *nmdefptr;
 
 			strcpy( nmstr, yytext + 1 );
 			nmstr[yyleng - 2] = '\0';  /* chop trailing brace */

--- a/to.do/unicode/tblcmp.c
+++ b/to.do/unicode/tblcmp.c
@@ -33,7 +33,7 @@
 
 /* declarations for functions that have forward references */
 
-void mkentry PROTO((register int*, int, int, int, int));
+void mkentry PROTO((int*, int, int, int, int));
 void mkprot PROTO((int[], int, int));
 void mktemplate PROTO((int[], int, int));
 void mv2front PROTO((int));
@@ -228,7 +228,7 @@ int state[], statenum, totaltrans, comstate, comfreq;
 void cmptmps()
 	{
 	int tmpstorage[CSIZE + 1];
-	register int *tmp = tmpstorage, i, j;
+	int *tmp = tmpstorage, i, j;
 	int totaltrans, trans;
 
 	peakpairs = numtemps * numecs + tblend;
@@ -300,7 +300,7 @@ void cmptmps()
 
 void expand_nxt_chk()
 	{
-	register int old_max = current_max_xpairs;
+	int old_max = current_max_xpairs;
 
 	current_max_xpairs += MAX_XPAIRS_INCREMENT;
 
@@ -339,9 +339,9 @@ int *state, numtrans;
 	/* Firstfree is the position of the first possible occurrence of two
 	 * consecutive unused records in the chk and nxt arrays.
 	 */
-	register int i;
-	register int *state_ptr, *chk_ptr;
-	register int *ptr_to_last_entry_in_state;
+	int i;
+	int *state_ptr, *chk_ptr;
+	int *ptr_to_last_entry_in_state;
 
 	/* If there are too many out-transitions, put the state at the end of
 	 * nxt and chk.
@@ -434,7 +434,7 @@ int *state, numtrans;
  */
 void inittbl()
 	{
-	register int i;
+	int i;
 
 	zero_out( (char *) chk, (size_t) (current_max_xpairs * sizeof( int )) );
 
@@ -515,10 +515,10 @@ void mkdeftbl()
  */
 
 void mkentry( state, numchars, statenum, deflink, totaltrans )
-register int *state;
+int *state;
 int numchars, statenum, deflink, totaltrans;
 	{
-	register int minec, maxec, i, baseaddr;
+	int minec, maxec, i, baseaddr;
 	int tblbase, tbllast;
 
 	if ( totaltrans == 0 )
@@ -792,8 +792,8 @@ int qelm;
 void place_state( state, statenum, transnum )
 int *state, statenum, transnum;
 	{
-	register int i;
-	register int *state_ptr;
+	int i;
+	int *state_ptr;
 	int position = find_table_space( state, transnum );
 
 	/* "base" is the table of start positions. */
@@ -867,8 +867,8 @@ int statenum, sym, nextstate, deflink;
 int tbldiff( state, pr, ext )
 int state[], pr, ext[];
 	{
-	register int i, *sp = state, *ep = ext, *protp;
-	register int numdiff = 0;
+	int i, *sp = state, *ep = ext, *protp;
+	int numdiff = 0;
 
 	protp = &protsave[numecs * (pr - 1)];
 


### PR DESCRIPTION
clang-3.5.0 now complains about them: warning: 'register' storage class specifier is deprecated [-Wdeprecated-register]

Modern compilers should know better what registers to assign. In addition, modern CPUs (amg64) have many more registers and heuristics possibly observed when those 'register' specifiers were set are now most likely obsolete.
