### PR TITLE
Remove allocation casts

### DIFF
--- a/src/dfa.c
+++ b/src/dfa.c
@@ -511,15 +511,13 @@ void ntod (void)
 		 * So we'll have to realloc() on the way...
 		 * we'll wait until we can calculate yynxt_tbl->td_hilen.
 		 */
-		yynxt_tbl =
-			(struct yytbl_data *) calloc (1,
-						      sizeof (struct
-							      yytbl_data));
+		yynxt_tbl = calloc(1, sizeof (struct yytbl_data));
+     
 		yytbl_data_init (yynxt_tbl, YYTD_ID_NXT);
 		yynxt_tbl->td_hilen = 1;
 		yynxt_tbl->td_lolen = num_full_table_rows;
 		yynxt_tbl->td_data = yynxt_data =
-			(flex_int32_t *) calloc (yynxt_tbl->td_lolen *
+			calloc(yynxt_tbl->td_lolen *
 					    yynxt_tbl->td_hilen,
 					    sizeof (flex_int32_t));
 		yynxt_curr = 0;
@@ -703,7 +701,7 @@ void ntod (void)
 			/* Each time we hit here, it's another td_hilen, so we realloc. */
 			yynxt_tbl->td_hilen++;
 			yynxt_tbl->td_data = yynxt_data =
-				(flex_int32_t *) realloc (yynxt_data,
+				realloc (yynxt_data,
 						     yynxt_tbl->td_hilen *
 						     yynxt_tbl->td_lolen *
 						     sizeof (flex_int32_t));

--- a/src/flexdef.h
+++ b/src/flexdef.h
@@ -682,48 +682,46 @@ void   *flex_realloc PROTO ((void *, size_t));
 void flex_free PROTO ((void *));
 
 #define allocate_integer_array(size) \
-	(int *) allocate_array( size, sizeof( int ) )
+	allocate_array(size, sizeof(int))
 
 #define reallocate_integer_array(array,size) \
-	(int *) reallocate_array( (void *) array, size, sizeof( int ) )
+	reallocate_array((void *) array, size, sizeof(int))
 
 #define allocate_bool_array(size) \
-	(bool *) allocate_array( size, sizeof( bool ) )
+	allocate_array(size, sizeof(bool))
 
 #define reallocate_bool_array(array,size) \
-	(bool *) reallocate_array( (void *) array, size, sizeof( bool ) )
+	reallocate_array((void *) array, size, sizeof(bool))
 
 #define allocate_int_ptr_array(size) \
-	(int **) allocate_array( size, sizeof( int * ) )
+	allocate_array(size, sizeof(int *))
 
 #define allocate_char_ptr_array(size) \
-	(char **) allocate_array( size, sizeof( char * ) )
+	allocate_array(size, sizeof(char *))
 
 #define allocate_dfaacc_union(size) \
-	(union dfaacc_union *) \
-		allocate_array( size, sizeof( union dfaacc_union ) )
+	allocate_array(size, sizeof(union dfaacc_union))
 
 #define reallocate_int_ptr_array(array,size) \
-	(int **) reallocate_array( (void *) array, size, sizeof( int * ) )
+	reallocate_array((void *) array, size, sizeof(int *))
 
 #define reallocate_char_ptr_array(array,size) \
-	(char **) reallocate_array( (void *) array, size, sizeof( char * ) )
+	reallocate_array((void *) array, size, sizeof(char *))
 
 #define reallocate_dfaacc_union(array, size) \
-	(union dfaacc_union *) \
-	reallocate_array( (void *) array, size, sizeof( union dfaacc_union ) )
+	reallocate_array((void *) array, size, sizeof(union dfaacc_union))
 
 #define allocate_character_array(size) \
-	(char *) allocate_array( size, sizeof( char ) )
+	allocate_array( size, sizeof(char))
 
 #define reallocate_character_array(array,size) \
-	(char *) reallocate_array( (void *) array, size, sizeof( char ) )
+	reallocate_array((void *) array, size, sizeof(char))
 
 #define allocate_Character_array(size) \
-	(unsigned char *) allocate_array( size, sizeof( unsigned char ) )
+	allocate_array(size, sizeof(unsigned char))
 
 #define reallocate_Character_array(array,size) \
-	(unsigned char *) reallocate_array( (void *) array, size, sizeof( unsigned char ) )
+	reallocate_array((void *) array, size, sizeof(unsigned char))
 
 
 /* Used to communicate between scanner and parser.  The type should really

--- a/src/gen.c
+++ b/src/gen.c
@@ -125,12 +125,12 @@ static struct yytbl_data *mkeoltbl (void)
 	flex_int8_t *tdata = 0;
 	struct yytbl_data *tbl;
 
-	tbl = (struct yytbl_data *) calloc (1, sizeof (struct yytbl_data));
+	tbl = calloc(1, sizeof (struct yytbl_data));
 	yytbl_data_init (tbl, YYTD_ID_RULE_CAN_MATCH_EOL);
 	tbl->td_flags = YYTD_DATA8;
 	tbl->td_lolen = num_rules + 1;
 	tbl->td_data = tdata =
-		(flex_int8_t *) calloc (tbl->td_lolen, sizeof (flex_int8_t));
+		calloc(tbl->td_lolen, sizeof (flex_int8_t));
 
 	for (i = 1; i <= num_rules; i++)
 		tdata[i] = rule_has_nl[i] ? 1 : 0;
@@ -232,14 +232,14 @@ static struct yytbl_data *mkctbl (void)
 		    ((tblend + numecs + 1) >= INT16_MAX
 		     || long_align) ? "flex_int32_t" : "flex_int16_t");
 
-	tbl = (struct yytbl_data *) calloc (1, sizeof (struct yytbl_data));
+	tbl = calloc(1, sizeof (struct yytbl_data));
 	yytbl_data_init (tbl, YYTD_ID_TRANSITION);
 	tbl->td_flags = YYTD_DATA32 | YYTD_STRUCT;
 	tbl->td_hilen = 0;
 	tbl->td_lolen = tblend + numecs + 1;	/* number of structs */
 
 	tbl->td_data = tdata =
-		(flex_int32_t *) calloc (tbl->td_lolen * 2, sizeof (flex_int32_t));
+		calloc(tbl->td_lolen * 2, sizeof (flex_int32_t));
 
 	/* We want the transition to be represented as the offset to the
 	 * next state, not the actual state number, which is what it currently
@@ -328,14 +328,14 @@ static struct yytbl_data *mkssltbl (void)
 	flex_int32_t *tdata = 0;
 	flex_int32_t i;
 
-	tbl = (struct yytbl_data *) calloc (1, sizeof (struct yytbl_data));
+	tbl = calloc(1, sizeof (struct yytbl_data));
 	yytbl_data_init (tbl, YYTD_ID_START_STATE_LIST);
 	tbl->td_flags = YYTD_DATA32 | YYTD_PTRANS;
 	tbl->td_hilen = 0;
 	tbl->td_lolen = lastsc * 2 + 1;
 
 	tbl->td_data = tdata =
-		(flex_int32_t *) calloc (tbl->td_lolen, sizeof (flex_int32_t));
+		calloc(tbl->td_lolen, sizeof (flex_int32_t));
 
 	for (i = 0; i <= lastsc * 2; ++i)
 		tdata[i] = base[i];
@@ -458,14 +458,14 @@ struct yytbl_data *mkecstbl (void)
 	struct yytbl_data *tbl = 0;
 	flex_int32_t *tdata = 0;
 
-	tbl = (struct yytbl_data *) calloc (1, sizeof (struct yytbl_data));
+	tbl = calloc(1, sizeof (struct yytbl_data));
 	yytbl_data_init (tbl, YYTD_ID_EC);
 	tbl->td_flags |= YYTD_DATA32;
 	tbl->td_hilen = 0;
 	tbl->td_lolen = csize;
 
 	tbl->td_data = tdata =
-		(flex_int32_t *) calloc (tbl->td_lolen, sizeof (flex_int32_t));
+		calloc(tbl->td_lolen, sizeof (flex_int32_t));
 
 	for (i = 1; i < csize; ++i) {
 		ecgroup[i] = ABS (ecgroup[i]);
@@ -664,14 +664,14 @@ struct yytbl_data *mkftbl (void)
 	struct yytbl_data *tbl;
 	flex_int32_t *tdata = 0;
 
-	tbl = (struct yytbl_data *) calloc (1, sizeof (struct yytbl_data));
+	tbl = calloc(1, sizeof (struct yytbl_data));
 	yytbl_data_init (tbl, YYTD_ID_ACCEPT);
 	tbl->td_flags |= YYTD_DATA32;
 	tbl->td_hilen = 0;	/* it's a one-dimensional array */
 	tbl->td_lolen = lastdfa + 1;
 
 	tbl->td_data = tdata =
-		(flex_int32_t *) calloc (tbl->td_lolen, sizeof (flex_int32_t));
+		calloc(tbl->td_lolen, sizeof (flex_int32_t));
 
 	dfaacc[end_of_buffer_state].dfaacc_state = end_of_buffer_action;
 
@@ -1111,11 +1111,11 @@ void gentabs (void)
                 "\t{YYTD_ID_ACCLIST, (void**)&yy_acclist, sizeof(%s)},\n",
                 long_align ? "flex_int32_t" : "flex_int16_t");
 
-        yyacclist_tbl = (struct yytbl_data*)calloc(1,sizeof(struct yytbl_data));
+        yyacclist_tbl = calloc(1,sizeof(struct yytbl_data));
         yytbl_data_init (yyacclist_tbl, YYTD_ID_ACCLIST);
         yyacclist_tbl->td_lolen  = MAX(numas,1) + 1;
         yyacclist_tbl->td_data = yyacclist_data = 
-            (flex_int32_t *) calloc (yyacclist_tbl->td_lolen, sizeof (flex_int32_t));
+            calloc(yyacclist_tbl->td_lolen, sizeof (flex_int32_t));
         yyacclist_curr = 1;
 
 		j = 1;		/* index into "yy_acclist" array */
@@ -1220,13 +1220,11 @@ void gentabs (void)
 		    "\t{YYTD_ID_ACCEPT, (void**)&yy_accept, sizeof(%s)},\n",
 		    long_align ? "flex_int32_t" : "flex_int16_t");
 
