### PR TITLE
Replace Char macro with 'unsigned char'

### DIFF
--- a/src/ecs.c
+++ b/src/ecs.c
@@ -99,9 +99,9 @@ int     cre8ecs (int fwd[], int bck[], int num)
 /* mkeccl - update equivalence classes based on character class xtions
  *
  * synopsis
- *    Char ccls[];
+ *    unsigned char ccls[];
  *    int lenccl, fwd[llsiz], bck[llsiz], llsiz, NUL_mapping;
- *    void mkeccl( Char ccls[], int lenccl, int fwd[llsiz], int bck[llsiz],
+ *    void mkeccl( unsigned char ccls[], int lenccl, int fwd[llsiz], int bck[llsiz],
  *			int llsiz, int NUL_mapping );
  *
  * ccls contains the elements of the character class, lenccl is the
@@ -111,7 +111,7 @@ int     cre8ecs (int fwd[], int bck[], int num)
  * NUL_mapping is the value which NUL (0) should be mapped to.
  */
 
-void    mkeccl (Char ccls[], int lenccl, int fwd[], int bck[], int llsiz, int NUL_mapping)
+void    mkeccl (unsigned char ccls[], int lenccl, int fwd[], int bck[], int llsiz, int NUL_mapping)
 {
 	int     cclp, oldec, newec;
 	int     cclm, i, j;

--- a/src/flexdef.h
+++ b/src/flexdef.h
@@ -109,7 +109,6 @@ char *alloca ();
 
 /* Always be prepared to generate an 8-bit scanner. */
 #define CSIZE 256
-#define Char unsigned char
 
 /* Size of input alphabet - should be size of ASCII set. */
 #ifndef DEFAULT_CSIZE
@@ -647,7 +646,7 @@ extern int end_of_buffer_state;
 
 extern int lastccl, *cclmap, *ccllen, *cclng, cclreuse;
 extern int current_maxccls, current_max_ccl_tbl_size;
-extern Char *ccltbl;
+extern unsigned char *ccltbl;
 
 
 /* Variables for miscellaneous information:
@@ -721,10 +720,10 @@ void flex_free PROTO ((void *));
 	(char *) reallocate_array( (void *) array, size, sizeof( char ) )
 
 #define allocate_Character_array(size) \
-	(Char *) allocate_array( size, sizeof( Char ) )
+	(unsigned char *) allocate_array( size, sizeof( unsigned char ) )
 
 #define reallocate_Character_array(array,size) \
-	(Char *) reallocate_array( (void *) array, size, sizeof( Char ) )
+	(unsigned char *) reallocate_array( (void *) array, size, sizeof( unsigned char ) )
 
 
 /* Used to communicate between scanner and parser.  The type should really
@@ -777,7 +776,7 @@ extern void ccl2ecl PROTO ((void));
 extern int cre8ecs PROTO ((int[], int[], int));
 
 /* Update equivalence classes based on character class transitions. */
-extern void mkeccl PROTO ((Char[], int, int[], int[], int, int));
+extern void mkeccl PROTO ((unsigned char[], int, int[], int[], int, int));
 
 /* Create equivalence class for single character. */
 extern void mkechar PROTO ((int, int[], int[]));
@@ -856,13 +855,13 @@ extern int intcmp PROTO ((const void *, const void *));
 extern void check_char PROTO ((int c));
 
 /* Replace upper-case letter to lower-case. */
-extern Char clower PROTO ((int));
+extern unsigned char clower PROTO ((int));
 
 /* Returns a dynamically allocated copy of a string. */
 extern char *copy_string PROTO ((const char *));
 
 /* Returns a dynamically allocated copy of a (potentially) unsigned string. */
-extern Char *copy_unsigned_string PROTO ((Char *));
+extern unsigned char *copy_unsigned_string PROTO ((unsigned char *));
 
 /* Compare two characters for use by qsort with '\0' sorting last. */
 extern int cclcmp PROTO ((const void *, const void *));
@@ -901,7 +900,7 @@ extern void flexfatal PROTO ((const char *));
 #endif /* ! HAVE_DECL___func__ */
 
 /* Convert a hexadecimal digit string to an integer value. */
-extern int htoi PROTO ((Char[]));
+extern int htoi PROTO ((unsigned char[]));
 
 /* Report an error message formatted  */
 extern void lerr PROTO ((const char *, ...))
@@ -937,10 +936,10 @@ extern void mkdata PROTO ((int));	/* generate a data statement */
 extern int myctoi PROTO ((const char *));
 
 /* Return character corresponding to escape sequence. */
-extern Char myesc PROTO ((Char[]));
+extern unsigned char myesc PROTO ((unsigned char[]));
 
 /* Convert an octal digit string to an integer value. */
-extern int otoi PROTO ((Char[]));
+extern int otoi PROTO ((unsigned char[]));
 
 /* Output a (possibly-formatted) string to the generated scanner. */
 extern void out PROTO ((const char *));
@@ -1056,13 +1055,13 @@ extern int yywrap PROTO ((void));
 /* from file sym.c */
 
 /* Save the text of a character class. */
-extern void cclinstal PROTO ((Char[], int));
+extern void cclinstal PROTO ((unsigned char[], int));
 
 /* Lookup the number associated with character class. */
-extern int ccllookup PROTO ((Char[]));
+extern int ccllookup PROTO ((unsigned char[]));
 
-extern void ndinstal PROTO ((const char *, Char[]));	/* install a name definition */
-extern Char *ndlookup PROTO ((const char *));	/* lookup a name definition */
+extern void ndinstal PROTO ((const char *, unsigned char[]));	/* install a name definition */
+extern unsigned char *ndlookup PROTO ((const char *));	/* lookup a name definition */
 
 /* Increase maximum number of SC's. */
 extern void scextend PROTO ((void));

--- a/src/main.c
+++ b/src/main.c
@@ -94,7 +94,7 @@ int    *accsiz, *dhash, numas;
 int     numsnpairs, jambase, jamstate;
 int     lastccl, *cclmap, *ccllen, *cclng, cclreuse;
 int     current_maxccls, current_max_ccl_tbl_size;
-Char   *ccltbl;
+unsigned char   *ccltbl;
 char    nmstr[MAXLINE];
 int     sectnum, nummt, hshcol, dfaeql, numeps, eps2, num_reallocs;
 int     tmpuses, totnst, peakpairs, numuniq, numdup, hshsave;

--- a/src/misc.c
+++ b/src/misc.c
@@ -182,7 +182,7 @@ void   *allocate_array (int size, size_t element_size)
 int all_lower (char *str)
 {
 	while (*str) {
-		if (!isascii ((Char) * str) || !islower ((Char) * str))
+		if (!isascii ((unsigned char) * str) || !islower ((unsigned char) * str))
 			return 0;
 		++str;
 	}
@@ -196,7 +196,7 @@ int all_lower (char *str)
 int all_upper (char *str)
 {
 	while (*str) {
-		if (!isascii ((Char) * str) || !isupper ((Char) * str))
+		if (!isascii ((unsigned char) * str) || !isupper ((unsigned char) * str))
 			return 0;
 		++str;
 	}
@@ -234,9 +234,9 @@ void check_char (int c)
 
 /* clower - replace upper-case letter to lower-case */
 
-Char clower (int c)
+unsigned char clower (int c)
 {
-	return (Char) ((isascii (c) && isupper (c)) ? tolower (c) : c);
+	return (unsigned char) ((isascii (c) && isupper (c)) ? tolower (c) : c);
 }
 
 
@@ -269,10 +269,10 @@ char   *copy_string (const char *str)
  *    returns a dynamically allocated copy of a (potentially) unsigned string
  */
 
-Char   *copy_unsigned_string (Char *str)
+unsigned char   *copy_unsigned_string (unsigned char *str)
 {
-	Char *c;
-	Char   *copy;
+	unsigned char *c;
+	unsigned char   *copy;
 
 	/* find length */
 	for (c = str; *c; ++c) ;
@@ -289,13 +289,13 @@ Char   *copy_unsigned_string (Char *str)
 
 int cclcmp (const void *a, const void *b)
 {
-  if (!*(const Char *) a)
+  if (!*(const unsigned char *) a)
 	return 1;
   else
-	if (!*(const Char *) b)
+	if (!*(const unsigned char *) b)
 	  return - 1;
 	else
-	  return *(const Char *) a - *(const Char *) b;
+	  return *(const unsigned char *) a - *(const unsigned char *) b;
 }
 
 
@@ -361,7 +361,7 @@ void flexfatal (const char *msg)
 
 /* htoi - convert a hexadecimal digit string to an integer value */
 
-int htoi (Char str[])
+int htoi (unsigned char str[])
 {
 	unsigned int result;
 
@@ -539,9 +539,9 @@ int myctoi (const char *array)
 
 /* myesc - return character corresponding to escape sequence */
 
-Char myesc (Char array[])
+unsigned char myesc (unsigned char array[])
 {
-	Char    c, esc_char;
+	unsigned char    c, esc_char;
 
 	switch (array[1]) {
 	case 'b':
@@ -626,7 +626,7 @@ Char myesc (Char array[])
 
 /* otoi - convert an octal digit string to an integer value */
 
-int otoi (Char str[])
+int otoi (unsigned char str[])
 {
 	unsigned int result;
 

--- a/src/scan.l
+++ b/src/scan.l
@@ -135,7 +135,7 @@ M4QEND      "]]"
 
 	int doing_codeblock = false;
 	int i, brace_depth=0, brace_start_line=0;
-	Char nmdef[MAXLINE];
+	unsigned char nmdef[MAXLINE];
 
 
 <INITIAL>{
@@ -627,7 +627,7 @@ M4QEND      "]]"
                    * The reason it was disabled is so yacc/bison can parse
                    * ccl operations, such as ccl difference and union.
                    */
-                &&  (cclval = ccllookup( (Char *) nmstr )) != 0 )
+                &&  (cclval = ccllookup( (unsigned char *) nmstr )) != 0 )
 				{
 				if ( input() != ']' )
 					synerr( _( "bad character class" ) );
@@ -641,7 +641,7 @@ M4QEND      "]]"
 				/* We fudge a bit.  We know that this ccl will
 				 * soon be numbered as lastccl + 1 by cclinit.
 				 */
-				cclinstal( (Char *) nmstr, lastccl + 1 );
+				cclinstal( (unsigned char *) nmstr, lastccl + 1 );
 
 				/* Push back everything but the leading bracket
 				 * so the ccl can be rescanned.
@@ -661,7 +661,7 @@ M4QEND      "]]"
      * context.
      */
 	"{"{NAME}"}"[[:space:]]?	 {
-			Char *nmdefptr;
+			unsigned char *nmdefptr;
             int end_is_ws, end_ch;
 
             end_ch = yytext[yyleng-1];
@@ -947,7 +947,7 @@ nmstr[yyleng - 2 - end_is_ws] = '\0';  /* chop trailing brace */
 			}
 
 <SECT2,QUOTE,FIRSTCCL,CCL>{ESCSEQ}	{
-			yylval = myesc( (Char *) yytext );
+			yylval = myesc( (unsigned char *) yytext );
 
 			if ( YY_START == FIRSTCCL )
 				BEGIN(CCL);

--- a/src/scanopt.c
+++ b/src/scanopt.c
@@ -173,7 +173,7 @@ scanopt_t *scanopt_init (const optspec_t *options, int argc, char **argv, int fl
 	s->aux = (struct _aux *) malloc (s->optc * sizeof (struct _aux));
 
 	for (i = 0; i < s->optc; i++) {
-		const Char *p, *pname;
+		const unsigned char *p, *pname;
 		const struct optspec_t *opt;
 		struct _aux *aux;
 
@@ -184,11 +184,11 @@ scanopt_t *scanopt_init (const optspec_t *options, int argc, char **argv, int fl
 
 		if (opt->opt_fmt[0] == '-' && opt->opt_fmt[1] == '-') {
 			aux->flags |= IS_LONG;
-			pname = (const Char *)(opt->opt_fmt + 2);
+			pname = (const unsigned char *)(opt->opt_fmt + 2);
 			s->has_long = 1;
 		}
 		else {
-			pname = (const Char *)(opt->opt_fmt + 1);
+			pname = (const unsigned char *)(opt->opt_fmt + 1);
 			s->has_short = 1;
 		}
 		aux->printlen = strlen (opt->opt_fmt);

--- a/src/sym.c
+++ b/src/sym.c
@@ -114,7 +114,7 @@ static int addsym (char sym[], char *str_def, int int_def, hash_table table, int
 
 /* cclinstal - save the text of a character class */
 
-void    cclinstal (Char ccltxt[], int cclnum)
+void    cclinstal (unsigned char ccltxt[], int cclnum)
 {
 	/* We don't bother checking the return status because we are not
 	 * called unless the symbol is new.
@@ -130,7 +130,7 @@ void    cclinstal (Char ccltxt[], int cclnum)
  * Returns 0 if there's no CCL associated with the text.
  */
 
-int     ccllookup (Char ccltxt[])
+int     ccllookup (unsigned char ccltxt[])
 {
 	return findsym ((char *) ccltxt, ccltab, CCL_HASH_SIZE)->int_val;
 }
@@ -178,7 +178,7 @@ static int hashfunct (const char *str, int hash_size)
 
 /* ndinstal - install a name definition */
 
-void    ndinstal (const char *name, Char definition[])
+void    ndinstal (const char *name, unsigned char definition[])
 {
 
 	if (addsym (copy_string (name),
@@ -193,9 +193,9 @@ void    ndinstal (const char *name, Char definition[])
  * Returns a nil pointer if the name definition does not exist.
  */
 
-Char   *ndlookup (const char *nd)
+unsigned char   *ndlookup (const char *nd)
 {
-	return (Char *) findsym (nd, ndtbl, NAME_TABLE_HASH_SIZE)->str_val;
+	return (unsigned char *) findsym (nd, ndtbl, NAME_TABLE_HASH_SIZE)->str_val;
 }
 
 

--- a/src/tblcmp.c
+++ b/src/tblcmp.c
@@ -678,7 +678,7 @@ void    mkprot (int state[], int statenum, int comstate)
 void    mktemplate (int state[], int statenum, int comstate)
 {
 	int     i, numdiff, tmpbase, tmp[CSIZE + 1];
-	Char    transset[CSIZE + 1];
+	unsigned char    transset[CSIZE + 1];
 	int     tsptr;
 
 	++numtemps;


### PR DESCRIPTION
Thanks to Michael McConville for pointing out that the old Char macro causes problems with static analysis.  The macro has been removed and replaced with 'unsigned char' throughout the src.