### PR TITLE
Remove alloca() configuration

### DIFF
--- a/src/flexdef.h
+++ b/src/flexdef.h
@@ -39,21 +39,6 @@
 #include <config.h>
 #endif
 
-/* AIX requires this to be the first thing in the file.  */
-#if !defined(__GNUC__) && !defined(__lint__)
-# if HAVE_ALLOCA_H
-#  include <alloca.h>
-# else
-#  ifdef _AIX
- #pragma alloca
-#  else
-#   ifndef alloca /* predefined by HP cc +Olibcalls */
-char *alloca ();
-#   endif
-#  endif
-# endif
-#endif
-
 #ifdef STDC_HEADERS
 #include <stdio.h>
 #include <stdlib.h>


### PR DESCRIPTION
alloca() is deprecated and dangerous. Unless I'm missing something, we
should never be using it.