-	yyacc_tbl =
-		(struct yytbl_data *) calloc (1,
-					      sizeof (struct yytbl_data));
+	yyacc_tbl = calloc(1, sizeof (struct yytbl_data));
 	yytbl_data_init (yyacc_tbl, YYTD_ID_ACCEPT);
 	yyacc_tbl->td_lolen = k;
 	yyacc_tbl->td_data = yyacc_data =
-		(flex_int32_t *) calloc (yyacc_tbl->td_lolen, sizeof (flex_int32_t));
+		calloc(yyacc_tbl->td_lolen, sizeof (flex_int32_t));
     yyacc_curr=1;
 
 	for (i = 1; i <= lastdfa; ++i) {
@@ -1279,14 +1277,11 @@ void gentabs (void)
 		 * templates with).
 		 */
 		flex_int32_t *yymecs_data = 0;
-		yymeta_tbl =
-			(struct yytbl_data *) calloc (1,
-						      sizeof (struct
-							      yytbl_data));
+		yymeta_tbl = calloc(1, sizeof (struct yytbl_data));
 		yytbl_data_init (yymeta_tbl, YYTD_ID_META);
 		yymeta_tbl->td_lolen = numecs + 1;
 		yymeta_tbl->td_data = yymecs_data =
-			(flex_int32_t *) calloc (yymeta_tbl->td_lolen,
+			calloc(yymeta_tbl->td_lolen,
 					    sizeof (flex_int32_t));
 
 		if (trace)
@@ -1330,13 +1325,11 @@ void gentabs (void)
 		    "\t{YYTD_ID_BASE, (void**)&yy_base, sizeof(%s)},\n",
 		    (tblend >= INT16_MAX
 		     || long_align) ? "flex_uint32_t" : "flex_uint16_t");
