### PR TITLE
Replace copy_unsigned_string() with xstrdup().

### DIFF
--- a/src/flexdef.h
+++ b/src/flexdef.h
@@ -860,9 +860,6 @@ extern unsigned char clower PROTO ((int));
 /* strdup() that fails fatally on allocation failures. */
 extern char *xstrdup(const char *);
 
-/* Returns a dynamically allocated copy of a (potentially) unsigned string. */
-extern unsigned char *copy_unsigned_string PROTO ((unsigned char *));
-
 /* Compare two characters for use by qsort with '\0' sorting last. */
 extern int cclcmp PROTO ((const void *, const void *));
 

--- a/src/misc.c
+++ b/src/misc.c
@@ -251,26 +251,6 @@ char *xstrdup(const char *s)
 }
 
 
-/* copy_unsigned_string -
- *    returns a dynamically allocated copy of a (potentially) unsigned string
- */
-
-unsigned char   *copy_unsigned_string (unsigned char *str)
-{
-	unsigned char *c;
-	unsigned char   *copy;
-
-	/* find length */
-	for (c = str; *c; ++c) ;
-
-	copy = allocate_Character_array (c - str + 1);
-
-	for (c = copy; (*c++ = *str++) != 0;) ;
-
-	return copy;
-}
-
-
 /* cclcmp - compares two characters for use by qsort with '\0' sorting last. */
 
 int cclcmp (const void *a, const void *b)

--- a/src/sym.c
+++ b/src/sym.c
@@ -120,7 +120,7 @@ void    cclinstal (unsigned char ccltxt[], int cclnum)
 	 * called unless the symbol is new.
 	 */
 
-	(void) addsym ((char *) copy_unsigned_string (ccltxt),
+	(void) addsym (xstrdup(ccltxt),
 		       (char *) 0, cclnum, ccltab, CCL_HASH_SIZE);
 }
 
@@ -182,7 +182,7 @@ void    ndinstal (const char *name, unsigned char definition[])
 {
 
 	if (addsym (xstrdup(name),
-		    (char *) copy_unsigned_string (definition), 0,
+		    xstrdup(definition), 0,
 		    ndtbl, NAME_TABLE_HASH_SIZE))
 			synerr (_("name defined twice"));
 }

--- a/to.do/unicode/flexdef.h
+++ b/to.do/unicode/flexdef.h
@@ -841,9 +841,6 @@ extern void check_char PROTO((int c));
 /* Replace upper-case letter to lower-case. */
 extern Char clower PROTO((int));
 
-/* Returns a dynamically allocated copy of a (potentially) unsigned string. */
-extern Char *copy_unsigned_string PROTO((register Char *));
-
 /* Shell sort a character array. */
 extern void cshell PROTO((wchar_t[], int, int));
 

--- a/to.do/unicode/misc.c
+++ b/to.do/unicode/misc.c
@@ -193,29 +193,6 @@ register int c;
 	}
 
 
-/* copy_unsigned_string -
- *    returns a dynamically allocated copy of a (potentially) unsigned string
- */
-
-Char *copy_unsigned_string( str )
-register Char *str;
-	{
-	register Char *c;
-	Char *copy;
-
-	/* find length */
-	for ( c = str; *c; ++c )
-		;
-
-	copy = allocate_Character_array( c - str + 1 );
-
-	for ( c = copy; (*c++ = *str++) != 0; )
-		;
-
-	return copy;
-	}
-
-
 /* cshell - shell sort a character array in increasing order
  *
  * synopsis


### PR DESCRIPTION
Like copy_string(), copy_unsigned_string() is just a clone of the
stlib's strdup(). We only use it twice. I'm pretty confident that char
signedness is irrelevant in this case.