### PR TITLE
C++ cleanup

### DIFF
--- a/autogen.sh
+++ b/autogen.sh
@@ -29,5 +29,5 @@
 #Makefile first.)
 
 touch ChangeLog
-libtoolize --install --force
+libtoolize --install --force || glibtoolize --install --force
 autoreconf --install --force

--- a/examples/testxxLexer.l
+++ b/examples/testxxLexer.l
@@ -39,13 +39,13 @@ number	{num1}|{num2}
 			}
 		}
 
-{number}	FLEX_STD cout << "number " << YYText() << '\n';
+{number}	std::cout << "number " << YYText() << '\n';
 
 \n		mylineno++;
 
-{name}		FLEX_STD cout << "name " << YYText() << '\n';
+{name}		std::cout << "name " << YYText() << '\n';
 
-{string}	FLEX_STD cout << "string " << YYText() << '\n';
+{string}	std::cout << "string " << YYText() << '\n';
 
 %%
 

--- a/src/FlexLexer.h
+++ b/src/FlexLexer.h
@@ -49,9 +49,6 @@
 #define __FLEX_LEXER_H
 
 #include <iostream>
-#  ifndef FLEX_STD
-#    define FLEX_STD std::
-#  endif
 
 extern "C++" {
 
@@ -60,53 +57,53 @@ typedef int yy_state_type;
 
 class FlexLexer {
 public:
-	virtual ~FlexLexer()	{ }
+        virtual ~FlexLexer()	{ }
 
-	const char* YYText() const	{ return yytext; }
-	int YYLeng()	const	{ return yyleng; }
+        const char* YYText() const	{ return yytext; }
+        int YYLeng()	const	{ return yyleng; }
 
-	virtual void
-		yy_switch_to_buffer( struct yy_buffer_state* new_buffer ) = 0;
-	virtual struct yy_buffer_state*
-		yy_create_buffer( FLEX_STD istream* s, int size ) = 0;
-	virtual struct yy_buffer_state*
-		yy_create_buffer( FLEX_STD istream& s, int size ) = 0;
-	virtual void yy_delete_buffer( struct yy_buffer_state* b ) = 0;
-	virtual void yyrestart( FLEX_STD istream* s ) = 0;	
-	virtual void yyrestart( FLEX_STD istream& s ) = 0;
+        virtual void
+                yy_switch_to_buffer( struct yy_buffer_state* new_buffer ) = 0;
+        virtual struct yy_buffer_state*
+                yy_create_buffer( std::istream* s, int size ) = 0;
+        virtual struct yy_buffer_state*
+                yy_create_buffer( std::istream& s, int size ) = 0;
+        virtual void yy_delete_buffer( struct yy_buffer_state* b ) = 0;
+        virtual void yyrestart( std::istream* s ) = 0;
+        virtual void yyrestart( std::istream& s ) = 0;
 
-	virtual int yylex() = 0;
+        virtual int yylex() = 0;
 
-	// Call yylex with new input/output sources.
-	int yylex( FLEX_STD istream& new_in, FLEX_STD ostream& new_out )
-	{
-		switch_streams( new_in, new_out );
-		return yylex();
-	}
-	
-	int yylex( FLEX_STD istream* new_in, FLEX_STD ostream* new_out = 0)
-	{
-		switch_streams( new_in, new_out );
-		return yylex();
-	}
+        // Call yylex with new input/output sources.
+        int yylex( std::istream& new_in, std::ostream& new_out )
+        {
+                switch_streams( new_in, new_out );
+                return yylex();
+        }
 
-	// Switch to new input/output streams.  A nil stream pointer
-	// indicates "keep the current one".
-	virtual void switch_streams( FLEX_STD istream* new_in,
-					FLEX_STD ostream* new_out ) = 0;
-	virtual void switch_streams( FLEX_STD istream& new_in,
-					FLEX_STD ostream& new_out ) = 0;
+        int yylex( std::istream* new_in, std::ostream* new_out = 0)
+        {
+                switch_streams( new_in, new_out );
+                return yylex();
+        }
 
-	int lineno() const		{ return yylineno; }
+        // Switch to new input/output streams.  A nil stream pointer
+        // indicates "keep the current one".
+        virtual void switch_streams( std::istream* new_in,
+                                        std::ostream* new_out ) = 0;
+        virtual void switch_streams( std::istream& new_in,
+                                        std::ostream& new_out ) = 0;
 
-	int debug() const		{ return yy_flex_debug; }
-	void set_debug( int flag )	{ yy_flex_debug = flag; }
+        int lineno() const		{ return yylineno; }
+
+        int debug() const		{ return yy_flex_debug; }
+        void set_debug( int flag )	{ yy_flex_debug = flag; }
 
 protected:
-	char* yytext;
-	int yyleng;
-	int yylineno;		// only maintained if you use %option yylineno
-	int yy_flex_debug;	// only has effect with -d or "%option debug"
+        char* yytext;
+        int yyleng;
+        int yylineno;		// only maintained if you use %option yylineno
+        int yy_flex_debug;	// only has effect with -d or "%option debug"
 };
 
 }
