### PR TITLE
Add disambiguation braces in main.c

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -1577,11 +1577,12 @@ void readin ()
     }
 
 	if (!do_yywrap) {
-		if (!C_plus_plus)
+		if (!C_plus_plus) {
 			 if (reentrant)
 				outn ("\n#define yywrap(yyscanner) 1");
 			 else
 				outn ("\n#define yywrap() 1");
+		}
 		outn ("#define YY_SKIP_YYWRAP");
 	}
 


### PR DESCRIPTION
This makes code easier to read, and also eliminates warning.
