### PR TITLE
Fix -Wdocumentation warnings

### DIFF
--- a/src/misc.c
+++ b/src/misc.c
@@ -721,7 +721,6 @@ void outn (str)
 /** Print "m4_define( [[def]], [[val]])m4_dnl\n".
  * @param def The m4 symbol to define.
  * @param val The definition; may be NULL.
- * @return buf
  */
 void out_m4_define (const char* def, const char* val)
 {

--- a/src/regex.c
+++ b/src/regex.c
@@ -113,7 +113,6 @@ char   *regmatch_cpy (regmatch_t * m, char *dest, const char *src)
 
 /** Get the length in characters of the match.
  * @param m A match as returned by regexec().
- * @param src The source string that was passed to regexec().
  * @return The length of the match.
  */
 int regmatch_len (regmatch_t * m)

--- a/src/tables.c
+++ b/src/tables.c
@@ -65,7 +65,7 @@ static flex_int32_t yytbl_data_getijk (const struct yytbl_data *tbl, int i,
 
 /** Initialize the table writer.
  *  @param wr an uninitialized writer
- *  @param the output file
+ *  @param out the output file
  *  @return 0 on success
  */
 int yytbl_writer_init (struct yytbl_writer *wr, FILE * out)
@@ -96,7 +96,7 @@ int yytbl_hdr_init (struct yytbl_hdr *th, const char *version_str,
 }
 
 /** Allocate and initialize a table data structure.
- *  @param tbl a pointer to an uninitialized table
+ *  @param td a pointer to an uninitialized table
  *  @param id  the table identifier
  *  @return 0 on success
  */
@@ -137,7 +137,7 @@ static int yytbl_write_pad64 (struct yytbl_writer *wr)
 }
 
 /** write the header.
- *  @param out the output stream
+ *  @param wr the output stream
  *  @param th table header to be written
  *  @return -1 on error, or bytes written on success.
  */
@@ -183,7 +183,7 @@ int yytbl_hdr_fwrite (struct yytbl_writer *wr, const struct yytbl_hdr *th)
 
 
 /** Write this table.
- *  @param out the file writer
+ *  @param wr the file writer
  *  @param td table data to be written
  *  @return -1 on error, or bytes written on success.
  */

--- a/src/tables_shared.c
+++ b/src/tables_shared.c
@@ -52,7 +52,7 @@ dnl
 
 /** Get the number of integers in this table. This is NOT the
  *  same thing as the number of elements.
- *  @param td the table 
+ *  @param tbl the table
  *  @return the number of integers in the table
  */
 yyskel_static flex_int32_t yytbl_calc_total_len (const struct yytbl_data *tbl)


### PR DESCRIPTION
misc.c:724:5: warning: '@return' command used in a comment that is attached to a function returning void [-Wdocumentation]
tables.c:68:12: warning: parameter 'the' not found in the function declaration [-Wdocumentation]
tables.c:68:12: note: did you mean 'out'?
tables.c:99:12: warning: parameter 'tbl' not found in the function declaration [-Wdocumentation]
tables.c:99:12: note: did you mean 'td'?
tables.c:140:12: warning: parameter 'out' not found in the function declaration [-Wdocumentation]
tables.c:186:12: warning: parameter 'out' not found in the function declaration [-Wdocumentation]
tables_shared.c:55:12: warning: parameter 'td' not found in the function declaration [-Wdocumentation]
regex.c:116:11: warning: parameter 'src' not found in the function declaration [-Wdocumentation]
