### PR TITLE
Avoid realloc on every call of sf_push()

### DIFF
--- a/src/scanflags.c
+++ b/src/scanflags.c
@@ -39,9 +39,10 @@ size_t _sf_top_ix=0, _sf_max=0;
 void
 sf_push (void)
 {
-    if (_sf_top_ix + 1 >= _sf_max)
+    if (_sf_top_ix + 1 >= _sf_max) {
         _sf_max += 32;
         _sf_stk = realloc(_sf_stk, sizeof(scanflags_t) * _sf_max);
+    }
 
     // copy the top element
     _sf_stk[_sf_top_ix + 1] = _sf_stk[_sf_top_ix];


### PR DESCRIPTION
Currently, every call to sf_push() realloc()'s _sf_stack, even if the
maximum size _sf_max wasn't changed. As the indentation beneath the
"if" clause already indicates, the realloc() should only be executed
if _sf_max was increased.

Found by compiling flex with the -Wmisleading-indentation flags of gcc,
which leads to the following warning:

scanflags.c: In function ‘sf_push’:
scanflags.c:42:5: warning: this ‘if’ clause does not guard... [-Wmisleading-indentation]
     if (_sf_top_ix + 1 >= _sf_max)
     ^~
scanflags.c:44:9: note: ...this statement, but the latter is misleadingly indented as if it is guarded by the ‘if’
         _sf_stk = realloc(_sf_stk, sizeof(scanflags_t) * _sf_max);
         ^~~~~~~