@@ -122,104 +119,103 @@ extern "C++" {
 
 class yyFlexLexer : public FlexLexer {
 public:
-	// arg_yyin and arg_yyout default to the cin and cout, but we
-	// only make that assignment when initializing in yylex().
-	yyFlexLexer( FLEX_STD istream& arg_yyin, FLEX_STD ostream& arg_yyout );
-	yyFlexLexer( FLEX_STD istream* arg_yyin = 0, FLEX_STD ostream* arg_yyout = 0 );
+        // arg_yyin and arg_yyout default to the cin and cout, but we
+        // only make that assignment when initializing in yylex().
+        yyFlexLexer( std::istream& arg_yyin, std::ostream& arg_yyout );
+        yyFlexLexer( std::istream* arg_yyin = 0, std::ostream* arg_yyout = 0 );
 private:
-	void ctor_common();
+        void ctor_common();
 
 public:
 
-	virtual ~yyFlexLexer();
+        virtual ~yyFlexLexer();
 
-	void yy_switch_to_buffer( struct yy_buffer_state* new_buffer );
-	struct yy_buffer_state* yy_create_buffer( FLEX_STD istream* s, int size );	
-	struct yy_buffer_state* yy_create_buffer( FLEX_STD istream& s, int size );
-	void yy_delete_buffer( struct yy_buffer_state* b );
-	void yyrestart( FLEX_STD istream* s );
-	void yyrestart( FLEX_STD istream& s );
+        void yy_switch_to_buffer( struct yy_buffer_state* new_buffer );
+        struct yy_buffer_state* yy_create_buffer( std::istream* s, int size );
+        struct yy_buffer_state* yy_create_buffer( std::istream& s, int size );
+        void yy_delete_buffer( struct yy_buffer_state* b );
+        void yyrestart( std::istream* s );
+        void yyrestart( std::istream& s );
 
-	void yypush_buffer_state( struct yy_buffer_state* new_buffer );
-	void yypop_buffer_state();
+        void yypush_buffer_state( struct yy_buffer_state* new_buffer );
+        void yypop_buffer_state();
 
-	virtual int yylex();
-	virtual void switch_streams( FLEX_STD istream& new_in, FLEX_STD ostream& new_out );
-	virtual void switch_streams( FLEX_STD istream* new_in = 0, FLEX_STD ostream* new_out = 0 );
-	virtual int yywrap();
+        virtual int yylex();
+        virtual void switch_streams( std::istream& new_in, std::ostream& new_out );
+        virtual void switch_streams( std::istream* new_in = 0, std::ostream* new_out = 0 );
+        virtual int yywrap();
 
 protected:
-	virtual int LexerInput( char* buf, int max_size );
-	virtual void LexerOutput( const char* buf, int size );
-	virtual void LexerError( const char* msg );
+        virtual int LexerInput( char* buf, int max_size );
+        virtual void LexerOutput( const char* buf, int size );
+        virtual void LexerError( const char* msg );
 
-	void yyunput( int c, char* buf_ptr );
-	int yyinput();
+        void yyunput( int c, char* buf_ptr );
+        int yyinput();
 
-	void yy_load_buffer_state();
-	void yy_init_buffer( struct yy_buffer_state* b, FLEX_STD istream& s );
-	void yy_flush_buffer( struct yy_buffer_state* b );
+        void yy_load_buffer_state();
+        void yy_init_buffer( struct yy_buffer_state* b, std::istream& s );
+        void yy_flush_buffer( struct yy_buffer_state* b );
 
-	int yy_start_stack_ptr;
-	int yy_start_stack_depth;
-	int* yy_start_stack;
+        int yy_start_stack_ptr;
+        int yy_start_stack_depth;
+        int* yy_start_stack;
 
-	void yy_push_state( int new_state );
-	void yy_pop_state();
-	int yy_top_state();
+        void yy_push_state( int new_state );
+        void yy_pop_state();
+        int yy_top_state();
 
-	yy_state_type yy_get_previous_state();
-	yy_state_type yy_try_NUL_trans( yy_state_type current_state );
-	int yy_get_next_buffer();
+        yy_state_type yy_get_previous_state();
+        yy_state_type yy_try_NUL_trans( yy_state_type current_state );
+        int yy_get_next_buffer();
 
-	FLEX_STD istream yyin;	// input source for default LexerInput
-	FLEX_STD ostream yyout;	// output sink for default LexerOutput
+        std::istream yyin;	// input source for default LexerInput
+        std::ostream yyout;	// output sink for default LexerOutput
 
-	// yy_hold_char holds the character lost when yytext is formed.
-	char yy_hold_char;
+        // yy_hold_char holds the character lost when yytext is formed.
+        char yy_hold_char;
 
-	// Number of characters read into yy_ch_buf.
-	int yy_n_chars;
+        // Number of characters read into yy_ch_buf.
+        int yy_n_chars;
 
-	// Points to current character in buffer.
-	char* yy_c_buf_p;
+        // Points to current character in buffer.
+        char* yy_c_buf_p;
 
-	int yy_init;		// whether we need to initialize
-	int yy_start;		// start state number
+        int yy_init;		// whether we need to initialize
+        int yy_start;		// start state number
 
-	// Flag which is used to allow yywrap()'s to do buffer switches
-	// instead of setting up a fresh yyin.  A bit of a hack ...
-	int yy_did_buffer_switch_on_eof;
+        // Flag which is used to allow yywrap()'s to do buffer switches
+        // instead of setting up a fresh yyin.  A bit of a hack ...
+        int yy_did_buffer_switch_on_eof;
 
 
-	size_t yy_buffer_stack_top; /**< index of top of stack. */
-	size_t yy_buffer_stack_max; /**< capacity of stack. */
-	struct yy_buffer_state ** yy_buffer_stack; /**< Stack as an array. */
-	void yyensure_buffer_stack(void);
+        size_t yy_buffer_stack_top; /**< index of top of stack. */
+        size_t yy_buffer_stack_max; /**< capacity of stack. */
+        struct yy_buffer_state ** yy_buffer_stack; /**< Stack as an array. */
+        void yyensure_buffer_stack(void);
 
-	// The following are not always needed, but may be depending
-	// on use of certain flex features (like REJECT or yymore()).
+        // The following are not always needed, but may be depending
+        // on use of certain flex features (like REJECT or yymore()).
 
-	yy_state_type yy_last_accepting_state;
-	char* yy_last_accepting_cpos;
+        yy_state_type yy_last_accepting_state;
+        char* yy_last_accepting_cpos;
 
-	yy_state_type* yy_state_buf;
-	yy_state_type* yy_state_ptr;
+        yy_state_type* yy_state_buf;
+        yy_state_type* yy_state_ptr;
 
-	char* yy_full_match;
-	int* yy_full_state;
-	int yy_full_lp;
+        char* yy_full_match;
+        int* yy_full_state;
+        int yy_full_lp;
 
-	int yy_lp;
-	int yy_looking_for_trail_begin;
+        int yy_lp;
+        int yy_looking_for_trail_begin;
 
-	int yy_more_flag;
-	int yy_more_len;
-	int yy_more_offset;
-	int yy_prev_more_offset;
+        int yy_more_flag;
+        int yy_more_len;
+        int yy_more_offset;
+        int yy_prev_more_offset;
 };
 
 }
 
 #endif // yyFlexLexer || ! yyFlexLexerOnce
