### PR TITLE
Replace zero_out() with the stdlib's memset

### DIFF
--- a/src/flexdef.h
+++ b/src/flexdef.h
@@ -959,9 +959,6 @@ extern void transition_struct_out PROTO ((int, int));
 /* Only needed when using certain broken versions of bison to build parse.c. */
 extern void *yy_flex_xmalloc PROTO ((int));
 
-/* Set a region of memory to 0. */
-extern void zero_out PROTO ((char *, size_t));
-
 
 /* from file nfa.c */
 

--- a/src/misc.c
+++ b/src/misc.c
@@ -906,22 +906,6 @@ void   *yy_flex_xmalloc (int size)
 }
 
 
-/* zero_out - set a region of memory to 0
- *
- * Sets region_ptr[0] through region_ptr[size_in_bytes - 1] to zero.
- */
-
-void zero_out (char *region_ptr, size_t size_in_bytes)
-{
-	char *rp, *rp_end;
-
-	rp = region_ptr;
-	rp_end = region_ptr + size_in_bytes;
-
-	while (rp < rp_end)
-		*rp++ = 0;
-}
-
 /* Remove all '\n' and '\r' characters, if any, from the end of str.
  * str can be any null-terminated string, or NULL.
  * returns str. */

--- a/src/tblcmp.c
+++ b/src/tblcmp.c
@@ -299,8 +299,7 @@ void    expand_nxt_chk (void)
 	nxt = reallocate_integer_array (nxt, current_max_xpairs);
 	chk = reallocate_integer_array (chk, current_max_xpairs);
 
-	zero_out ((char *) (chk + old_max),
-		  (size_t) (MAX_XPAIRS_INCREMENT * sizeof (int)));
+	memset(chk + old_max, 0, MAX_XPAIRS_INCREMENT * sizeof(int));
 }
 
 
@@ -421,9 +420,7 @@ void    inittbl (void)
 {
 	int i;
 
-	zero_out ((char *) chk,
-
-		  (size_t) (current_max_xpairs * sizeof (int)));
+	memset(chk, 0, current_max_xpairs * sizeof(int));
 
 	tblend = 0;
 	firstfree = tblend + 1;

--- a/to.do/unicode/flexdef.h
+++ b/to.do/unicode/flexdef.h
@@ -913,9 +913,6 @@ extern void transition_struct_out PROTO((int, int));
 /* Only needed when using certain broken versions of bison to build parse.c. */
 extern void *yy_flex_xmalloc PROTO(( int ));
 
-/* Set a region of memory to 0. */
-extern void zero_out PROTO((char *, size_t));
-
 
 /* from file nfa.c */
 

--- a/to.do/unicode/misc.c
+++ b/to.do/unicode/misc.c
@@ -824,22 +824,3 @@ int size;
 
 	return result;
 	}
-
-
-/* zero_out - set a region of memory to 0
- *
- * Sets region_ptr[0] through region_ptr[size_in_bytes - 1] to zero.
- */
-
-void zero_out( region_ptr, size_in_bytes )
-char *region_ptr;
-size_t size_in_bytes;
-	{
-	register char *rp, *rp_end;
-
-	rp = region_ptr;
-	rp_end = region_ptr + size_in_bytes;
-
-	while ( rp < rp_end )
-		*rp++ = 0;
-	}

--- a/to.do/unicode/tblcmp.c
+++ b/to.do/unicode/tblcmp.c
@@ -309,8 +309,7 @@ void expand_nxt_chk()
 	nxt = reallocate_integer_array( nxt, current_max_xpairs );
 	chk = reallocate_integer_array( chk, current_max_xpairs );
 
-	zero_out( (char *) (chk + old_max),
-		(size_t) (MAX_XPAIRS_INCREMENT * sizeof( int )) );
+	memset(chk + old_max, 0, MAX_XPAIRS_INCREMENT * sizeof(int));
 	}
 
 
@@ -436,7 +435,7 @@ void inittbl()
 	{
 	register int i;
 
-	zero_out( (char *) chk, (size_t) (current_max_xpairs * sizeof( int )) );
+	memset(chk, 0, current_max_xpairs * sizeof(int));
 
 	tblend = 0;
 	firstfree = tblend + 1;


### PR DESCRIPTION
memset() is a stdlib function, so there's no need to recreate it.