### PR TITLE
Enhance configure.ac checks for maintenance programs

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -48,8 +48,23 @@ AC_PROG_LN_S
 AC_PROG_AWK
 AC_PROG_INSTALL
 
-AC_PATH_PROG(BISON, bison,bison)
-AC_PATH_PROG(HELP2MAN, help2man, help2man)
+AC_PATH_PROG([BISON], bison, no)
+AS_IF([test "$BISON" != no],[],
+	[ AC_SUBST([BISON], [\${top_srcdir}/build-aux/missing bison]) 
+	  AC_MSG_NOTICE(no bison program found: only required for maintainers)
+	])
+
+AC_PATH_PROG([HELP2MAN], help2man, no)
+AS_IF([test "$HELP2MAN" != no],[],i
+	[ AC_SUBST([HELP2MAN], [\${top_srcdir}/build-aux/missing help2man])
+	  AC_MSG_NOTICE(no help2man program found: only required for maintainers)
+	])
+
+AC_PATH_PROGS([TEXI2DVI], [texi2dvi gtexi2dvi], [no])
+AS_IF([test "$TEXI2DVI" != no],[],
+	[ AC_SUBST([TEXI2DVI], [:])
+	  AC_MSG_NOTICE(no texi2dvi program found: only required for maintainers)
+	])
 
 # Check for a m4 that supports -P
 


### PR DESCRIPTION
Add test for presence of texi2dvi program. Give notice if texi2dvi
is unavailable and set TEXI2DVI=: to avoid giving users headaches.

Enhance tests for bison and help2man with notices when the programs
aren't found.  Set their program variables to use the missing script
in build-aux since it's compatible with them.