### PR TITLE
tests: fix out-of-tree builds

### DIFF
--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -19,6 +19,8 @@
 # WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
 # PURPOSE.
 
+AM_CPPFLAGS = -I$(top_srcdir)/src
+
 TESTS = $(check_PROGRAMS) options.cn
 
 # The script testwrapper.sh will run most tests as is. A couple tests


### PR DESCRIPTION
Automake sets up DEFAULT_INCLUDES for us that point to a few dirs:
-I. -- the current build directory
-I$(srcdir) -- the current source directory
-I$(config.h dir) -- the directory where the config.h is generated

For in tree builds, this works out fine -- tests/ needs headers that
live in src/, and since config.h is generated in src/, the -I flags
point to the right place.  For out of tree builds, this fails: the
config.h is now generated in $(top_builddir)/src which means there
is no -I flag to $(top_srcdir)/src which means all the tests include
header files from the system.  If you have an old version, the build
fails in weird ways.

Fix this by always listing -I$(top_srcdir)/src as that has the flex
include headers we need.

URL: https://bugs.gentoo.org/567332
Reported-by: tka@kamph.org