-

--- a/src/FlexLexer.h
+++ b/src/FlexLexer.h
@@ -50,8 +50,6 @@
 
 #include <iostream>
 
-extern "C++" {
-
 struct yy_buffer_state;
 typedef int yy_state_type;
 
@@ -105,8 +103,6 @@ protected:
         int yylineno;		// only maintained if you use %option yylineno
         int yy_flex_debug;	// only has effect with -d or "%option debug"
 };
-
-}
 #endif // FLEXLEXER_H
 
 #if defined(yyFlexLexer) || ! defined(yyFlexLexerOnce)
@@ -114,8 +110,6 @@ protected:
 // or this is a repeated include to define a different flavor of
 // yyFlexLexer, as discussed in the flex manual.
 #define yyFlexLexerOnce
-
-extern "C++" {
 
 class yyFlexLexer : public FlexLexer {
 public:
@@ -215,7 +209,5 @@ protected:
         int yy_more_offset;
         int yy_prev_more_offset;
 };
-
-}
 
 #endif // yyFlexLexer || ! yyFlexLexerOnce

--- a/src/FlexLexer.h
+++ b/src/FlexLexer.h
@@ -35,14 +35,14 @@
 // to rename each yyFlexLexer to some other xxFlexLexer.  You then
 // include <FlexLexer.h> in your other sources once per lexer class:
 //
