### PR TITLE
Remove needless aliases for stdlib allocation functions

### DIFF
--- a/src/buf.c
+++ b/src/buf.c
@@ -73,7 +73,8 @@ struct Buf *buf_prints (struct Buf *buf, const char *fmt, const char *s)
 	char   *t;
         size_t tsz;
 
-	t = flex_alloc (tsz = strlen (fmt) + strlen (s) + 1);
+	tsz = strlen(fmt) + strlen(s) + 1;
+	t = malloc(tsz);
 	if (!t)
 	    flexfatal (_("Allocation of buffer to print string failed"));
 	snprintf (t, tsz, fmt, s);
@@ -93,7 +94,7 @@ struct Buf *buf_linedir (struct Buf *buf, const char* filename, int lineno)
     char *dst, *t;
     const char *src;
 
-    t = flex_alloc (strlen ("#line \"\"\n")          +   /* constant parts */
+    t = malloc(strlen("#line \"\"\n")          +   /* constant parts */
                     2 * strlen (filename)            +   /* filename with possibly all backslashes escaped */
                     (int) (1 + log10 (abs (lineno))) +   /* line number */
                     1);                                  /* NUL */
@@ -165,7 +166,8 @@ struct Buf *buf_m4_define (struct Buf *buf, const char* def, const char* val)
     size_t strsz;
 
     val = val?val:"";
-    str = (char*)flex_alloc(strsz = strlen(fmt) + strlen(def) + strlen(val) + 2);
+    strsz = strlen(fmt) + strlen(def) + strlen(val) + 2;
+    str = malloc(strsz);
     if (!str)
         flexfatal (_("Allocation of buffer for m4 def failed"));
 
@@ -185,7 +187,8 @@ struct Buf *buf_m4_undefine (struct Buf *buf, const char* def)
     char * str;
     size_t strsz;
 
-    str = (char*)flex_alloc(strsz = strlen(fmt) + strlen(def) + 2);
+    strsz = strlen(fmt) + strlen(def) + 2;
+    str = malloc(strsz);
     if (!str)
         flexfatal (_("Allocation of buffer for m4 undef failed"));
 

--- a/src/buf.c
+++ b/src/buf.c
@@ -79,7 +79,7 @@ struct Buf *buf_prints (struct Buf *buf, const char *fmt, const char *s)
 	    flexfatal (_("Allocation of buffer to print string failed"));
 	snprintf (t, tsz, fmt, s);
 	buf = buf_strappend (buf, t);
-	flex_free (t);
+	free(t);
 	return buf;
 }
 
@@ -107,7 +107,7 @@ struct Buf *buf_linedir (struct Buf *buf, const char* filename, int lineno)
     *dst++ = '\n';
     *dst   = '\0';
     buf = buf_strappend (buf, t);
-    flex_free (t);
+    free(t);
     return buf;
 }
 
@@ -209,9 +209,10 @@ void buf_init (struct Buf *buf, size_t elem_size)
 /* frees memory */
 void buf_destroy (struct Buf *buf)
 {
-	if (buf && buf->elts)
-		flex_free (buf->elts);
-	buf->elts = NULL;
+	if (buf) {
+		free(buf->elts);
+		buf->elts = NULL;
+	}
 }
 
 

--- a/src/dfa.c
+++ b/src/dfa.c
@@ -793,8 +793,8 @@ void ntod (void)
 		mkdeftbl ();
 	}
 
-	flex_free ((void *) accset);
-	flex_free ((void *) nset);
+	free(accset);
+	free(nset);
 }
 
 

