### PR TITLE
Switch function definitions from mixed K&R to consistent ANSI C

### DIFF
--- a/src/buf.c
+++ b/src/buf.c
@@ -124,10 +124,7 @@ struct Buf *buf_concat(struct Buf* dest, const struct Buf* src)
 
 
 /* Appends n characters in str to buf. */
-struct Buf *buf_strnappend (buf, str, n)
-     struct Buf *buf;
-     const char *str;
-     int n;
+struct Buf *buf_strnappend (struct Buf *buf, const char *str, int n)
 {
 	buf_append (buf, str, n + 1);
 
@@ -138,18 +135,13 @@ struct Buf *buf_strnappend (buf, str, n)
 }
 
 /* Appends characters in str to buf. */
-struct Buf *buf_strappend (buf, str)
-     struct Buf *buf;
-     const char *str;
+struct Buf *buf_strappend (struct Buf *buf, const char *str)
 {
 	return buf_strnappend (buf, str, strlen (str));
 }
 
 /* appends "#define str def\n" */
-struct Buf *buf_strdefine (buf, str, def)
-     struct Buf *buf;
-     const char *str;
-     const char *def;
+struct Buf *buf_strdefine (struct Buf *buf, const char *str, const char *def)
 {
 	buf_strappend (buf, "#define ");
 	buf_strappend (buf, " ");
@@ -203,9 +195,7 @@ struct Buf *buf_m4_undefine (struct Buf *buf, const char* def)
 }
 
 /* create buf with 0 elements, each of size elem_size. */
-void buf_init (buf, elem_size)
-     struct Buf *buf;
-     size_t elem_size;
+void buf_init (struct Buf *buf, size_t elem_size)
 {
 	buf->elts = (void *) 0;
 	buf->nelts = 0;
@@ -214,8 +204,7 @@ void buf_init (buf, elem_size)
 }
 
 /* frees memory */
