### PR TITLE
Replace copy_string() with strdup()

### DIFF
--- a/src/flexdef.h
+++ b/src/flexdef.h
@@ -857,8 +857,8 @@ extern void check_char PROTO ((int c));
 /* Replace upper-case letter to lower-case. */
 extern unsigned char clower PROTO ((int));
 
-/* Returns a dynamically allocated copy of a string. */
-extern char *copy_string PROTO ((const char *));
+/* strdup() that fails fatally on allocation failures. */
+extern char *xstrdup(const char *);
 
 /* Returns a dynamically allocated copy of a (potentially) unsigned string. */
 extern unsigned char *copy_unsigned_string PROTO ((unsigned char *));

--- a/src/misc.c
+++ b/src/misc.c
@@ -106,7 +106,7 @@ void action_define (const char *defname, int value)
 	add_action (buf);
 
 	/* track #defines so we can undef them when we're done. */
-	cpy = copy_string (defname);
+	cpy = xstrdup(defname);
 	buf_append (&defs_buf, &cpy, 1);
 }
 
@@ -240,28 +240,14 @@ unsigned char clower (int c)
 }
 
 
-/* copy_string - returns a dynamically allocated copy of a string */
-
-char   *copy_string (const char *str)
+char *xstrdup(const char *s)
 {
-	const char *c1;
-	char *c2;
-	char   *copy;
-	unsigned int size;
+	char *s2;
 
-	/* find length */
-	for (c1 = str; *c1; ++c1) ;
+	if ((s2 = strdup(s)) == NULL)
+		flexfatal (_("memory allocation failure in xstrdup()"));
 
-	size = (c1 - str + 1) * sizeof (char);
-
-	copy = (char *) flex_alloc (size);
-
-	if (copy == NULL)
-		flexfatal (_("dynamic memory failure in copy_string()"));
-
-	for (c2 = copy; (*c2++ = *str++) != 0;) ;
-
-	return copy;
+	return s2;
 }
 
 

--- a/src/parse.y
+++ b/src/parse.y
@@ -193,19 +193,19 @@ optionlist	:  optionlist option
 
 option		:  OPT_OUTFILE '=' NAME
 			{
-			outfilename = copy_string( nmstr );
+			outfilename = xstrdup(nmstr);
 			did_outfilename = 1;
 			}
 		|  OPT_EXTRA_TYPE '=' NAME
-			{ extra_type = copy_string( nmstr ); }
+			{ extra_type = xstrdup(nmstr); }
 		|  OPT_PREFIX '=' NAME
-			{ prefix = copy_string( nmstr ); }
+			{ prefix = xstrdup(nmstr); }
 		|  OPT_YYCLASS '=' NAME
-			{ yyclass = copy_string( nmstr ); }
+			{ yyclass = xstrdup(nmstr); }
 		|  OPT_HEADER '=' NAME
-			{ headerfilename = copy_string( nmstr ); }
+			{ headerfilename = xstrdup(nmstr); }
 	    |  OPT_TABLES '=' NAME
-            { tablesext = true; tablesfilename = copy_string( nmstr ); }
+            { tablesext = true; tablesfilename = xstrdup(nmstr); }
 		;
 
 sect2		:  sect2 scon initforrule flexrule '\n'

--- a/src/scan.l
+++ b/src/scan.l
@@ -232,7 +232,7 @@ M4QEND      "]]"
 
 	\"[^"\n]*\"	{
 			flex_free( (void *) infilename );
-			infilename = copy_string( yytext + 1 );
+			infilename = xstrdup(yytext + 1);
 			infilename[strlen( infilename ) - 1] = '\0';
 			}
 	.		/* ignore spurious characters */