-//	#undef yyFlexLexer
-//	#define yyFlexLexer xxFlexLexer
-//	#include <FlexLexer.h>
+//      #undef yyFlexLexer
+//      #define yyFlexLexer xxFlexLexer
+//      #include <FlexLexer.h>
 //
-//	#undef yyFlexLexer
-//	#define yyFlexLexer zzFlexLexer
-//	#include <FlexLexer.h>
-//	...
+//      #undef yyFlexLexer
+//      #define yyFlexLexer zzFlexLexer
+//      #include <FlexLexer.h>
+//      ...
 
 #ifndef __FLEX_LEXER_H
 // Never included before - need to define base class.
@@ -53,55 +53,54 @@
 struct yy_buffer_state;
 typedef int yy_state_type;
 
-class FlexLexer {
+class FlexLexer
+{
 public:
-        virtual ~FlexLexer()	{ }
+  virtual ~FlexLexer()        { }
 
-        const char* YYText() const	{ return yytext; }
-        int YYLeng()	const	{ return yyleng; }
+  const char* YYText() const  { return yytext; }
+  int YYLeng()        const   { return yyleng; }
 
-        virtual void
-                yy_switch_to_buffer( yy_buffer_state* new_buffer ) = 0;
-        virtual yy_buffer_state*
-                yy_create_buffer( std::istream* s, int size ) = 0;
-        virtual yy_buffer_state*
-                yy_create_buffer( std::istream& s, int size ) = 0;
-        virtual void yy_delete_buffer( yy_buffer_state* b ) = 0;
-        virtual void yyrestart( std::istream* s ) = 0;
-        virtual void yyrestart( std::istream& s ) = 0;
+  virtual void
+  yy_switch_to_buffer( yy_buffer_state* new_buffer ) = 0;
+  virtual yy_buffer_state* yy_create_buffer( std::istream* s, int size ) = 0;
+  virtual yy_buffer_state* yy_create_buffer( std::istream& s, int size ) = 0;
+  virtual void yy_delete_buffer( yy_buffer_state* b ) = 0;
+  virtual void yyrestart( std::istream* s ) = 0;
+  virtual void yyrestart( std::istream& s ) = 0;
 
-        virtual int yylex() = 0;
+  virtual int yylex() = 0;
 
-        // Call yylex with new input/output sources.
-        int yylex( std::istream& new_in, std::ostream& new_out )
-        {
-                switch_streams( new_in, new_out );
-                return yylex();
-        }
+  // Call yylex with new input/output sources.
+  int yylex( std::istream& new_in, std::ostream& new_out )
+  {
+    switch_streams( new_in, new_out );
+    return yylex();
+  }
 
-        int yylex( std::istream* new_in, std::ostream* new_out = 0)
-        {
-                switch_streams( new_in, new_out );
-                return yylex();
-        }
+  int yylex( std::istream* new_in, std::ostream* new_out = 0)
+  {
+    switch_streams( new_in, new_out );
+    return yylex();
+  }
 
-        // Switch to new input/output streams.  A nil stream pointer
-        // indicates "keep the current one".
-        virtual void switch_streams( std::istream* new_in,
-                                        std::ostream* new_out ) = 0;
-        virtual void switch_streams( std::istream& new_in,
-                                        std::ostream& new_out ) = 0;
+  // Switch to new input/output streams.  A nil stream pointer
+  // indicates "keep the current one".
+  virtual void switch_streams( std::istream* new_in,
+                               std::ostream* new_out ) = 0;
+  virtual void switch_streams( std::istream& new_in,
+                               std::ostream& new_out ) = 0;
 
-        int lineno() const		{ return yylineno; }
+  int lineno() const          { return yylineno; }
 
-        int debug() const		{ return yy_flex_debug; }
-        void set_debug( int flag )	{ yy_flex_debug = flag; }
+  int debug() const           { return yy_flex_debug; }
+  void set_debug( int flag )  { yy_flex_debug = flag; }
 
 protected:
-        char* yytext;
-        int yyleng;
-        int yylineno;		// only maintained if you use %option yylineno
-        int yy_flex_debug;	// only has effect with -d or "%option debug"
+  char* yytext;
+  int yyleng;
+  int yylineno;       // only maintained if you use %option yylineno
+  int yy_flex_debug;  // only has effect with -d or "%option debug"
 };
 #endif // FLEXLEXER_H
 
@@ -109,105 +108,106 @@ protected:
 // Either this is the first time through (yyFlexLexerOnce not defined),
 // or this is a repeated include to define a different flavor of
 // yyFlexLexer, as discussed in the flex manual.
-#define yyFlexLexerOnce
+# define yyFlexLexerOnce
 
-class yyFlexLexer : public FlexLexer {
+class yyFlexLexer : public FlexLexer
+{
 public:
-        // arg_yyin and arg_yyout default to the cin and cout, but we
-        // only make that assignment when initializing in yylex().
-        yyFlexLexer( std::istream& arg_yyin, std::ostream& arg_yyout );
-        yyFlexLexer( std::istream* arg_yyin = 0, std::ostream* arg_yyout = 0 );
+  // arg_yyin and arg_yyout default to the cin and cout, but we
+  // only make that assignment when initializing in yylex().
+  yyFlexLexer( std::istream& arg_yyin, std::ostream& arg_yyout );
+  yyFlexLexer( std::istream* arg_yyin = 0, std::ostream* arg_yyout = 0 );
 private:
-        void ctor_common();
+  void ctor_common();
 
 public:
 
-        virtual ~yyFlexLexer();
+  virtual ~yyFlexLexer();
 
-        void yy_switch_to_buffer( yy_buffer_state* new_buffer );
-        yy_buffer_state* yy_create_buffer( std::istream* s, int size );
-        yy_buffer_state* yy_create_buffer( std::istream& s, int size );
-        void yy_delete_buffer( yy_buffer_state* b );
-        void yyrestart( std::istream* s );
-        void yyrestart( std::istream& s );
+  void yy_switch_to_buffer( yy_buffer_state* new_buffer );
+  yy_buffer_state* yy_create_buffer( std::istream* s, int size );
+  yy_buffer_state* yy_create_buffer( std::istream& s, int size );
+  void yy_delete_buffer( yy_buffer_state* b );
+  void yyrestart( std::istream* s );
+  void yyrestart( std::istream& s );
 
-        void yypush_buffer_state( yy_buffer_state* new_buffer );
-        void yypop_buffer_state();
+  void yypush_buffer_state( yy_buffer_state* new_buffer );
+  void yypop_buffer_state();
 
-        virtual int yylex();
-        virtual void switch_streams( std::istream& new_in, std::ostream& new_out );
-        virtual void switch_streams( std::istream* new_in = 0, std::ostream* new_out = 0 );
-        virtual int yywrap();
+  virtual int yylex();
+  virtual void switch_streams( std::istream& new_in, std::ostream& new_out );
+  virtual void switch_streams( std::istream* new_in = 0, std::ostream* new_out = 0 );
+  virtual int yywrap();
 
 protected:
-        virtual int LexerInput( char* buf, int max_size );
-        virtual void LexerOutput( const char* buf, int size );
-        virtual void LexerError( const char* msg );
+  virtual int LexerInput( char* buf, int max_size );
+  virtual void LexerOutput( const char* buf, int size );
+  virtual void LexerError( const char* msg );
 
-        void yyunput( int c, char* buf_ptr );
-        int yyinput();
+  void yyunput( int c, char* buf_ptr );
+  int yyinput();
 
-        void yy_load_buffer_state();
-        void yy_init_buffer( yy_buffer_state* b, std::istream& s );
-        void yy_flush_buffer( yy_buffer_state* b );
+  void yy_load_buffer_state();
+  void yy_init_buffer( yy_buffer_state* b, std::istream& s );
+  void yy_flush_buffer( yy_buffer_state* b );
 
-        int yy_start_stack_ptr;
-        int yy_start_stack_depth;
-        int* yy_start_stack;
+  int yy_start_stack_ptr;
+  int yy_start_stack_depth;
+  int* yy_start_stack;
 
-        void yy_push_state( int new_state );
-        void yy_pop_state();
-        int yy_top_state();
+  void yy_push_state( int new_state );
+  void yy_pop_state();
+  int yy_top_state();
 
-        yy_state_type yy_get_previous_state();
-        yy_state_type yy_try_NUL_trans( yy_state_type current_state );
-        int yy_get_next_buffer();
+  yy_state_type yy_get_previous_state();
+  yy_state_type yy_try_NUL_trans( yy_state_type current_state );
+  int yy_get_next_buffer();
 
-        std::istream yyin;	// input source for default LexerInput
-        std::ostream yyout;	// output sink for default LexerOutput
+  std::istream yyin;  // input source for default LexerInput
+  std::ostream yyout; // output sink for default LexerOutput
 
-        // yy_hold_char holds the character lost when yytext is formed.
-        char yy_hold_char;
+  // yy_hold_char holds the character lost when yytext is formed.
+  char yy_hold_char;
 
-        // Number of characters read into yy_ch_buf.
-        int yy_n_chars;
+  // Number of characters read into yy_ch_buf.
+  int yy_n_chars;
 
-        // Points to current character in buffer.
-        char* yy_c_buf_p;
+  // Points to current character in buffer.
+  char* yy_c_buf_p;
 
-        int yy_init;		// whether we need to initialize
-        int yy_start;		// start state number
+  int yy_init;                // whether we need to initialize
+  int yy_start;               // start state number
 
-        // Flag which is used to allow yywrap()'s to do buffer switches
-        // instead of setting up a fresh yyin.  A bit of a hack ...
-        int yy_did_buffer_switch_on_eof;
+  // Flag which is used to allow yywrap()'s to do buffer switches
+  // instead of setting up a fresh yyin.  A bit of a hack ...
+  int yy_did_buffer_switch_on_eof;
 
 
-        size_t yy_buffer_stack_top; /**< index of top of stack. */
-        size_t yy_buffer_stack_max; /**< capacity of stack. */
-        yy_buffer_state ** yy_buffer_stack; /**< Stack as an array. */
-        void yyensure_buffer_stack(void);
+  size_t yy_buffer_stack_top; /**< index of top of stack. */
+  size_t yy_buffer_stack_max; /**< capacity of stack. */
+  yy_buffer_state ** yy_buffer_stack; /**< Stack as an array. */
+  void yyensure_buffer_stack(void);
 
-        // The following are not always needed, but may be depending
-        // on use of certain flex features (like REJECT or yymore()).
+  // The following are not always needed, but may be depending
+  // on use of certain flex features (like REJECT or yymore()).
 
-        yy_state_type yy_last_accepting_state;
-        char* yy_last_accepting_cpos;
+  yy_state_type yy_last_accepting_state;
+  char* yy_last_accepting_cpos;
 
-        yy_state_type* yy_state_buf;
-        yy_state_type* yy_state_ptr;
+  yy_state_type* yy_state_buf;
+  yy_state_type* yy_state_ptr;
 
-        char* yy_full_match;
-        int* yy_full_state;
-        int yy_full_lp;
+  char* yy_full_match;
+  int* yy_full_state;
+  int yy_full_lp;
 
-        int yy_lp;
-        int yy_looking_for_trail_begin;
+  int yy_lp;
+  int yy_looking_for_trail_begin;
 
-        int yy_more_flag;
-        int yy_more_len;
-        int yy_more_offset;
-        int yy_prev_more_offset;
+  int yy_more_flag;
+  int yy_more_len;
+  int yy_more_offset;
+  int yy_prev_more_offset;
 };
 
 #endif // yyFlexLexer || ! yyFlexLexerOnce

--- a/src/FlexLexer.h
+++ b/src/FlexLexer.h
@@ -63,12 +63,12 @@ public:
         int YYLeng()	const	{ return yyleng; }
 
         virtual void
-                yy_switch_to_buffer( struct yy_buffer_state* new_buffer ) = 0;
-        virtual struct yy_buffer_state*
+                yy_switch_to_buffer( yy_buffer_state* new_buffer ) = 0;
+        virtual yy_buffer_state*
                 yy_create_buffer( std::istream* s, int size ) = 0;
-        virtual struct yy_buffer_state*
+        virtual yy_buffer_state*
                 yy_create_buffer( std::istream& s, int size ) = 0;
-        virtual void yy_delete_buffer( struct yy_buffer_state* b ) = 0;
+        virtual void yy_delete_buffer( yy_buffer_state* b ) = 0;
         virtual void yyrestart( std::istream* s ) = 0;
         virtual void yyrestart( std::istream& s ) = 0;
 
@@ -130,14 +130,14 @@ public:
 
         virtual ~yyFlexLexer();
 
-        void yy_switch_to_buffer( struct yy_buffer_state* new_buffer );
-        struct yy_buffer_state* yy_create_buffer( std::istream* s, int size );
-        struct yy_buffer_state* yy_create_buffer( std::istream& s, int size );
-        void yy_delete_buffer( struct yy_buffer_state* b );
+        void yy_switch_to_buffer( yy_buffer_state* new_buffer );
+        yy_buffer_state* yy_create_buffer( std::istream* s, int size );
+        yy_buffer_state* yy_create_buffer( std::istream& s, int size );
+        void yy_delete_buffer( yy_buffer_state* b );
         void yyrestart( std::istream* s );
         void yyrestart( std::istream& s );
 
-        void yypush_buffer_state( struct yy_buffer_state* new_buffer );
+        void yypush_buffer_state( yy_buffer_state* new_buffer );
         void yypop_buffer_state();
 
         virtual int yylex();
@@ -154,8 +154,8 @@ protected:
         int yyinput();
 
         void yy_load_buffer_state();
-        void yy_init_buffer( struct yy_buffer_state* b, std::istream& s );
-        void yy_flush_buffer( struct yy_buffer_state* b );
+        void yy_init_buffer( yy_buffer_state* b, std::istream& s );
+        void yy_flush_buffer( yy_buffer_state* b );
 
         int yy_start_stack_ptr;
         int yy_start_stack_depth;
@@ -191,7 +191,7 @@ protected:
 
         size_t yy_buffer_stack_top; /**< index of top of stack. */
         size_t yy_buffer_stack_max; /**< capacity of stack. */
-        struct yy_buffer_state ** yy_buffer_stack; /**< Stack as an array. */
+        yy_buffer_state ** yy_buffer_stack; /**< Stack as an array. */
         void yyensure_buffer_stack(void);
 
         // The following are not always needed, but may be depending

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -66,8 +66,15 @@ EXTRA_DIST = \
 
 MAINTAINERCLEANFILES = skel.c
 
-skel.c: flex.skl mkskel.sh flexint.h tables_shared.h
-	sed 's/m4_/m4postproc_/g; s/m4preproc_/m4_/g' $(srcdir)/flex.skl | $(m4) -P -DFLEX_MAJOR_VERSION=`echo $(VERSION)|cut -f 1 -d .` -DFLEX_MINOR_VERSION=`echo $(VERSION)|cut -f 2 -d .` -DFLEX_SUBMINOR_VERSION=`echo $(VERSION)|cut -f 3 -d .` | sed 's/m4postproc_/m4_/g' | $(SHELL) $(srcdir)/mkskel.sh  >skel.c
+$(srcdir)/skel.c: flex.skl mkskel.sh flexint.h tables_shared.h
+	sed 's/m4_/m4postproc_/g; s/m4preproc_/m4_/g' $(srcdir)/flex.skl | \
+	  $(m4) -P -I $(srcdir)						   \
+	    -DFLEX_MAJOR_VERSION=`   echo $(VERSION)|cut -f 1 -d .`	   \
+	    -DFLEX_MINOR_VERSION=`   echo $(VERSION)|cut -f 2 -d .`	   \
+	    -DFLEX_SUBMINOR_VERSION=`echo $(VERSION)|cut -f 3 -d .` |	   \
+	  sed 's/m4postproc_/m4_/g' |					   \
+	  $(SHELL) $(srcdir)/mkskel.sh >skel.c.tmp
+	mv skel.c.tmp $(srcdir)/skel.c
 
 # Explicitly describe dependencies.
 # You can recreate this with `gcc -I. -MM *.c'

--- a/src/flex.skl
+++ b/src/flex.skl
@@ -1533,7 +1533,7 @@ do_action:	/* This label is used only to access EOF actions. */
  * This constructor simply maintains backward compatibility.
  * DEPRECATED
  */
-yyFlexLexer::yyFlexLexer( FLEX_STD istream* arg_yyin, FLEX_STD ostream* arg_yyout ):
+yyFlexLexer::yyFlexLexer( std::istream* arg_yyin, std::ostream* arg_yyout ):
 	yyin(arg_yyin ? arg_yyin->rdbuf() : std::cin.rdbuf()),
 	yyout(arg_yyout ? arg_yyout->rdbuf() : std::cout.rdbuf())
 {

--- a/src/main.c
+++ b/src/main.c
@@ -533,7 +533,6 @@ void flexend (int exit_status)
                 "EOB_ACT_END_OF_FILE",
                 "EOB_ACT_LAST_MATCH",
                 "FLEX_SCANNER",
-                "FLEX_STD",
                 "REJECT",
                 "YYFARGS0",
                 "YYFARGS1",


### PR DESCRIPTION
Hi,

The following commits clean up the C++ code.

I have a number of failures of the test suite.  Unrelated to these patches, master fails.  Is this known?  It's mostly `flex_int32_t` errors: it is undefined.