-void buf_destroy (buf)
-     struct Buf *buf;
+void buf_destroy (struct Buf *buf)
 {
 	if (buf && buf->elts)
 		flex_free (buf->elts);
@@ -229,10 +218,7 @@ void buf_destroy (buf)
  * We grow by mod(512) boundaries.
  */
 
-struct Buf *buf_append (buf, ptr, n_elem)
-     struct Buf *buf;
-     const void *ptr;
-     int n_elem;
+struct Buf *buf_append (struct Buf *buf, const void *ptr, int n_elem)
 {
 	int     n_alloc = 0;
 

--- a/src/ccl.c
+++ b/src/ccl.c
@@ -52,9 +52,7 @@ ccl_contains (const int cclp, const int ch)
 
 /* ccladd - add a single character to a ccl */
 
-void    ccladd (cclp, ch)
-     int     cclp;
-     int     ch;
+void ccladd (int cclp, int ch)
 {
 	int     ind, len, newpos, i;
 
@@ -185,7 +183,7 @@ ccl_set_union (int a, int b)
 
 /* cclinit - return an empty ccl */
 
-int     cclinit ()
+int     cclinit (void)
 {
 	if (++lastccl >= current_maxccls) {
 		current_maxccls += MAX_CCLS_INCREMENT;
@@ -225,8 +223,7 @@ int     cclinit ()
 
 /* cclnegate - negate the given ccl */
 
-void    cclnegate (cclp)
-     int     cclp;
+void    cclnegate (int cclp)
 {
 	cclng[cclp] = 1;
 	ccl_has_nl[cclp] = !ccl_has_nl[cclp];
@@ -240,9 +237,7 @@ void    cclnegate (cclp)
  * has a non-zero value in the cset array.
  */
 
-void    list_character_set (file, cset)
-     FILE   *file;
-     int     cset[];
+void    list_character_set (FILE *file, int cset[])
 {
 	int i;
 

--- a/src/dfa.c
+++ b/src/dfa.c
@@ -49,9 +49,7 @@ int symfollowset PROTO ((int[], int, int, int[]));
  * indexed by equivalence class.
  */
 
-void check_for_backing_up (ds, state)
-     int ds;
-     int state[];
+void check_for_backing_up (int ds, int state[])
 {
 	if ((reject && !dfaacc[ds].dfaacc_set) || (!reject && !dfaacc[ds].dfaacc_state)) {	/* state is non-accepting */
 		++num_backing_up;
@@ -96,10 +94,7 @@ void check_for_backing_up (ds, state)
  *    accset[1 .. nacc] is the list of accepting numbers for the DFA state.
  */
 
-void check_trailing_context (nfa_states, num_states, accset, nacc)
-     int    *nfa_states, num_states;
-     int    *accset;
-     int nacc;
+void check_trailing_context (int *nfa_states, int num_states, int *accset, int nacc)
 {
 	int i, j;
 
@@ -137,9 +132,7 @@ void check_trailing_context (nfa_states, num_states, accset, nacc)
  * and writes a report to the given file.
  */
 
-void dump_associated_rules (file, ds)
-     FILE   *file;
-     int ds;
+void dump_associated_rules (FILE *file, int ds)
 {
 	int i, j;
 	int num_associated_rules = 0;
@@ -187,9 +180,7 @@ void dump_associated_rules (file, ds)
  * is done to the given file.
  */
 
-void dump_transitions (file, state)
-     FILE   *file;
-     int state[];
+void dump_transitions (FILE *file, int state[])
 {
 	int i, ec;
 	int out_char_set[CSIZE];
@@ -235,8 +226,7 @@ void dump_transitions (file, state)
  *  hashval is the hash value for the dfa corresponding to the state set.
  */
 
-int    *epsclosure (t, ns_addr, accset, nacc_addr, hv_addr)
-     int    *t, *ns_addr, accset[], *nacc_addr, *hv_addr;
+int    *epsclosure (int *t, int *ns_addr, int accset[], int *nacc_addr, int *hv_addr)
 {
 	int     stkpos, ns, tsp;
 	int     numstates = *ns_addr, nacc, hashval, transsym, nfaccnum;
@@ -351,7 +341,7 @@ ADD_STATE(state); \
 
 /* increase_max_dfas - increase the maximum number of DFAs */
 
-void increase_max_dfas ()
+void increase_max_dfas (void)
 {
 	current_max_dfas += MAX_DFAS_INCREMENT;
 
@@ -378,7 +368,7 @@ void increase_max_dfas ()
  * dfa starts out in state #1.
  */
 
-void ntod ()
+void ntod (void)
 {
 	int    *accset, ds, nacc, newds;
 	int     sym, hashval, numstates, dsize;
@@ -820,8 +810,7 @@ void ntod ()
  * On return, the dfa state number is in newds.
  */
 
-int snstods (sns, numstates, accset, nacc, hashval, newds_addr)
-     int sns[], numstates, accset[], nacc, hashval, *newds_addr;
+int snstods (int sns[], int numstates, int accset[], int nacc, int hashval, int *newds_addr)
 {
 	int didsort = 0;
 	int i, j;
@@ -942,8 +931,7 @@ int snstods (sns, numstates, accset, nacc, hashval, newds_addr)
  *				int transsym, int nset[current_max_dfa_size] );
  */
 
-int symfollowset (ds, dsize, transsym, nset)
-     int ds[], dsize, transsym, nset[];
+int symfollowset (int ds[], int dsize, int transsym, int nset[])
 {
 	int     ns, tsp, sym, i, j, lenccl, ch, numstates, ccllist;
 
@@ -1020,9 +1008,7 @@ int symfollowset (ds, dsize, transsym, nset)
  *			int symlist[numecs], int duplist[numecs] );
  */
 
-void sympartition (ds, numstates, symlist, duplist)
-     int ds[], numstates;
-     int symlist[], duplist[];
+void sympartition (int ds[], int numstates, int symlist[], int duplist[])
 {
 	int     tch, i, j, k, ns, dupfwd[CSIZE + 1], lenccl, cclp, ich;
 

--- a/src/ecs.c
+++ b/src/ecs.c
@@ -36,7 +36,7 @@
 
 /* ccl2ecl - convert character classes to set of equivalence classes */
 
-void    ccl2ecl ()
+void    ccl2ecl (void)
 {
 	int     i, ich, newlen, cclp, ccls, cclmec;
 
@@ -74,8 +74,7 @@ void    ccl2ecl ()
  * Returned is the number of classes.
  */
 
-int     cre8ecs (fwd, bck, num)
-     int     fwd[], bck[], num;
+int     cre8ecs (int fwd[], int bck[], int num)
 {
 	int     i, j, numcl;
 
@@ -112,9 +111,7 @@ int     cre8ecs (fwd, bck, num)
  * NUL_mapping is the value which NUL (0) should be mapped to.
  */
 
-void    mkeccl (ccls, lenccl, fwd, bck, llsiz, NUL_mapping)
-     Char    ccls[];
-     int     lenccl, fwd[], bck[], llsiz, NUL_mapping;
+void    mkeccl (Char ccls[], int lenccl, int fwd[], int bck[], int llsiz, int NUL_mapping)
 {
 	int     cclp, oldec, newec;
 	int     cclm, i, j;
@@ -201,8 +198,7 @@ void    mkeccl (ccls, lenccl, fwd, bck, llsiz, NUL_mapping)
 
 /* mkechar - create equivalence class for single character */
 
-void    mkechar (tch, fwd, bck)
-     int     tch, fwd[], bck[];
+void    mkechar (int tch, int fwd[], int bck[])
 {
 	/* If until now the character has been a proper subset of
 	 * an equivalence class, break it away to create a new ec

--- a/src/gen.c
+++ b/src/gen.c
@@ -1497,8 +1497,7 @@ void gentabs (void)
  * current indentation level, adding a final newline.
  */
 
-void indent_put2s (fmt, arg)
-     const char *fmt, *arg;
+void indent_put2s (const char *fmt, const char *arg)
 {
 	do_indent ();
 	out_str (fmt, arg);
@@ -1510,8 +1509,7 @@ void indent_put2s (fmt, arg)
  * newline.
  */
 
-void indent_puts (str)
-     const char *str;
+void indent_puts (const char *str)
 {
 	do_indent ();
 	outn (str);

--- a/src/main.c
+++ b/src/main.c
@@ -147,9 +147,7 @@ static int preproc_level = 1000;
 int flex_main PROTO ((int argc, char *argv[]));
 int main PROTO ((int argc, char *argv[]));
 
-int flex_main (argc, argv)
-     int argc;
-     char   *argv[];
+int flex_main (int argc, char *argv[])
 {
 	int     i, exit_status, child_status;
 
@@ -209,9 +207,7 @@ int flex_main (argc, argv)
 }
 
 /* Wrapper around flex_main, so flex_main can be built as a library. */
-int main (argc, argv)
-     int argc;
-     char   *argv[];
+int main (int argc, char *argv[])
 {
 #if ENABLE_NLS
 #if HAVE_LOCALE_H
@@ -227,7 +223,7 @@ int main (argc, argv)
 
 /* check_options - check user-specified options */
 
-void check_options ()
+void check_options (void)
 {
 	int     i;
     const char * m4 = NULL;
@@ -490,9 +486,7 @@ void check_options ()
  *    This routine does not return.
  */
 
-void flexend (exit_status)
-     int exit_status;
-
+void flexend (int exit_status)
 {
 	static int called_before = -1;	/* prevent infinite recursion. */
 	int     tblsiz;
@@ -926,9 +920,7 @@ void flexend (exit_status)
 
 /* flexinit - initialize flex */
 
-void flexinit (argc, argv)
-     int argc;
-     char  **argv;
+void flexinit (int argc, char **argv)
 {
 	int     i, sawcmpflag, rv, optind;
 	char   *arg;
@@ -1456,7 +1448,7 @@ void flexinit (argc, argv)
 
 /* readin - read in the rules section of the input file(s) */
 
-void readin ()
+void readin (void)
 {
 	static char yy_stdinit[] = "FILE *yyin = stdin, *yyout = stdout;";
 	static char yy_nostdinit[] =
@@ -1715,7 +1707,7 @@ void readin ()
 
 /* set_up_initial_allocations - allocate memory for internal tables */
 
-void set_up_initial_allocations ()
+void set_up_initial_allocations (void)
 {
 	maximum_mns = (long_align ? MAXIMUM_MNS_LONG : MAXIMUM_MNS);
 	current_mns = INITIAL_MNS;
@@ -1775,9 +1767,7 @@ void set_up_initial_allocations ()
 
 /* extracts basename from path, optionally stripping the extension "\.*"
  * (same concept as /bin/sh `basename`, but different handling of extension). */
-static char *basename2 (path, strip_ext)
-     char   *path;
-     int strip_ext;		/* boolean */
+static char *basename2 (char *path, int /* boolean */ strip_ext)
 {
 	char   *b, *e = 0;
 
@@ -1793,7 +1783,7 @@ static char *basename2 (path, strip_ext)
 	return b;
 }
 
-void usage ()
+void usage (void)
 {
 	FILE   *f = stdout;
 

--- a/src/misc.c
+++ b/src/misc.c
@@ -90,9 +90,7 @@ static void sko_pop(bool* dc)
 }
 
 /* Append "#define defname value\n" to the running buffer. */
-void action_define (defname, value)
-     const char *defname;
-     int value;
+void action_define (const char *defname, int value)
 {
 	char    buf[MAXLINE];
 	char   *cpy;
@@ -137,8 +135,7 @@ static void action_m4_define (const char *defname, const char * value)
 #endif
 
 /* Append "new_text" to the running buffer. */
-void add_action (new_text)
-     const char   *new_text;
+void add_action (const char *new_text)
 {
 	int     len = strlen (new_text);
 
@@ -166,9 +163,7 @@ void add_action (new_text)
 
 /* allocate_array - allocate memory for an integer array of the given size */
 
-void   *allocate_array (size, element_size)
-     int size;
-     size_t element_size;
+void   *allocate_array (int size, size_t element_size)
 {
 	void *mem;
 	size_t  num_bytes = element_size * size;
@@ -184,8 +179,7 @@ void   *allocate_array (size, element_size)
 
 /* all_lower - true if a string is all lower-case */
 
-int all_lower (str)
-     char *str;
+int all_lower (char *str)
 {
 	while (*str) {
 		if (!isascii ((Char) * str) || !islower ((Char) * str))
@@ -199,8 +193,7 @@ int all_lower (str)
 
 /* all_upper - true if a string is all upper-case */
 
-int all_upper (str)
-     char *str;
+int all_upper (char *str)
 {
 	while (*str) {
 		if (!isascii ((Char) * str) || !isupper ((Char) * str))
@@ -225,8 +218,7 @@ int intcmp (const void *a, const void *b)
  *		and exits.
  */
 
-void check_char (c)
-     int c;
+void check_char (int c)
 {
 	if (c >= CSIZE)
 		lerr (_("bad character '%s' detected in check_char()"),
@@ -242,8 +234,7 @@ void check_char (c)
 
 /* clower - replace upper-case letter to lower-case */
 
-Char clower (c)
-     int c;
+Char clower (int c)
 {
 	return (Char) ((isascii (c) && isupper (c)) ? tolower (c) : c);
 }
@@ -251,8 +242,7 @@ Char clower (c)
 
 /* copy_string - returns a dynamically allocated copy of a string */
 
-char   *copy_string (str)
-     const char *str;
+char   *copy_string (const char *str)
 {
 	const char *c1;
 	char *c2;
@@ -279,8 +269,7 @@ char   *copy_string (str)
  *    returns a dynamically allocated copy of a (potentially) unsigned string
  */
 
-Char   *copy_unsigned_string (str)
-     Char *str;
+Char   *copy_unsigned_string (Char *str)
 {
 	Char *c;
 	Char   *copy;
@@ -312,7 +301,7 @@ int cclcmp (const void *a, const void *b)
 
 /* dataend - finish up a block of data declarations */
 
-void dataend ()
+void dataend (void)
 {
 	/* short circuit any output */
 	if (gentables) {
@@ -330,7 +319,7 @@ void dataend ()
 
 /* dataflush - flush generated data statements */
 
-void dataflush ()
+void dataflush (void)
 {
 	/* short circuit any output */
 	if (!gentables)
@@ -353,8 +342,7 @@ void dataflush ()
 
 /* flexerror - report an error message and terminate */
 
-void flexerror (msg)
-     const char *msg;
+void flexerror (const char *msg)
 {
 	fprintf (stderr, "%s: %s\n", program_name, msg);
 	flexend (1);
@@ -363,8 +351,7 @@ void flexerror (msg)
 
 /* flexfatal - report a fatal error message and terminate */
 
-void flexfatal (msg)
-     const char *msg;
+void flexfatal (const char *msg)
 {
 	fprintf (stderr, _("%s: fatal internal error, %s\n"),
 		 program_name, msg);
@@ -374,8 +361,7 @@ void flexfatal (msg)
 
 /* htoi - convert a hexadecimal digit string to an integer value */
 
-int htoi (str)
-     Char str[];
+int htoi (Char str[])
 {
 	unsigned int result;
 
@@ -387,7 +373,8 @@ int htoi (str)
 
 /* lerr - report an error message */
 
-void lerr (const char *msg, ...) {
+void lerr (const char *msg, ...)
+{
 	char    errmsg[MAXLINE];
 	va_list args;
 
@@ -414,9 +401,7 @@ void lerr_fatal (const char *msg, ...)
 
 /* line_directive_out - spit out a "#line" statement */
 
-void line_directive_out (output_file, do_infile)
-     FILE   *output_file;
-     int do_infile;
+void line_directive_out (FILE *output_file, int do_infile)
 {
 	char    directive[MAXLINE], filename[MAXLINE];
 	char   *s1, *s2, *s3;
@@ -464,7 +449,7 @@ void line_directive_out (output_file, do_infile)
  *               representing where the user's section 1 definitions end
  *		 and the prolog begins
  */
-void mark_defs1 ()
+void mark_defs1 (void)
 {
 	defs1_offset = 0;
 	action_array[action_index++] = '\0';
@@ -476,7 +461,7 @@ void mark_defs1 ()
 /* mark_prolog - mark the current position in the action array as
  *               representing the end of the action prolog
  */
-void mark_prolog ()
+void mark_prolog (void)
 {
 	action_array[action_index++] = '\0';
 	action_offset = action_index;
@@ -488,8 +473,7 @@ void mark_prolog ()
  *
  * Generates a data statement initializing the current 2-D array to "value".
  */
-void mk2data (value)
-     int value;
+void mk2data (int value)
 {
 	/* short circuit any output */
 	if (!gentables)
@@ -518,8 +502,7 @@ void mk2data (value)
  * Generates a data statement initializing the current array element to
  * "value".
  */
-void mkdata (value)
-     int value;
+void mkdata (int value)
 {
 	/* short circuit any output */
 	if (!gentables)
@@ -544,8 +527,7 @@ void mkdata (value)
 
 /* myctoi - return the integer represented by a string of digits */
 
-int myctoi (array)
-     const char *array;
+int myctoi (const char *array)
 {
 	int     val = 0;
 
@@ -557,8 +539,7 @@ int myctoi (array)
 
 /* myesc - return character corresponding to escape sequence */
 
-Char myesc (array)
-     Char array[];
+Char myesc (Char array[])
 {
 	Char    c, esc_char;
 
@@ -645,8 +626,7 @@ Char myesc (array)
 
 /* otoi - convert an octal digit string to an integer value */
 
-int otoi (str)
-     Char str[];
+int otoi (Char str[])
 {
 	unsigned int result;
 
@@ -659,60 +639,47 @@ int otoi (str)
  *	 generated scanner, keeping track of the line count.
  */
 
-void out (str)
-     const char *str;
+void out (const char *str)
 {
 	fputs (str, stdout);
 }
 
-void out_dec (fmt, n)
-     const char *fmt;
-     int n;
+void out_dec (const char *fmt, int n)
 {
 	fprintf (stdout, fmt, n);
 }
 
-void out_dec2 (fmt, n1, n2)
-     const char *fmt;
-     int n1, n2;
+void out_dec2 (const char *fmt, int n1, int n2)
 {
 	fprintf (stdout, fmt, n1, n2);
 }
 
-void out_hex (fmt, x)
-     const char *fmt;
-     unsigned int x;
+void out_hex (const char *fmt, unsigned int x)
 {
 	fprintf (stdout, fmt, x);
 }
 
-void out_str (fmt, str)
-     const char *fmt, str[];
+void out_str (const char *fmt, const char str[])
 {
 	fprintf (stdout,fmt, str);
 }
 
-void out_str3 (fmt, s1, s2, s3)
-     const char *fmt, s1[], s2[], s3[];
+void out_str3 (const char *fmt, const char s1[], const char s2[], const char s3[])
 {
 	fprintf (stdout,fmt, s1, s2, s3);
 }
 
-void out_str_dec (fmt, str, n)
-     const char *fmt, str[];
-     int n;
+void out_str_dec (const char *fmt, const char str[], int n)
 {
 	fprintf (stdout,fmt, str, n);
 }
 
-void outc (c)
-     int c;
+void outc (int c)
 {
 	fputc (c, stdout);
 }
 
-void outn (str)
-     const char *str;
+void outn (const char *str)
 {
 	fputs (str,stdout);
     fputc('\n',stdout);
@@ -734,8 +701,7 @@ void out_m4_define (const char* def, const char* val)
  * The returned string is in static storage.
  */
 
-char   *readable_form (c)
-     int c;
+char   *readable_form (int c)
 {
 	static char rform[20];
 
@@ -782,10 +748,7 @@ char   *readable_form (c)
 
 /* reallocate_array - increase the size of a dynamic array */
 
-void   *reallocate_array (array, size, element_size)
-     void   *array;
-     int size;
-     size_t element_size;
+void   *reallocate_array (void *array, int size, size_t element_size)
 {
 	void *new_array;
 	size_t  num_bytes = element_size * size;
@@ -804,7 +767,7 @@ void   *reallocate_array (array, size, element_size)
  *    Copies skelfile or skel array to stdout until a line beginning with
  *    "%%" or EOF is found.
  */
-void skelout ()
+void skelout (void)
 {
 	char    buf_storage[MAXLINE];
 	char   *buf = buf_storage;
@@ -961,8 +924,7 @@ void transition_struct_out (element_v, element_n)
 /* The following is only needed when building flex's parser using certain
  * broken versions of bison.
  */
-void   *yy_flex_xmalloc (size)
-     int size;
+void   *yy_flex_xmalloc (int size)
 {
 	void   *result = flex_alloc ((size_t) size);
 
@@ -979,9 +941,7 @@ void   *yy_flex_xmalloc (size)
  * Sets region_ptr[0] through region_ptr[size_in_bytes - 1] to zero.
  */
 
-void zero_out (region_ptr, size_in_bytes)
-     char   *region_ptr;
-     size_t size_in_bytes;
+void zero_out (char *region_ptr, size_t size_in_bytes)
 {
 	char *rp, *rp_end;
 
@@ -995,8 +955,7 @@ void zero_out (region_ptr, size_in_bytes)
 /* Remove all '\n' and '\r' characters, if any, from the end of str.
  * str can be any null-terminated string, or NULL.
  * returns str. */
-char   *chomp (str)
-     char   *str;
+char   *chomp (char *str)
 {
 	char   *p = str;
 

--- a/src/nfa.c
+++ b/src/nfa.c
@@ -45,8 +45,7 @@ void mkxtion PROTO ((int, int));
  * accepting_number becomes mach's accepting number.
  */
 
-void    add_accept (mach, accepting_number)
-     int     mach, accepting_number;
+void    add_accept (int mach, int accepting_number)
 {
 	/* Hang the accepting number off an epsilon state.  if it is associated
 	 * with a state that has a non-epsilon out-transition, then the state
@@ -77,8 +76,7 @@ void    add_accept (mach, accepting_number)
  *     num    - the number of copies of singl to be present in newsng
  */
 
-int     copysingl (singl, num)
-     int     singl, num;
+int     copysingl (int singl, int num)
 {
 	int     copy, i;
 
@@ -93,9 +91,7 @@ int     copysingl (singl, num)
 
 /* dumpnfa - debugging routine to write out an nfa */
 
-void    dumpnfa (state1)
-     int     state1;
-
+void    dumpnfa (int state1)
 {
 	int     sym, tsp1, tsp2, anum, ns;
 
@@ -148,8 +144,7 @@ void    dumpnfa (state1)
  * states accessible by the arrays firstst and lastst
  */
 
-int     dupmachine (mach)
-     int     mach;
+int     dupmachine (int mach)
 {
 	int     i, init, state_offset;
 	int     state = 0;
@@ -196,9 +191,8 @@ int     dupmachine (mach)
  * context has variable length.
  */
 
-void    finish_rule (mach, variable_trail_rule, headcnt, trailcnt,
-		     pcont_act)
-     int     mach, variable_trail_rule, headcnt, trailcnt, pcont_act;
+void    finish_rule (int mach, int variable_trail_rule, int headcnt, int trailcnt,
+		     int pcont_act)
 {
 	char    action_text[MAXLINE];
 
@@ -312,8 +306,7 @@ void    finish_rule (mach, variable_trail_rule, headcnt, trailcnt,
  *  FIRST is set to new by the operation.  last is unmolested.
  */
 
-int     link_machines (first, last)
-     int     first, last;
+int     link_machines (int first, int last)
 {
 	if (first == NIL)
 		return last;
@@ -339,8 +332,7 @@ int     link_machines (first, last)
  * The "beginning" states are the epsilon closure of the first state
  */
 
-void    mark_beginning_as_normal (mach)
-     int mach;
+void    mark_beginning_as_normal (int mach)
 {
 	switch (state_type[mach]) {
 	case STATE_NORMAL:
@@ -381,8 +373,7 @@ void    mark_beginning_as_normal (mach)
  * more mkbranch's.  Compare with mkor()
  */
 
-int     mkbranch (first, second)
-     int     first, second;
+int     mkbranch (int first, int second)
 {
 	int     eps;
 
@@ -409,8 +400,7 @@ int     mkbranch (first, second)
  * new - a new state which matches the closure of "state"
  */
 
-int     mkclos (state)
-     int     state;
+int     mkclos (int state)
 {
 	return mkopt (mkposcl (state));
 }
@@ -430,8 +420,7 @@ int     mkclos (state)
  *     2. mach is destroyed by the call
  */
 
-int     mkopt (mach)
-     int     mach;
+int     mkopt (int mach)
 {
 	int     eps;
 
@@ -467,8 +456,7 @@ int     mkopt (mach)
  * the number of epsilon states needed
  */
 
-int     mkor (first, second)
-     int     first, second;
+int     mkor (int first, int second)
 {
 	int     eps, orend;
 
@@ -523,8 +511,7 @@ int     mkor (first, second)
  *    new - a machine matching the positive closure of "state"
  */
 
-int     mkposcl (state)
-     int     state;
+int     mkposcl (int state)
 {
 	int     eps;
 
@@ -553,8 +540,7 @@ int     mkposcl (state)
  *   if "ub" is INFINITE_REPEAT then "new" matches "lb" or more occurrences of "mach"
  */
 
-int     mkrep (mach, lb, ub)
-     int     mach, lb, ub;
+int     mkrep (int mach, int lb, int ub)
 {
 	int     base_mach, tail, copy, i;
 
@@ -600,8 +586,7 @@ int     mkrep (mach, lb, ub)
  * that it admittedly is)
  */
 
-int     mkstate (sym)
-     int     sym;
+int     mkstate (int sym)
 {
 	if (++lastnfa >= current_mns) {
 		if ((current_mns += MNS_INCREMENT) >= maximum_mns)
@@ -677,8 +662,7 @@ current_mns);
  *     stateto   - the state to which the transition is to be made
  */
 
-void    mkxtion (statefrom, stateto)
-     int     statefrom, stateto;
+void    mkxtion (int statefrom, int stateto)
 {
 	if (trans1[statefrom] == NO_TRANSITION)
 		trans1[statefrom] = stateto;
@@ -695,7 +679,7 @@ void    mkxtion (statefrom, stateto)
 
 /* new_rule - initialize for a new rule */
 
-void    new_rule ()
+void    new_rule (void)
 {
 	if (++num_rules >= current_max_rules) {
 		++num_reallocs;

--- a/src/parse.y
+++ b/src/parse.y
@@ -951,7 +951,7 @@ string		:  string CHAR
  *                    conditions
  */
 
-void build_eof_action()
+void build_eof_action(void)
 	{
 	int i;
 	char action_text[MAXLINE];
@@ -990,8 +990,7 @@ void build_eof_action()
 
 /* format_synerr - write out formatted syntax error */
 
-void format_synerr( msg, arg )
-const char *msg, arg[];
+void format_synerr( const char *msg, const char arg[] )
 	{
 	char errmsg[MAXLINE];
 
@@ -1002,8 +1001,7 @@ const char *msg, arg[];
 
 /* synerr - report a syntax error */
 
-void synerr( str )
-const char *str;
+void synerr( const char *str )
 	{
 	syntaxerror = true;
 	pinpoint_message( str );
@@ -1012,8 +1010,7 @@ const char *str;
 
 /* format_warn - write out formatted warning */
 
-void format_warn( msg, arg )
-const char *msg, arg[];
+void format_warn( const char *msg, const char arg[] )
 	{
 	char warn_msg[MAXLINE];
 
@@ -1024,8 +1021,7 @@ const char *msg, arg[];
 
 /* warn - report a warning, unless -w was given */
 
-void warn( str )
-const char *str;
+void warn( const char *str )
 	{
 	line_warning( str, linenum );
 	}
@@ -1034,8 +1030,7 @@ const char *str;
  *			     pinpointing its location
  */
 
-void format_pinpoint_message( msg, arg )
-const char *msg, arg[];
+void format_pinpoint_message( const char *msg, const char arg[] )
 	{
 	char errmsg[MAXLINE];
 
@@ -1046,8 +1041,7 @@ const char *msg, arg[];
 
 /* pinpoint_message - write out a message, pinpointing its location */
 
-void pinpoint_message( str )
-const char *str;
+void pinpoint_message( const char *str )
 	{
 	line_pinpoint( str, linenum );
 	}
@@ -1055,9 +1049,7 @@ const char *str;
 
 /* line_warning - report a warning at a given line, unless -w was given */
 
-void line_warning( str, line )
-const char *str;
-int line;
+void line_warning( const char *str, int line )
 	{
 	char warning[MAXLINE];
 
@@ -1071,9 +1063,7 @@ int line;
 
 /* line_pinpoint - write out a message, pinpointing it at the given line */
 
-void line_pinpoint( str, line )
-const char *str;
-int line;
+void line_pinpoint( const char *str, int line )
 	{
 	fprintf( stderr, "%s:%d: %s\n", infilename, line, str );
 	}
@@ -1083,8 +1073,7 @@ int line;
  *	     currently, messages are ignore
  */
 
-void yyerror( msg )
-const char *msg;
+void yyerror( const char *msg )
 	{
 		(void)msg;
 	}

--- a/src/scan.l
+++ b/src/scan.l
@@ -969,7 +969,7 @@ nmstr[yyleng - 2 - end_is_ws] = '\0';  /* chop trailing brace */
 %%
 
 
-int yywrap()
+int yywrap(void)
 	{
 	if ( --num_input_files > 0 )
 		{
@@ -984,8 +984,7 @@ int yywrap()
 
 /* set_input_file - open the given file (if NULL, stdin) for scanning */
 
-void set_input_file( file )
-char *file;
+void set_input_file( char *file )
 	{
 	if ( file && strcmp( file, "-" ) )
 		{
@@ -1008,21 +1007,17 @@ char *file;
 
 /* Wrapper routines for accessing the scanner's malloc routines. */
 
-void *flex_alloc( size )
-size_t size;
+void *flex_alloc( size_t size )
 	{
 	return (void *) malloc( size );
 	}
 
-void *flex_realloc( ptr, size )
-void *ptr;
-size_t size;
+void *flex_realloc( void *ptr, size_t size )
 	{
 	return (void *) realloc( ptr, size );
 	}
 
-void flex_free( ptr )
-void *ptr;
+void flex_free( void *ptr )
 	{
 	if ( ptr )
 		free( ptr );

--- a/src/scanopt.c
+++ b/src/scanopt.c
@@ -42,9 +42,7 @@
 #else
 static int STRCASECMP PROTO ((const char *, const char *));
 
-static int STRCASECMP (a, b)
-     const char *a;
-     const char *b;
+static int STRCASECMP (const char *a, const char *b)
 {
 	while (tolower ((unsigned char)*a++) == tolower ((unsigned char)*b++)) ;
 	return b - a;
@@ -87,38 +85,28 @@ static int matchlongopt PROTO ((char *, char **, int *, char **, int *));
 static int find_opt
 PROTO ((struct _scanopt_t *, int, char *, int, int *, int *opt_offset));
 
-static const char *NAME (s, i)
-     struct _scanopt_t *s;
-     int     i;
+static const char *NAME (struct _scanopt_t *s, int i)
 {
 	return s->options[i].opt_fmt +
 		((s->aux[i].flags & IS_LONG) ? 2 : 1);
 }
 
-static int PRINTLEN (s, i)
-     struct _scanopt_t *s;
-     int     i;
+static int PRINTLEN (struct _scanopt_t *s, int i)
 {
 	return s->aux[i].printlen;
 }
 
-static int RVAL (s, i)
-     struct _scanopt_t *s;
-     int     i;
+static int RVAL (struct _scanopt_t *s, int i)
 {
 	return s->options[i].r_val;
 }
 
-static int FLAGS (s, i)
-     struct _scanopt_t *s;
-     int     i;
+static int FLAGS (struct _scanopt_t *s, int i)
 {
 	return s->aux[i].flags;
 }
 
-static const char *DESC (s, i)
-     struct _scanopt_t *s;
-     int     i;
+static const char *DESC (struct _scanopt_t *s, int i)
 {
 	return s->options[i].desc ? s->options[i].desc : "";
 }
@@ -126,7 +114,7 @@ static const char *DESC (s, i)
 #ifndef NO_SCANOPT_USAGE
 static int get_cols PROTO ((void));
 
-static int get_cols ()
+static int get_cols (void)
 {
 	char   *env;
 	int     cols = 80;	/* default */
@@ -159,11 +147,7 @@ static int get_cols ()
        (s)->subscript= 0;  \
     }while(0)
 
-scanopt_t *scanopt_init (options, argc, argv, flags)
-     const optspec_t *options;
-     int     argc;
-     char  **argv;
-     int     flags;
+scanopt_t *scanopt_init (const optspec_t *options, int argc, char **argv, int flags)
 {
 	int     i;
 	struct _scanopt_t *s;
@@ -255,10 +239,7 @@ typedef struct usg_elem usg_elem;
 [indent][option, alias1, alias2...][indent][description line1
                                             description line2...]
  */
-int     scanopt_usage (scanner, fp, usage)
-     scanopt_t *scanner;
-     FILE   *fp;
-     const char *usage;
+int     scanopt_usage (scanopt_t *scanner, FILE *fp, const char *usage)
 {
 	struct _scanopt_t *s;
 	int     i, columns, indent = 2;
@@ -529,10 +510,7 @@ int     scanopt_usage (scanner, fp, usage)
 #endif /* no scanopt_usage */
 
 
-static int scanopt_err (s, is_short, err)
-     struct _scanopt_t *s;
-     int     is_short;
-     int     err;
+static int scanopt_err (struct _scanopt_t *s, int is_short, int err)
 {
 	const char *optname = "";
 	char    optchar[2];
@@ -587,12 +565,7 @@ static int scanopt_err (s, is_short, err)
  * optname will point to str + 2
  *
  */
-static int matchlongopt (str, optname, optlen, arg, arglen)
-     char   *str;
-     char  **optname;
-     int    *optlen;
-     char  **arg;
-     int    *arglen;
+static int matchlongopt (char *str, char **optname, int *optlen, char **arg, int *arglen)
 {
 	char   *p;
 
@@ -634,13 +607,8 @@ static int matchlongopt (str, optname, optlen, arg, arglen)
  * Short options must be exact.
  * Return boolean true if found and no error.
  * Error stored in err_code or zero if no error. */
-static int find_opt (s, lookup_long, optstart, len, err_code, opt_offset)
-     struct _scanopt_t *s;
-     int     lookup_long;
-     char   *optstart;
-     int     len;
-     int    *err_code;
-     int    *opt_offset;
+static int find_opt (struct _scanopt_t *s, int lookup_long, char *optstart, int
+	len, int *err_code, int *opt_offset)
 {
 	int     nmatch = 0, lastr_val = 0, i;
 
@@ -699,10 +667,7 @@ static int find_opt (s, lookup_long, optstart, len, err_code, opt_offset)
 }
 
 
-int     scanopt (svoid, arg, optindex)
-     scanopt_t *svoid;
-     char  **arg;
-     int    *optindex;
+int     scanopt (scanopt_t *svoid, char **arg, int *optindex)
 {
 	char   *optname = NULL, *optarg = NULL, *pstart;
 	int     namelen = 0, arglen = 0;
@@ -848,8 +813,7 @@ int     scanopt (svoid, arg, optindex)
 }
 
 
-int     scanopt_destroy (svoid)
-     scanopt_t *svoid;
+int     scanopt_destroy (scanopt_t *svoid)
 {
 	struct _scanopt_t *s;
 

--- a/src/sym.c
+++ b/src/sym.c
@@ -72,12 +72,7 @@ static int hashfunct PROTO ((const char *, int));
  * -1 is returned if the symbol already exists, and the change not made.
  */
 
-static int addsym (sym, str_def, int_def, table, table_size)
-     char sym[];
-     char   *str_def;
-     int     int_def;
-     hash_table table;
-     int     table_size;
+static int addsym (char sym[], char *str_def, int int_def, hash_table table, int table_size)
 {
 	int    hash_val = hashfunct (sym, table_size);
 	struct hash_entry *sym_entry = table[hash_val];
@@ -119,9 +114,7 @@ static int addsym (sym, str_def, int_def, table, table_size)
 
 /* cclinstal - save the text of a character class */
 
-void    cclinstal (ccltxt, cclnum)
-     Char    ccltxt[];
-     int     cclnum;
+void    cclinstal (Char ccltxt[], int cclnum)
 {
 	/* We don't bother checking the return status because we are not
 	 * called unless the symbol is new.
@@ -137,8 +130,7 @@ void    cclinstal (ccltxt, cclnum)
  * Returns 0 if there's no CCL associated with the text.
  */
 
-int     ccllookup (ccltxt)
-     Char    ccltxt[];
+int     ccllookup (Char ccltxt[])
 {
 	return findsym ((char *) ccltxt, ccltab, CCL_HASH_SIZE)->int_val;
 }
@@ -146,10 +138,7 @@ int     ccllookup (ccltxt)
 
 /* findsym - find symbol in symbol table */
 
-static struct hash_entry *findsym (sym, table, table_size)
-     const char *sym;
-     hash_table table;
-     int     table_size;
+static struct hash_entry *findsym (const char *sym, hash_table table, int table_size)
 {
 	static struct hash_entry empty_entry = {
 		(struct hash_entry *) 0, (struct hash_entry *) 0,
@@ -170,9 +159,7 @@ static struct hash_entry *findsym (sym, table, table_size)
 
 /* hashfunct - compute the hash value for "str" and hash size "hash_size" */
 
-static int hashfunct (str, hash_size)
-     const char *str;
-     int     hash_size;
+static int hashfunct (const char *str, int hash_size)
 {
 	int hashval;
 	int locstr;
@@ -191,9 +178,7 @@ static int hashfunct (str, hash_size)
 
 /* ndinstal - install a name definition */
 
-void    ndinstal (name, definition)
-     const char *name;
-     Char    definition[];
+void    ndinstal (const char *name, Char definition[])
 {
 
 	if (addsym (copy_string (name),
@@ -208,8 +193,7 @@ void    ndinstal (name, definition)
  * Returns a nil pointer if the name definition does not exist.
  */
 
-Char   *ndlookup (nd)
-     const char *nd;
+Char   *ndlookup (const char *nd)
 {
 	return (Char *) findsym (nd, ndtbl, NAME_TABLE_HASH_SIZE)->str_val;
 }
@@ -217,7 +201,7 @@ Char   *ndlookup (nd)
 
 /* scextend - increase the maximum number of start conditions */
 
-void    scextend ()
+void    scextend (void)
 {
 	current_max_scs += MAX_SCS_INCREMENT;
 
@@ -237,9 +221,7 @@ void    scextend ()
  *    The start condition is "exclusive" if xcluflg is true.
  */
 
-void    scinstal (str, xcluflg)
-     const char *str;
-     int     xcluflg;
+void    scinstal (const char *str, int xcluflg)
 {
 
 	if (++lastsc >= current_max_scs)
@@ -265,8 +247,7 @@ str);
  * Returns 0 if no such start condition.
  */
 
-int     sclookup (str)
-     const char *str;
+int     sclookup (const char *str)
 {
 	return findsym (str, sctbl, START_COND_HASH_SIZE)->int_val;
 }

--- a/src/tblcmp.c
+++ b/src/tblcmp.c
@@ -78,8 +78,7 @@ int tbldiff PROTO ((int[], int, int[]));
  * cost only one difference.
  */
 
-void    bldtbl (state, statenum, totaltrans, comstate, comfreq)
-     int     state[], statenum, totaltrans, comstate, comfreq;
+void    bldtbl (int state[], int statenum, int totaltrans, int comstate, int comfreq)
 {
 	int     extptr, extrct[2][CSIZE + 1];
 	int     mindiff, minprot, i, d;
@@ -221,7 +220,7 @@ void    bldtbl (state, statenum, totaltrans, comstate, comfreq)
  * classes.
  */
 
-void    cmptmps ()
+void    cmptmps (void)
 {
 	int tmpstorage[CSIZE + 1];
 	int *tmp = tmpstorage, i, j;
@@ -289,7 +288,7 @@ void    cmptmps ()
 
 /* expand_nxt_chk - expand the next check arrays */
 
-void    expand_nxt_chk ()
+void    expand_nxt_chk (void)
 {
 	int old_max = current_max_xpairs;
 
@@ -324,8 +323,7 @@ void    expand_nxt_chk ()
  * and an action number will be added in [-1].
  */
 
-int     find_table_space (state, numtrans)
-     int    *state, numtrans;
+int     find_table_space (int *state, int numtrans)
 {
 	/* Firstfree is the position of the first possible occurrence of two
 	 * consecutive unused records in the chk and nxt arrays.
@@ -419,7 +417,7 @@ int     find_table_space (state, numtrans)
  * Initializes "firstfree" to be one beyond the end of the table.  Initializes
  * all "chk" entries to be zero.
  */
-void    inittbl ()
+void    inittbl (void)
 {
 	int i;
 
@@ -451,7 +449,7 @@ void    inittbl ()
 
 /* mkdeftbl - make the default, "jam" table entries */
 
-void    mkdeftbl ()
+void    mkdeftbl (void)
 {
 	int     i;
 
@@ -500,9 +498,8 @@ void    mkdeftbl ()
  * state array.
  */
 
-void    mkentry (state, numchars, statenum, deflink, totaltrans)
-     int *state;
-     int numchars, statenum, deflink, totaltrans;
+void    mkentry (int *state, int numchars, int statenum, int deflink,
+		 int totaltrans)
 {
 	int minec, maxec, i, baseaddr;
 	int tblbase, tbllast;
@@ -616,8 +613,7 @@ void    mkentry (state, numchars, statenum, deflink, totaltrans)
  *            has only one out-transition
  */
 
-void    mk1tbl (state, sym, onenxt, onedef)
-     int     state, sym, onenxt, onedef;
+void    mk1tbl (int state, int sym, int onenxt, int onedef)
 {
 	if (firstfree < sym)
 		firstfree = sym;
@@ -642,8 +638,7 @@ void    mk1tbl (state, sym, onenxt, onedef)
 
 /* mkprot - create new proto entry */
 
-void    mkprot (state, statenum, comstate)
-     int     state[], statenum, comstate;
+void    mkprot (int state[], int statenum, int comstate)
 {
 	int     i, slot, tblbase;
 
@@ -680,8 +675,7 @@ void    mkprot (state, statenum, comstate)
  *              to it
  */
 
-void    mktemplate (state, statenum, comstate)
-     int     state[], statenum, comstate;
+void    mktemplate (int state[], int statenum, int comstate)
 {
 	int     i, numdiff, tmpbase, tmp[CSIZE + 1];
 	Char    transset[CSIZE + 1];
@@ -732,8 +726,7 @@ void    mktemplate (state, statenum, comstate)
 
 /* mv2front - move proto queue element to front of queue */
 
-void    mv2front (qelm)
-     int     qelm;
+void    mv2front (int qelm)
 {
 	if (firstprot != qelm) {
 		if (qelm == lastprot)
@@ -759,8 +752,7 @@ void    mv2front (qelm)
  * Transnum is the number of out-transitions for the state.
  */
 
-void    place_state (state, statenum, transnum)
-     int    *state, statenum, transnum;
+void    place_state (int *state, int statenum, int transnum)
 {
 	int i;
 	int *state_ptr;
@@ -802,8 +794,7 @@ void    place_state (state, statenum, transnum)
  * no room, we process the sucker right now.
  */
 
-void    stack1 (statenum, sym, nextstate, deflink)
-     int     statenum, sym, nextstate, deflink;
+void    stack1 (int statenum, int sym, int nextstate, int deflink)
 {
 	if (onesp >= ONE_STACK_SIZE - 1)
 		mk1tbl (statenum, sym, nextstate, deflink);
@@ -832,8 +823,7 @@ void    stack1 (statenum, sym, nextstate, deflink)
  * number is "numecs" minus the number of "SAME_TRANS" entries in "ext".
  */
 
-int     tbldiff (state, pr, ext)
-     int     state[], pr, ext[];
+int     tbldiff (int state[], int pr, int ext[])
 {
 	int i, *sp = state, *ep = ext, *protp;
 	int numdiff = 0;


### PR DESCRIPTION
flex was using K&R function defintions for some functions and
ANSI C style in others, sometimes even in the same file. Change
the code to consistently use ANSI C.

Signed-off-by: Stefan Reinauer <stefan.reinauer@coreboot.org>