-	yybase_tbl =
-		(struct yytbl_data *) calloc (1,
-					      sizeof (struct yytbl_data));
+	yybase_tbl = calloc (1, sizeof (struct yytbl_data));
 	yytbl_data_init (yybase_tbl, YYTD_ID_BASE);
 	yybase_tbl->td_lolen = total_states + 1;
 	yybase_tbl->td_data = yybase_data =
-		(flex_int32_t *) calloc (yybase_tbl->td_lolen,
+		calloc(yybase_tbl->td_lolen,
 				    sizeof (flex_int32_t));
 	yybase_curr = 1;
 
@@ -1390,13 +1383,11 @@ void gentabs (void)
 		    (total_states >= INT16_MAX
 		     || long_align) ? "flex_int32_t" : "flex_int16_t");
 
-	yydef_tbl =
-		(struct yytbl_data *) calloc (1,
-					      sizeof (struct yytbl_data));
+	yydef_tbl = calloc(1, sizeof (struct yytbl_data));
 	yytbl_data_init (yydef_tbl, YYTD_ID_DEF);
 	yydef_tbl->td_lolen = total_states + 1;
 	yydef_tbl->td_data = yydef_data =
-		(flex_int32_t *) calloc (yydef_tbl->td_lolen, sizeof (flex_int32_t));
+		calloc(yydef_tbl->td_lolen, sizeof (flex_int32_t));
 
 	for (i = 1; i <= total_states; ++i) {
 		mkdata (def[i]);
@@ -1424,13 +1415,11 @@ void gentabs (void)
 		    (total_states >= INT16_MAX
 		     || long_align) ? "flex_uint32_t" : "flex_uint16_t");
 
