### PR TITLE
Fix potential buffer overflow in strncat()

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -375,7 +375,7 @@ void check_options (void)
 					strncpy(m4_path, path, sizeof(m4_path));
 					m4_path[endOfDir-path] = '/';
 					m4_path[endOfDir-path+1] = '\0';
-					strncat(m4_path, m4, sizeof(m4_path));
+					strncat(m4_path, m4, sizeof(m4_path) - strlen(m4_path) - 1);
 					if (stat(m4_path, &sbuf) == 0 &&
 						(S_ISREG(sbuf.st_mode)) && sbuf.st_mode & S_IXUSR) {
 						m4 = strdup(m4_path);


### PR DESCRIPTION
When using clang/llvm 3.8 to compile flex, the following warning is
emitted:

main.c:378:27: warning: the value of the size argument in 'strncat' is too large, might lead to a buffer overflow [-Wstrncat-size]
                                        strncat(m4_path, m4, sizeof(m4_path));
                                                             ^~~~~~~~~~~~~~~
main.c:378:27: note: change the argument to be the free space in the destination buffer minus the terminating null byte
                                        strncat(m4_path, m4, sizeof(m4_path));
                                                             ^~~~~~~~~~~~~~~
                                                             sizeof(m4_path) - strlen(m4_path) - 1

Fix it up by using the solution proposed by the warning message.