### PR TITLE
Remove MS-DOS and non-POSIX-compliant-VMS macros

### DIFF
--- a/src/flexdef.h
+++ b/src/flexdef.h
@@ -108,18 +108,6 @@
 #endif
 #endif
 
-#ifdef VMS
-#ifndef __VMS_POSIX
-#define unlink remove
-#define SHORT_FILE_NAMES
-#endif
-#endif
-
-#ifdef MS_DOS
-#define SHORT_FILE_NAMES
-#endif
-
-
 /* Maximum line length we'll have to deal with. */
 #define MAXLINE 2048
 


### PR DESCRIPTION
I'd venture a guess that no one builds on these platforms anymore.