### PR TITLE
Fix escaping of `[[` and `]]` in strings

### DIFF
--- a/src/scan.l
+++ b/src/scan.l
@@ -939,7 +939,9 @@ nmstr[yyleng - 2 - end_is_ws] = '\0';  /* chop trailing brace */
 <ACTION_STRING>{
 	[^"\\\n]+	ACTION_ECHO;
 	\\.		ACTION_ECHO;
-	{NL}		++linenum; ACTION_ECHO; BEGIN(ACTION);
+        {M4QEND}        ACTION_ECHO_QEND;
+        {M4QSTART}      ACTION_ECHO_QSTART;
+	{NL}		++linenum; ACTION_ECHO;
 	\"		ACTION_ECHO; BEGIN(ACTION);
 	.		ACTION_ECHO;
 }


### PR DESCRIPTION
Previously, `[[` and `]]` were not escaped in strings, which led
to bad interactions with m4.

Also, don't break strings on newline, as GCC et al support whitespace
between a backslash and the subsequent newline.