--- a/src/filter.c
+++ b/src/filter.c
@@ -47,9 +47,9 @@ struct filter *filter_create_ext (struct filter *chain, const char *cmd,
 	va_list ap;
 
 	/* allocate and initialize new filter */
-	f = (struct filter *) flex_alloc (sizeof (struct filter));
+	f = malloc(sizeof(struct filter));
 	if (!f)
-		flexerror (_("flex_alloc failed (f) in filter_create_ext"));
+		flexerror(_("malloc failed (f) in filter_create_ext"));
 	memset (f, 0, sizeof (*f));
 	f->filter_func = NULL;
 	f->extra = NULL;
@@ -66,11 +66,9 @@ struct filter *filter_create_ext (struct filter *chain, const char *cmd,
 
 	/* allocate argv, and populate it with the argument list. */
 	max_args = 8;
-	f->argv =
-		(const char **) flex_alloc (sizeof (char *) *
-					    (max_args + 1));
+	f->argv = malloc(sizeof(char *) * (max_args + 1));
 	if (!f->argv)
-		flexerror (_("flex_alloc failed (f->argv) in filter_create_ext"));
+		flexerror(_("malloc failed (f->argv) in filter_create_ext"));
 	f->argv[f->argc++] = cmd;
 
 	va_start (ap, cmd);
@@ -107,9 +105,9 @@ struct filter *filter_create_int (struct filter *chain,
 	struct filter *f;
 
 	/* allocate and initialize new filter */
-	f = (struct filter *) flex_alloc (sizeof (struct filter));
+	f = malloc(sizeof(struct filter));
 	if (!f)
-		flexerror (_("flex_alloc failed in filter_create_int"));
+		flexerror(_("malloc failed in filter_create_int"));
 	memset (f, 0, sizeof (*f));
 	f->next = NULL;
 	f->argc = 0;
@@ -288,9 +286,9 @@ int filter_tee_header (struct filter *chain)
 	fprintf (to_c, "m4_define( [[M4_YY_OUTFILE_NAME]],[[%s]])m4_dnl\n",
 		 outfilename ? outfilename : "<stdout>");
 
-	buf = (char *) flex_alloc (readsz);
+	buf = malloc(readsz);
 	if (!buf)
-		flexerror (_("flex_alloc failed in filter_tee_header"));
+		flexerror(_("malloc failed in filter_tee_header"));
 	while (fgets (buf, readsz, stdin)) {
 		fputs (buf, to_c);
 		if (write_header)
@@ -349,9 +347,9 @@ int filter_fix_linedirs (struct filter *chain)
 	if (!chain)
 		return 0;
 
-	buf = (char *) flex_alloc (readsz);
+	buf = malloc(readsz);
 	if (!buf)
-		flexerror (_("flex_alloc failed in filter_fix_linedirs"));
+		flexerror(_("malloc failed in filter_fix_linedirs"));
 
 	while (fgets (buf, readsz, stdin)) {
 

--- a/src/filter.c
+++ b/src/filter.c
@@ -75,12 +75,7 @@ struct filter *filter_create_ext (struct filter *chain, const char *cmd,
 	while ((s = va_arg (ap, const char *)) != NULL) {
 		if (f->argc >= max_args) {
 			max_args += 8;
-			f->argv =
-				(const char **) flex_realloc (f->argv,
-							      sizeof (char
-								      *) *
-							      (max_args +
-							       1));
+			f->argv = realloc(f->argv, sizeof(char*) * (max_args + 1));
 		}
 		f->argv[f->argc++] = s;
 	}

--- a/src/flexdef.h
+++ b/src/flexdef.h
@@ -677,8 +677,6 @@ extern int num_backing_up, bol_needed;
 void   *allocate_array PROTO ((int, size_t));
 void   *reallocate_array PROTO ((void *, int, size_t));
 
-void flex_free PROTO ((void *));
-
 #define allocate_integer_array(size) \
 	allocate_array(size, sizeof(int))
 

--- a/src/flexdef.h
+++ b/src/flexdef.h
@@ -677,7 +677,6 @@ extern int num_backing_up, bol_needed;
 void   *allocate_array PROTO ((int, size_t));
 void   *reallocate_array PROTO ((void *, int, size_t));
 
-void   *flex_alloc PROTO ((size_t));
 void   *flex_realloc PROTO ((void *, size_t));
 void flex_free PROTO ((void *));
 

--- a/src/flexdef.h
+++ b/src/flexdef.h
@@ -677,7 +677,6 @@ extern int num_backing_up, bol_needed;
 void   *allocate_array PROTO ((int, size_t));
 void   *reallocate_array PROTO ((void *, int, size_t));
 
-void   *flex_realloc PROTO ((void *, size_t));
 void flex_free PROTO ((void *));
 
 #define allocate_integer_array(size) \

--- a/src/gen.c
+++ b/src/gen.c
@@ -1476,7 +1476,7 @@ void gentabs (void)
 	}
 	/* End generating yy_chk */
 
-	flex_free ((void *) acc_array);
+	free(acc_array);
 }
 
 

--- a/src/main.c
+++ b/src/main.c
@@ -448,7 +448,8 @@ void check_options (void)
              char *str, *fmt = "#define %s %d\n";
              size_t strsz;
 
-             str = (char*)flex_alloc(strsz = strlen(fmt) + strlen(scname[i]) + (int)(1 + log10(i)) + 2);
+             strsz = strlen(fmt) + strlen(scname[i]) + (int)(1 + log10(i)) + 2;
+             str = malloc(strsz);
              if (!str)
                flexfatal(_("allocation of macro definition failed"));
              snprintf(str, strsz, fmt,      scname[i], i - 1);

--- a/src/misc.c
+++ b/src/misc.c
@@ -60,7 +60,7 @@ static void sko_push(bool dc)
 {
     if(!sko_stack){
         sko_sz = 1;
-        sko_stack = (struct sko_state*)flex_alloc(sizeof(struct sko_state)*sko_sz);
+        sko_stack = malloc(sizeof(struct sko_state) * sko_sz);
         if (!sko_stack)
             flexfatal(_("allocation of sko_stack failed"));
         sko_len = 0;
@@ -168,7 +168,7 @@ void   *allocate_array (int size, size_t element_size)
 	void *mem;
 	size_t  num_bytes = element_size * size;
 
-	mem = flex_alloc (num_bytes);
+	mem = malloc(num_bytes);
 	if (!mem)
 		flexfatal (_
 			   ("memory allocation failed in allocate_array()"));
@@ -889,11 +889,14 @@ void transition_struct_out (element_v, element_n)
 
 /* The following is only needed when building flex's parser using certain
  * broken versions of bison.
+ *
+ * XXX: this is should go soon
  */
 void   *yy_flex_xmalloc (int size)
 {
-	void   *result = flex_alloc ((size_t) size);
+	void   *result;
 
+	result = malloc(size);
 	if (!result)
 		flexfatal (_
 			   ("memory allocation failed in yy_flex_xmalloc()"));

--- a/src/misc.c
+++ b/src/misc.c
@@ -67,7 +67,8 @@ static void sko_push(bool dc)
     }
     if(sko_len >= sko_sz){
         sko_sz *= 2;
-        sko_stack = (struct sko_state*)flex_realloc(sko_stack,sizeof(struct sko_state)*sko_sz);
+        sko_stack = realloc(sko_stack,
+			sizeof(struct sko_state) * sko_sz);
     }
     
     /* initialize to zero and push */
@@ -719,7 +720,7 @@ void   *reallocate_array (void *array, int size, size_t element_size)
 	void *new_array;
 	size_t  num_bytes = element_size * size;
 
-	new_array = flex_realloc (array, num_bytes);
+	new_array = realloc(array, num_bytes);
 	if (!new_array)
 		flexfatal (_("attempt to increase array size failed"));
 

--- a/src/regex.c
+++ b/src/regex.c
@@ -57,10 +57,10 @@ void flex_regcomp(regex_t *preg, const char *regex, int cflags)
         const int errbuf_sz = 200;
         char *errbuf, *rxerr;
 
-		errbuf = (char*)flex_alloc(errbuf_sz *sizeof(char));
+		errbuf = malloc(errbuf_sz * sizeof(char));
 		if (!errbuf)
 			flexfatal(_("Unable to allocate buffer to report regcomp"));
-		rxerr = (char*)flex_alloc(errbuf_sz *sizeof(char));
+		rxerr = malloc(errbuf_sz * sizeof(char));
 		if (!rxerr)
 			flexfatal(_("Unable to allocate buffer for regerror"));
 		regerror (err, preg, rxerr, errbuf_sz);
@@ -85,7 +85,7 @@ char   *regmatch_dup (regmatch_t * m, const char *src)
 	if (m == NULL || m->rm_so < 0)
 		return NULL;
 	len = m->rm_eo - m->rm_so;
-	str = (char *) flex_alloc ((len + 1) * sizeof (char));
+	str = malloc((len + 1) * sizeof(char));
 	if (!str)
 		flexfatal(_("Unable to allocate a copy of the match"));
 	strncpy (str, src + m->rm_so, len);

--- a/src/scan.l
+++ b/src/scan.l
@@ -1013,11 +1013,6 @@ void set_input_file( char *file )
 
 /* Wrapper routines for accessing the scanner's malloc routines. */
 
-void *flex_realloc( void *ptr, size_t size )
-	{
-	return realloc(ptr, size);
-	}
-
 void flex_free( void *ptr )
 	{
 	if ( ptr )

--- a/src/scan.l
+++ b/src/scan.l
@@ -1013,11 +1013,6 @@ void set_input_file( char *file )
 
 /* Wrapper routines for accessing the scanner's malloc routines. */
 
-void *flex_alloc( size_t size )
-	{
-	return malloc(size);
-	}
-
 void *flex_realloc( void *ptr, size_t size )
 	{
 	return realloc(ptr, size);

--- a/src/scan.l
+++ b/src/scan.l
@@ -231,7 +231,7 @@ M4QEND      "]]"
 	[[:digit:]]+	linenum = myctoi( yytext );
 
 	\"[^"\n]*\"	{
-			flex_free( (void *) infilename );
+			free(infilename);
 			infilename = xstrdup(yytext + 1);
 			infilename[strlen( infilename ) - 1] = '\0';
 			}
@@ -1008,13 +1008,4 @@ void set_input_file( char *file )
 		}
 
 	linenum = 1;
-	}
-
-
-/* Wrapper routines for accessing the scanner's malloc routines. */
-
-void flex_free( void *ptr )
-	{
-	if ( ptr )
-		free( ptr );
 	}

--- a/src/scanflags.c
+++ b/src/scanflags.c
@@ -59,7 +59,8 @@ void
 sf_init (void)
 {
     assert(_sf_stk == NULL);
-    _sf_stk = (scanflags_t*) flex_alloc ( sizeof(scanflags_t) * (_sf_max = 32));
+    _sf_max = 32;
+    _sf_stk = malloc(sizeof(scanflags_t) * _sf_max);
     if (!_sf_stk)
         lerr_fatal(_("Unable to allocate %zu of stack"), sizeof(scanflags_t));
     _sf_stk[_sf_top_ix] = 0;

--- a/src/scanflags.c
+++ b/src/scanflags.c
@@ -40,7 +40,8 @@ void
 sf_push (void)
 {
     if (_sf_top_ix + 1 >= _sf_max)
-        _sf_stk = (scanflags_t*) flex_realloc ( (void*) _sf_stk, sizeof(scanflags_t) * (_sf_max += 32));
+        _sf_max += 32;
+        _sf_stk = realloc(_sf_stk, sizeof(scanflags_t) * _sf_max);
 
     // copy the top element
     _sf_stk[_sf_top_ix + 1] = _sf_stk[_sf_top_ix];

--- a/src/sym.c
+++ b/src/sym.c
@@ -88,8 +88,7 @@ static int addsym (char sym[], char *str_def, int int_def, hash_table table, int
 	}
 
 	/* create new entry */
-	new_entry = (struct hash_entry *)
-		flex_alloc (sizeof (struct hash_entry));
+	new_entry = malloc(sizeof(struct hash_entry));
 
 	if (new_entry == NULL)
 		flexfatal (_("symbol table memory allocation failed"));

--- a/to.do/unicode/flexdef.h
+++ b/to.do/unicode/flexdef.h
@@ -663,7 +663,6 @@ extern int num_backing_up, bol_needed;
 void *allocate_array PROTO((int, size_t));
 void *reallocate_array PROTO((void*, int, size_t));
 
-void *flex_realloc PROTO((void*, size_t));
 void flex_free PROTO((void*));
 
 #define allocate_integer_array(size) \

--- a/to.do/unicode/flexdef.h
+++ b/to.do/unicode/flexdef.h
@@ -663,8 +663,6 @@ extern int num_backing_up, bol_needed;
 void *allocate_array PROTO((int, size_t));
 void *reallocate_array PROTO((void*, int, size_t));
 
-void flex_free PROTO((void*));
-
 #define allocate_integer_array(size) \
 	(int *) allocate_array( size, sizeof( int ) )
 

--- a/to.do/unicode/flexdef.h
+++ b/to.do/unicode/flexdef.h
@@ -663,7 +663,6 @@ extern int num_backing_up, bol_needed;
 void *allocate_array PROTO((int, size_t));
 void *reallocate_array PROTO((void*, int, size_t));
 
-void *flex_alloc PROTO((size_t));
 void *flex_realloc PROTO((void*, size_t));
 void flex_free PROTO((void*));
 

--- a/to.do/unicode/misc.c
+++ b/to.do/unicode/misc.c
@@ -85,7 +85,7 @@ size_t element_size;
 	register void *mem;
 	size_t num_bytes = element_size * size;
 
-	mem = flex_alloc( num_bytes );
+	mem = malloc(num_bytes);
 	if ( ! mem )
 		flexfatal(
 			_( "memory allocation failed in allocate_array()" ) );
@@ -815,8 +815,9 @@ int element_v, element_n;
 void *yy_flex_xmalloc( size )
 int size;
 	{
-	void *result = flex_alloc( (size_t) size );
+	void *result;
 
+	result = malloc(size);
 	if ( ! result  )
 		flexfatal(
 			_( "memory allocation failed in yy_flex_xmalloc()" ) );

--- a/to.do/unicode/misc.c
+++ b/to.do/unicode/misc.c
@@ -718,7 +718,7 @@ size_t element_size;
 	register void *new_array;
 	size_t num_bytes = element_size * size;
 
-	new_array = flex_realloc( array, num_bytes );
+	new_array = realloc(array, num_bytes);
 	if ( ! new_array )
 		flexfatal( _( "attempt to increase array size failed" ) );
 

--- a/to.do/unicode/scan.l
+++ b/to.do/unicode/scan.l
@@ -159,7 +159,7 @@ LEXOPT		[aceknopr]
 	[[:digit:]]+	linenum = myctoi( yytext );
 
 	\"[^"\n]*\"	{
-			flex_free( (void *) infilename );
+			free(infilename);
 			infilename = xstrdup(yytext + 1);
 			infilename[strlen( infilename ) - 1] = '\0';
 			}
@@ -684,14 +684,4 @@ char *file;
 		}
 
 	linenum = 1;
-	}
-
-
-/* Wrapper routines for accessing the scanner's malloc routines. */
-
-void flex_free( ptr )
-void *ptr;
-	{
-	if ( ptr )
-		free( ptr );
 	}

--- a/to.do/unicode/scan.l
+++ b/to.do/unicode/scan.l
@@ -689,13 +689,6 @@ char *file;
 
 /* Wrapper routines for accessing the scanner's malloc routines. */
 
-void *flex_realloc( ptr, size )
-void *ptr;
-size_t size;
-	{
-	return realloc(ptr, size);
-	}
-
 void flex_free( ptr )
 void *ptr;
 	{

--- a/to.do/unicode/scan.l
+++ b/to.do/unicode/scan.l
@@ -689,12 +689,6 @@ char *file;
 
 /* Wrapper routines for accessing the scanner's malloc routines. */
 
-void *flex_alloc( size )
-size_t size;
-	{
-	return malloc(size);
-	}
-
 void *flex_realloc( ptr, size )
 void *ptr;
 size_t size;


### PR DESCRIPTION
See the commit messages for more details. There's one commit for each of:

* `flex_alloc()`
* `flex_realloc()`
* `flex_free()`