### PR TITLE
Remove prototype for main()

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -135,7 +135,6 @@ const char *escaped_qend   = "[[]]M4_YY_NOOP]M4_YY_NOOP]M4_YY_NOOP[[]]";
 static int preproc_level = 1000;
 
 int flex_main PROTO ((int argc, char *argv[]));
-int main PROTO ((int argc, char *argv[]));
 
 int flex_main (int argc, char *argv[])
 {


### PR DESCRIPTION
It's not called anywhere else so the prototype is not needed.
See the C99 standard [1], section 5.1.2.2.1 for more info.

[1]: http://www.open-std.org/jtc1/sc22/wg14/www/docs/n1256.pdf