### PR TITLE
Add reallocarray

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -125,7 +125,15 @@ AC_FUNC_ALLOCA
 AC_FUNC_FORK
 AC_FUNC_MALLOC
 AC_FUNC_REALLOC
-AC_CHECK_FUNCS([dup2 memset pow regcomp setlocale strchr strdup strtol])
+AC_CHECK_FUNCS([dup2 \
+		memset \
+		pow \
+		reallocarray \
+		regcomp \
+		setlocale \
+		strchr \
+		strdup \
+		strtol])
 
 AC_CONFIG_FILES(
 Makefile

--- a/src/flexdef.h
+++ b/src/flexdef.h
@@ -654,6 +654,10 @@ extern int sectnum, nummt, hshcol, dfaeql, numeps, eps2, num_reallocs;
 extern int tmpuses, totnst, peakpairs, numuniq, numdup, hshsave;
 extern int num_backing_up, bol_needed;
 
+#ifndef HAVE_REALLOCARRAY
+void *reallocarray(void *, size_t, size_t);
+#endif
+
 void   *allocate_array PROTO ((int, size_t));
 void   *reallocate_array PROTO ((void *, int, size_t));
 

--- a/src/reallocarray.c
+++ b/src/reallocarray.c
@@ -1,0 +1,46 @@
+/*	$OpenBSD: reallocarray.c,v 1.2 2014/12/08 03:45:00 bcook Exp $	*/
+/*
+ * Copyright (c) 2008 Otto Moerbeek <otto@drijf.net>
+ *
+ * Permission to use, copy, modify, and distribute this software for any
+ * purpose with or without fee is hereby granted, provided that the above
+ * copyright notice and this permission notice appear in all copies.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ * WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ * ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ * WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ */
+
+/* OPENBSD ORIGINAL: lib/libc/stdlib/reallocarray.c */
+
+#include "includes.h"
+#ifndef HAVE_REALLOCARRAY
+
+#include <sys/types.h>
+#include <errno.h>
+#ifdef HAVE_STDINT_H
+#include <stdint.h>
+#endif
+#include <stdlib.h>
+
+/*
+ * This is sqrt(SIZE_MAX+1), as s1*s2 <= SIZE_MAX
+ * if both s1 < MUL_NO_OVERFLOW and s2 < MUL_NO_OVERFLOW
+ */
+#define MUL_NO_OVERFLOW	((size_t)1 << (sizeof(size_t) * 4))
+
+void *
+reallocarray(void *optr, size_t nmemb, size_t size)
+{
+	if ((nmemb >= MUL_NO_OVERFLOW || size >= MUL_NO_OVERFLOW) &&
+	    nmemb > 0 && SIZE_MAX / nmemb < size) {
+		errno = ENOMEM;
+		return NULL;
+	}
+	return realloc(optr, size * nmemb);
+}
+#endif /* HAVE_REALLOCARRAY */

--- a/src/reallocarray.c
+++ b/src/reallocarray.c
@@ -17,7 +17,7 @@
 
 /* OPENBSD ORIGINAL: lib/libc/stdlib/reallocarray.c */
 
-#include "includes.h"
+#include "config.h"
 #ifndef HAVE_REALLOCARRAY
 
 #include <sys/types.h>


### PR DESCRIPTION
This is taken from OpenSSH Portable, which in turn takes it from
OpenBSD.

reallocarray wraps the stdlib's realloc function. It takes two size
arguments and checks for overflow, like calloc, but doesn't zero the
memory. Therefore, it allows us to do overflow-safe array reallocations
and overflow-safe unzeroed array allocations, which the stdlib
allocation functions don't.

We have a bunch of needlessly specific array allocation macros, none of
which check for overflow. reallocarray should be able to replace them.