@@ -994,7 +994,7 @@ void set_input_file( char *file )
 	{
 	if ( file && strcmp( file, "-" ) )
 		{
-		infilename = copy_string( file );
+		infilename = xstrdup(file);
 		yyin = fopen( infilename, "r" );
 
 		if ( yyin == NULL )
@@ -1004,7 +1004,7 @@ void set_input_file( char *file )
 	else
 		{
 		yyin = stdin;
-		infilename = copy_string( "<stdin>" );
+		infilename = xstrdup("<stdin>");
 		}
 
 	linenum = 1;

--- a/src/sym.c
+++ b/src/sym.c
@@ -181,7 +181,7 @@ static int hashfunct (const char *str, int hash_size)
 void    ndinstal (const char *name, unsigned char definition[])
 {
 
-	if (addsym (copy_string (name),
+	if (addsym (xstrdup(name),
 		    (char *) copy_unsigned_string (definition), 0,
 		    ndtbl, NAME_TABLE_HASH_SIZE))
 			synerr (_("name defined twice"));
@@ -227,7 +227,7 @@ void    scinstal (const char *str, int xcluflg)
 	if (++lastsc >= current_max_scs)
 		scextend ();
 
-	scname[lastsc] = copy_string (str);
+	scname[lastsc] = xstrdup(str);
 
 	if (addsym (scname[lastsc], (char *) 0, lastsc,
 		    sctbl, START_COND_HASH_SIZE))

--- a/src/tables.c
+++ b/src/tables.c
@@ -90,8 +90,8 @@ int yytbl_hdr_init (struct yytbl_hdr *th, const char *version_str,
 	th->th_hsize += yypad64 (th->th_hsize);
 	th->th_ssize = 0;	// Not known at this point.
 	th->th_flags = 0;
-	th->th_version = copy_string (version_str);
-	th->th_name = copy_string (name);
+	th->th_version = xstrdup(version_str);
+	th->th_name = xstrdup(name);
 	return 0;
 }
 

--- a/to.do/unicode/flexdef.h
+++ b/to.do/unicode/flexdef.h
@@ -841,9 +841,6 @@ extern void check_char PROTO((int c));
 /* Replace upper-case letter to lower-case. */
 extern Char clower PROTO((int));
 
-/* Returns a dynamically allocated copy of a string. */
-extern char *copy_string PROTO((register const char *));
-
 /* Returns a dynamically allocated copy of a (potentially) unsigned string. */
 extern Char *copy_unsigned_string PROTO((register Char *));
 

--- a/to.do/unicode/misc.c
+++ b/to.do/unicode/misc.c
@@ -193,33 +193,6 @@ register int c;
 	}
 
 
-/* copy_string - returns a dynamically allocated copy of a string */
-
-char *copy_string( str )
-register const char *str;
-	{
-	register const char *c1;
-	register char *c2;
-	char *copy;
-	unsigned int size;
-
-	/* find length */
-	for ( c1 = str; *c1; ++c1 )
-		;
-
-	size = (c1 - str + 1) * sizeof( char );
-	copy = (char *) flex_alloc( size );
-
-	if ( copy == NULL )
-		flexfatal( _( "dynamic memory failure in copy_string()" ) );
-
-	for ( c2 = copy; (*c2++ = *str++) != 0; )
-		;
-
-	return copy;
-	}
-
-
 /* copy_unsigned_string -
  *    returns a dynamically allocated copy of a (potentially) unsigned string
  */

--- a/to.do/unicode/scan.l
+++ b/to.do/unicode/scan.l
@@ -160,7 +160,7 @@ LEXOPT		[aceknopr]
 
 	\"[^"\n]*\"	{
 			flex_free( (void *) infilename );
-			infilename = copy_string( yytext + 1 );
+			infilename = xstrdup(yytext + 1);
 			infilename[strlen( infilename ) - 1] = '\0';
 			}
 	.		/* ignore spurious characters */
@@ -670,7 +670,7 @@ char *file;
 	{
 	if ( file && strcmp( file, "-" ) )
 		{
-		infilename = copy_string( file );
+		infilename = xstrdup(file);
 		yyin = fopen( infilename, "r" );
 
 		if ( yyin == NULL )
@@ -680,7 +680,7 @@ char *file;
 	else
 		{
 		yyin = stdin;
-		infilename = copy_string( "<stdin>" );
+		infilename = xstrdup("<stdin>");
 		}
 
 	linenum = 1;


### PR DESCRIPTION
Is there any reason not to use the stdlib alternative here? I can't imagine so.