### PR TITLE
Cleanup __STDC__ #ifdefs

### DIFF
--- a/src/flex.skl
+++ b/src/flex.skl
@@ -223,26 +223,8 @@ m4preproc_include(`flexint.h')
 /* end standard C++ headers. */
 %endif
 
-#ifdef __cplusplus
-
-/* The "const" storage-class-modifier is valid. */
-#define YY_USE_CONST
-
-#else	/* ! __cplusplus */
-
-/* C99 requires __STDC__ to be defined as 1. */
-#if defined (__STDC__)
-
-#define YY_USE_CONST
-
-#endif	/* defined (__STDC__) */
-#endif	/* ! __cplusplus */
-
-#ifdef YY_USE_CONST
+/* TODO: this is always defined, so inline it */
 #define yyconst const
-#else
-#define yyconst
-#endif
 
 %# For compilers that can not handle prototypes.
 %# e.g.,

--- a/src/misc.c
+++ b/src/misc.c
@@ -521,19 +521,10 @@ unsigned char myesc (unsigned char array[])
 		return '\r';
 	case 't':
 		return '\t';
-
-#if defined (__STDC__)
 	case 'a':
 		return '\a';
 	case 'v':
 		return '\v';
-#else
-	case 'a':
-		return '\007';
-	case 'v':
-		return '\013';
-#endif
-
 	case '0':
 	case '1':
 	case '2':
@@ -684,14 +675,10 @@ char   *readable_form (int c)
 			return "\\r";
 		case '\t':
 			return "\\t";
-
-#if defined (__STDC__)
 		case '\a':
 			return "\\a";
 		case '\v':
 			return "\\v";
-#endif
-
 		default:
 			if(trace_hex)
 				snprintf (rform, sizeof(rform), "\\x%.2x", (unsigned int) c);


### PR DESCRIPTION
Assuming a compiler conforming to the ISO C standard is used, i.e.,
__STDC__ is defined to 1, the ifdefs surrounding YY_USE_CONST can be
greatly simplified.