-	yynxt_tbl =
-		(struct yytbl_data *) calloc (1,
-					      sizeof (struct yytbl_data));
+	yynxt_tbl = calloc (1, sizeof (struct yytbl_data));
 	yytbl_data_init (yynxt_tbl, YYTD_ID_NXT);
 	yynxt_tbl->td_lolen = tblend + 1;
 	yynxt_tbl->td_data = yynxt_data =
-		(flex_int32_t *) calloc (yynxt_tbl->td_lolen, sizeof (flex_int32_t));
+		calloc (yynxt_tbl->td_lolen, sizeof (flex_int32_t));
 
 	for (i = 1; i <= tblend; ++i) {
 		/* Note, the order of the following test is important.
@@ -1463,13 +1452,11 @@ void gentabs (void)
 		    (total_states >= INT16_MAX
 		     || long_align) ? "flex_int32_t" : "flex_int16_t");
 
-	yychk_tbl =
-		(struct yytbl_data *) calloc (1,
-					      sizeof (struct yytbl_data));
+	yychk_tbl = calloc (1, sizeof (struct yytbl_data));
 	yytbl_data_init (yychk_tbl, YYTD_ID_CHK);
 	yychk_tbl->td_lolen = tblend + 1;
 	yychk_tbl->td_data = yychk_data =
-		(flex_int32_t *) calloc (yychk_tbl->td_lolen, sizeof (flex_int32_t));
+		calloc(yychk_tbl->td_lolen, sizeof (flex_int32_t));
 
 	for (i = 1; i <= tblend; ++i) {
 		if (chk[i] == 0)
@@ -1722,16 +1709,13 @@ void make_tables (void)
 			    (fullspd) ? "struct yy_trans_info*" :
 			    "flex_int32_t");
 
-		yynultrans_tbl =
-			(struct yytbl_data *) calloc (1,
-						      sizeof (struct
-							      yytbl_data));
+		yynultrans_tbl = calloc(1, sizeof (struct yytbl_data));
 		yytbl_data_init (yynultrans_tbl, YYTD_ID_NUL_TRANS);
 		if (fullspd)
 			yynultrans_tbl->td_flags |= YYTD_PTRANS;
 		yynultrans_tbl->td_lolen = lastdfa + 1;
 		yynultrans_tbl->td_data = yynultrans_data =
-			(flex_int32_t *) calloc (yynultrans_tbl->td_lolen,
+			calloc(yynultrans_tbl->td_lolen,
 					    sizeof (flex_int32_t));
 
 		for (i = 1; i <= lastdfa; ++i) {

--- a/src/main.c
+++ b/src/main.c
@@ -392,7 +392,7 @@ void check_options (void)
 
 		if (!tablesfilename) {
 			nbytes = strlen (prefix) + strlen (tablesfile_template) + 2;
-			tablesfilename = pname = (char *) calloc (nbytes, 1);
+			tablesfilename = pname = calloc(nbytes, 1);
 			snprintf (pname, nbytes, tablesfile_template, prefix);
 		}
 
@@ -405,7 +405,7 @@ void check_options (void)
 		yytbl_writer_init (&tableswr, tablesout);
 
 		nbytes = strlen (prefix) + strlen ("tables") + 2;
-		tablesname = (char *) calloc (nbytes, 1);
+		tablesname = calloc(nbytes, 1);
 		snprintf (tablesname, nbytes, "%stables", prefix);
 		yytbl_hdr_init (&hdr, flex_version, tablesname);
 

--- a/src/scan.l
+++ b/src/scan.l
@@ -1015,12 +1015,12 @@ void set_input_file( char *file )
 
 void *flex_alloc( size_t size )
 	{
-	return (void *) malloc( size );
+	return malloc(size);
 	}
 
 void *flex_realloc( void *ptr, size_t size )
 	{
-	return (void *) realloc( ptr, size );
+	return realloc(ptr, size);
 	}
 
 void flex_free( void *ptr )

--- a/src/scanopt.c
+++ b/src/scanopt.c
@@ -151,7 +151,7 @@ scanopt_t *scanopt_init (const optspec_t *options, int argc, char **argv, int fl
 {
 	int     i;
 	struct _scanopt_t *s;
-	s = (struct _scanopt_t *) malloc (sizeof (struct _scanopt_t));
+	s = malloc(sizeof (struct _scanopt_t));
 
 	s->options = options;
 	s->optc = 0;
@@ -170,7 +170,7 @@ scanopt_t *scanopt_init (const optspec_t *options, int argc, char **argv, int fl
 		s->optc++;
 
 	/* Build auxiliary data */
-	s->aux = (struct _aux *) malloc (s->optc * sizeof (struct _aux));
+	s->aux = malloc(s->optc * sizeof (struct _aux));
 
 	for (i = 0; i < s->optc; i++) {
 		const unsigned char *p, *pname;
@@ -274,7 +274,7 @@ int     scanopt_usage (scanopt_t *scanner, FILE *fp, const char *usage)
 	fprintf (fp, "\n");
 
 	/* Sort by r_val and string. Yes, this is O(n*n), but n is small. */
-	store = (usg_elem *) malloc (s->optc * sizeof (usg_elem));
+	store = malloc(s->optc * sizeof (usg_elem));
 	for (i = 0; i < s->optc; i++) {
 
 		/* grab the next preallocate node. */

--- a/tests/bison_nr_scanner.l
+++ b/tests/bison_nr_scanner.l
@@ -56,7 +56,7 @@ static char* STRDUP(char* s1);
 
 static char* STRDUP(char* s1)
 {
-    char* s2 = (char*)malloc(strlen(s1)+1);
+    char* s2 = malloc(strlen(s1)+1);
     sprintf(s2,"%s",s1);
     return s2;
 }

--- a/tests/bison_yylloc_scanner.l
+++ b/tests/bison_yylloc_scanner.l
@@ -59,7 +59,7 @@ static char* STRDUP(char* s1);
 
 static char* STRDUP(char* s1)
 {
-    char* s2 = (char*)malloc(strlen(s1)+1);
+    char* s2 = malloc(strlen(s1)+1);
     sprintf(s2,"%s",s1);
     return s2;
 }

--- a/tests/bison_yylval_scanner.l
+++ b/tests/bison_yylval_scanner.l
@@ -75,7 +75,7 @@ enum yesno_t { no=0, yes=1 };
 
 static char* STRDUP(char* s1)
 {
-    char* s2 = (char*)malloc(strlen(s1)+1);
+    char* s2 = malloc(strlen(s1)+1);
     sprintf(s2,"%s",s1);
     return s2;
 }

--- a/tests/mem_nr.l
+++ b/tests/mem_nr.l
@@ -91,12 +91,12 @@ void * yyalloc(yy_size_t n)
     int i;
 
     total_mem += n;
-    p = (void*)malloc(n);
+    p = malloc(n);
 
     if( nptrs >= arrsz){
         /* increase array size by 1 */
         arrsz++;
-        ptrs = (struct memsz*)realloc( ptrs, arrsz * sizeof(struct memsz));
+        ptrs = realloc(ptrs, arrsz * sizeof(struct memsz));
         ptrs[nptrs].p = 0;
         ptrs[nptrs].sz = 0;
     }
@@ -121,7 +121,7 @@ void * yyrealloc(void* p, yy_size_t n)
         if ( ptrs[i].p == p){
             total_mem -= ptrs[i].sz;
             total_mem += n;
-            ptrs[i].p = (void*)realloc(p,n);
+            ptrs[i].p = realloc(p,n);
             ptrs[i].sz = n;
 
             printf("yyflex_realloc(%#10lx,%8ld) total=%8ld return=%8lx\n",
@@ -161,7 +161,7 @@ int
 main ()
 {
     arrsz = 1;
-    ptrs  = (struct memsz*)calloc(1,sizeof(struct memsz));
+    ptrs  = calloc(1, sizeof(struct memsz));
     nptrs = 0;
 
     yyin = stdin;

--- a/tests/mem_r.l
+++ b/tests/mem_r.l
@@ -93,12 +93,12 @@ void * yyalloc(yy_size_t n , void* yyscanner)
     int i;
 
     total_mem += n;
-    p = (void*)malloc(n);
+    p = malloc(n);
 
     if( nptrs >= arrsz){
         /* increase array size by 1 */
         arrsz++;
-        ptrs = (struct memsz*)realloc( ptrs, arrsz * sizeof(struct memsz));
+        ptrs = realloc(ptrs, arrsz * sizeof(struct memsz));
         ptrs[nptrs].p = 0;
         ptrs[nptrs].sz = 0;
     }
@@ -125,7 +125,7 @@ void * yyrealloc(void* p, yy_size_t n , void* yyscanner)
         if ( ptrs[i].p == p){
             total_mem -= ptrs[i].sz;
             total_mem += n;
-            ptrs[i].p = (void*)realloc(p,n);
+            ptrs[i].p = realloc(p, n);
             ptrs[i].sz = n;
 
             printf("yyflex_realloc(%#10lx,%8ld) total=%8ld return=%8lx\n",
@@ -168,7 +168,7 @@ main ()
 {
     yyscan_t scanner;
     arrsz = 1;
-    ptrs  = (struct memsz*)calloc(1,sizeof(struct memsz));
+    ptrs  = calloc(1, sizeof(struct memsz));
     nptrs = 0;
 
     yylex_init(&scanner);

--- a/tests/pthread.l
+++ b/tests/pthread.l
@@ -167,7 +167,7 @@ int main (int ARGC, char *ARGV[])
     }
 
     /* Allocate and initialize the locks. One for each filename in ARGV. */
-    file_locks = (pthread_mutex_t*)malloc( (ARGC-1) * sizeof(pthread_mutex_t));
+    file_locks = malloc((ARGC-1) * sizeof(pthread_mutex_t));
     for( i = 0; i < ARGC-1; i++)
         pthread_mutex_init( &file_locks[i], NULL );
 

--- a/tests/string_nr.l
+++ b/tests/string_nr.l
@@ -82,7 +82,7 @@ main ()
        We make a copy, since the buffer will be modified by flex.*/
     printf("Testing: yy_scan_buffer(%s): ",INPUT_STRING_1); fflush(stdout);
     len = strlen(INPUT_STRING_1) + 2;
-    buf = (char*)malloc( len );
+    buf = malloc(len);
     strcpy( buf, INPUT_STRING_1);
     buf[ len -2 ]  = 0; /* Flex requires two NUL bytes at end of buffer. */
     buf[ len -1 ] =0;

--- a/tests/string_r.l
+++ b/tests/string_r.l
@@ -87,7 +87,7 @@ main ()
        We make a copy, since the buffer will be modified by flex.*/
     printf("Testing: yy_scan_buffer(%s): ",INPUT_STRING_1); fflush(stdout);
     len = strlen(INPUT_STRING_1) + 2;
-    buf = (char*)malloc( len );
+    buf = (malloc(len);
     strcpy( buf, INPUT_STRING_1);
     buf[ len -2 ]  = 0; /* Flex requires two NUL bytes at end of buffer. */
     buf[ len -1 ] =0;

--- a/tests/yyextra.l
+++ b/tests/yyextra.l
@@ -68,11 +68,11 @@ main ()
     struct Buffer * buf;
     int i;
 
-    buf = (struct Buffer*) malloc(sizeof(struct Buffer));
+    buf = malloc(sizeof(struct Buffer));
     buf->curr_len =0;
     buf->max_len = 4; 
     buf->grow_len = 100;
-    buf->data = (char*)malloc(buf->max_len);
+    buf->data = malloc(buf->max_len);
  
     testlex_init(&scanner);
     testset_in( stdin, scanner);
@@ -100,10 +100,10 @@ static void append_char (char c,  yyscan_t  scanner )
 
     if( buf->curr_len >= buf->max_len )
     {
-        new_buf = (struct Buffer*) malloc(sizeof(struct Buffer));
+        new_buf = malloc(sizeof(struct Buffer));
         new_buf->max_len = buf->max_len + buf->grow_len;
         new_buf->grow_len = buf->grow_len;
-        new_buf->data = (char*)malloc(new_buf->max_len);
+        new_buf->data = malloc(new_buf->max_len);
         for( new_buf->curr_len = 0;
              new_buf->curr_len < buf->curr_len;
              new_buf->curr_len++ )

--- a/to.do/unicode/scan.l
+++ b/to.do/unicode/scan.l
@@ -692,14 +692,14 @@ char *file;
 void *flex_alloc( size )
 size_t size;
 	{
-	return (void *) malloc( size );
+	return malloc(size);
 	}
 
 void *flex_realloc( ptr, size )
 void *ptr;
 size_t size;
 	{
-	return (void *) realloc( ptr, size );
+	return realloc(ptr, size);
 	}
 
 void flex_free( ptr )


### PR DESCRIPTION
These casts were necessary decades ago, but no more.

There's a lot more to do, but this diff is big enough as-is.