### PR TITLE
Unifdef SHORT_FILE_NAMES

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -27,11 +27,6 @@
 # and 7-bit scanners when using uncompressed tables (-f or -F options).
 # For flex to always generate 8-bit scanners, add "-DDEFAULT_CSIZE=256"
 # to DEFS.
-#
-# For Vax/VMS, add "-DVMS" to DEFS.
-#
-# For MS-DOS, add "-DMS_DOS" to DEFS.  See the directory MISC/MSDOS for
-# additional info.
 
 ACLOCAL_AMFLAGS = -I m4
 indent = @INDENT@

--- a/src/main.c
+++ b/src/main.c
@@ -117,19 +117,9 @@ struct yytbl_writer tableswr;
  */
 char   *program_name = "flex";
 
-#ifndef SHORT_FILE_NAMES
 static const char outfile_template[] = "lex.%s.%s";
 static const char backing_name[] = "lex.backup";
 static const char tablesfile_template[] = "lex.%s.tables";
-#else
-static const char outfile_template[] = "lex%s.%s";
-static const char backing_name[] = "lex.bck";
-static const char tablesfile_template[] = "lex%s.tbl";
-#endif
-
-#ifdef MS_DOS
-extern unsigned _stklen = 16384;
-#endif
 
 /* From scan.l */
 extern FILE* yyout;


### PR DESCRIPTION
It's never defined; see 13b5b214f53d1c3354a7ab910bd160c126df1331

While here also remove a stray MS_DOS ifdef.