### PR TITLE
Converted K&R style function definitions to ANSI C style

### DIFF
--- a/lib/lib.c
+++ b/lib/lib.c
@@ -3,5 +3,5 @@
  * moving something that flex treats as a library function into this
  * directory. */
 
-void do_nothing(){ return;}
+void do_nothing(void){ return;}
 

--- a/src/gen.c
+++ b/src/gen.c
@@ -725,8 +725,7 @@ void genftbl (void)
 
 /* Generate the code to find the next compressed-table state. */
 
-void gen_next_compressed_state (char_map)
-     char   *char_map;
+void gen_next_compressed_state (char *char_map)
 {
 	indent_put2s ("YY_CHAR yy_c = %s;", char_map);
 
@@ -876,8 +875,7 @@ void gen_next_match (void)
 
 /* Generate the code to find the next state. */
 
-void gen_next_state (worry_about_NULs)
-     int worry_about_NULs;
+void gen_next_state (int worry_about_NULs)
 {				/* NOTE - changes in here should be reflected in gen_next_match() */
 	char    char_map[256];
 

--- a/src/misc.c
+++ b/src/misc.c
@@ -852,8 +852,7 @@ void skelout (void)
  * element_n.  Formats the output with spaces and carriage returns.
  */
 
-void transition_struct_out (element_v, element_n)
-     int element_v, element_n;
+void transition_struct_out (int element_v, int element_n)
 {
 
 	/* short circuit any output */

--- a/src/scan.l
+++ b/src/scan.l
@@ -59,7 +59,7 @@ extern const char *escaped_qstart, *escaped_qend;
 #define MARK_END_OF_PROLOG mark_prolog();
 
 #define YY_DECL \
-	int flexscan()
+	int flexscan(void)
 
 #define RETURNCHAR \
 	yylval = (unsigned char) yytext[0]; \


### PR DESCRIPTION
Consistently make use of the ANSI C function definition style instead of
the K&R style.