### PR TITLE
Fix M4 quotation in section 3

### DIFF
--- a/src/filter.c
+++ b/src/filter.c
@@ -390,7 +390,7 @@ int filter_fix_linedirs (struct filter *chain)
 				/* Adjust the line directives. */
 				in_gen = true;
 				snprintf (buf, readsz, "#line %d \"%s\"\n",
-					  lineno + 1, filename);
+					  lineno, filename);
 			}
 			else {
 				/* it's a #line directive for code we didn't write */

--- a/src/flexdef.h
+++ b/src/flexdef.h
@@ -1063,6 +1063,7 @@ extern struct Buf defs_buf;    /* a char* buffer to save #define'd some symbols 
 extern struct Buf yydmap_buf;  /* a string buffer to hold yydmap elements */
 extern struct Buf m4defs_buf;  /* Holds m4 definitions. */
 extern struct Buf top_buf;     /* contains %top code. String buffer. */
+extern bool no_section3_escape; /* True if the undocumented option --unsafe-no-m4-sect3-escape was passed */
 
 /* For blocking out code from the header file. */
 #define OUT_BEGIN_CODE() outn("m4_ifdef( [[M4_YY_IN_HEADER]],,[[")

--- a/src/flexdef.h
+++ b/src/flexdef.h
@@ -1066,7 +1066,7 @@ extern struct Buf top_buf;     /* contains %top code. String buffer. */
 extern bool no_section3_escape; /* True if the undocumented option --unsafe-no-m4-sect3-escape was passed */
 
 /* For blocking out code from the header file. */
-#define OUT_BEGIN_CODE() outn("m4_ifdef( [[M4_YY_IN_HEADER]],,[[")
+#define OUT_BEGIN_CODE() outn("m4_ifdef( [[M4_YY_IN_HEADER]],,[[m4_dnl")
 #define OUT_END_CODE()   outn("]])")
 
 /* For setjmp/longjmp (instead of calling exit(2)). Linkage in main.c */

--- a/src/main.c
+++ b/src/main.c
@@ -1427,6 +1427,10 @@ void flexinit (int argc, char **argv)
 			break;
 		case OPT_HEX:
 			trace_hex = 1;
+                        break;
+                case OPT_NO_SECT3_ESCAPE:
+                        no_section3_escape = true;
+                        break;
 		}		/* switch */
 	}			/* while scanopt() */
 

--- a/src/misc.c
+++ b/src/misc.c
@@ -362,8 +362,8 @@ void line_directive_out (FILE *output_file, int do_infile)
 	s3 = &filename[sizeof (filename) - 2];
 
 	while (s2 < s3 && *s1) {
-		if (*s1 == '\\')
-			/* Escape the '\' */
+		if (*s1 == '\\' || *s1 == '"')
+			/* Escape the '\' or '"' */
 			*s2++ = '\\';
 
 		*s2++ = *s1++;
@@ -512,7 +512,8 @@ unsigned char myesc (unsigned char array[])
 		{		/* \<octal> */
 			int     sptr = 1;
 
-			while (isascii (array[sptr]) &&
+			while (sptr <= 3 &&
+                               isascii (array[sptr]) &&
 			       isdigit (array[sptr]))
 				/* Don't increment inside loop control
 				 * because if isdigit() is a macro it might

--- a/src/options.c
+++ b/src/options.c
@@ -271,7 +271,8 @@ optspec_t flexopts[] = {
 	,
 	{"--noyyset_lloc", OPT_NO_YYSET_LLOC, 0}
 	,
-
+        {"--unsafe-no-m4-sect3-escape", OPT_NO_SECT3_ESCAPE, 0}
+        ,
 	{0, 0, 0}		/* required final NULL entry. */
 };
 

--- a/src/options.h
+++ b/src/options.h
@@ -125,7 +125,8 @@ enum flexopt_flag_t {
 	OPT_YYCLASS,
 	OPT_YYLINENO,
 	OPT_YYMORE,
-	OPT_YYWRAP
+	OPT_YYWRAP,
+        OPT_NO_SECT3_ESCAPE,
 };
 
 #endif

--- a/src/scan.l
+++ b/src/scan.l
@@ -973,7 +973,12 @@ nmstr[yyleng - 2 - end_is_ws] = '\0';  /* chop trailing brace */
 
 
 <SECT3>{
-    "M4"|"m4"|"YY" no_section3_escape  || 1? fputs(yytext, stdout) : fprintf (yyout, "[[%s]]", yytext);
+    "M4"|"m4"|"YY" {
+        if (no_section3_escape) {
+           ECHO;
+        } else
+           fprintf (yyout, "[[%s]]", yytext);
+    }
     {M4QSTART}  fwrite (escaped_qstart, 1, strlen(escaped_qstart) - 0, yyout);
     {M4QEND}    fwrite (escaped_qend, 1, strlen(escaped_qend) - 0, yyout);
 	[^\[\]MmY\n]*(\n?) ECHO;

--- a/src/scan.l
+++ b/src/scan.l
@@ -613,11 +613,7 @@ M4QEND      "]]"
 
 	^"%%".*		{
 			sectnum = 3;
-                        if (!no_section3_escape) {
-                           BEGIN(SECT3);
-                        } else {
-                           BEGIN(SECT3_NOESCAPE);
-                        }
+			BEGIN(SECT3);
 			outn("/* Begin user sect3 */");
                         //fwrite(M4QSTART, 1, 2, yyout);
 			yyterminate(); /* to stop the parser */
@@ -975,29 +971,20 @@ nmstr[yyleng - 2 - end_is_ws] = '\0';  /* chop trailing brace */
 			return CHAR;
 			}
 
+
 <SECT3>{
-   {M4QSTART}  { fwrite (SECT3_ESCAPED_QSTART, 1,
-                         strlen(SECT3_ESCAPED_QSTART), yyout);
-               }
-   {M4QEND}    { fwrite (SECT3_ESCAPED_QEND, 1,
-                         strlen(SECT3_ESCAPED_QEND), yyout);
-               }
-    [^\[\]\n]*(\n?) ECHO;
-    (.|\n)      ECHO;
-    <<EOF>>		{
-       if (sectnum != 3)
-          abort();
-       sectnum = 0;
-       yyterminate();
-    }
+    "M4"|"m4"|"YY" no_section3_escape  || 1? fputs(yytext, stdout) : fprintf (yyout, "[[%s]]", yytext);
+    {M4QSTART}  fwrite (escaped_qstart, 1, strlen(escaped_qstart) - 0, yyout);
+    {M4QEND}    fwrite (escaped_qend, 1, strlen(escaped_qend) - 0, yyout);
+	[^\[\]MmY\n]*(\n?) ECHO;
+	(.|\n)      ECHO;
+	<<EOF>>		{
+           //fwrite(M4QEND, 1, strlen(M4QEND), yyout);
+           sectnum = 0;
+           yyterminate();
+        }
 }
-<SECT3_NOESCAPE>{
-   (.|\n)* ECHO;
-   <<EOF>> {
-      sectnum = 0;
-      yyterminate();
-   }
-}
+
 <*>.|\n			format_synerr( _( "bad character: %s" ), yytext );
 
 %%

--- a/src/scan.l
+++ b/src/scan.l
@@ -114,6 +114,7 @@ extern const char *escaped_qstart, *escaped_qend;
 %x EXTENDED_COMMENT
 %x COMMENT_DISCARD
 %x SECT3_NOESCAPE
+%x CHARACTER_CONSTANT
 
 WS		[[:blank:]]+
 OPTWS		[[:blank:]]*
@@ -244,7 +245,7 @@ M4QEND      "]]"
 			}
 	.		/* ignore spurious characters */
 }
-<ACTION,CODEBLOCK,ACTION_STRING,PERCENT_BRACE_ACTION,COMMENT>{
+<ACTION,CODEBLOCK,ACTION_STRING,PERCENT_BRACE_ACTION,COMMENT,CHARACTER_CONSTANT>{
    M4|YY|m4 add_action(M4QSTART); ACTION_ECHO; add_action(M4QEND);
    {M4QSTART}   ACTION_ECHO_QSTART;
    {M4QEND}     ACTION_ECHO_QEND;
@@ -927,7 +928,8 @@ nmstr[yyleng - 2 - end_is_ws] = '\0';  /* chop trailing brace */
 	[^[:alpha:]_{}\"'/\n\[\]]+	ACTION_ECHO;
     [\[\]]      ACTION_ECHO;
 	{NAME}		ACTION_ECHO;
-	"'"([^\'\\\n]|\\.)*"'"	ACTION_ECHO; /* character constant */
+        "'"([^\'\\\n]|\\.)"'" ACTION_ECHO; /* character constant */
+        "'"             ACTION_ECHO; yy_push_state(CHARACTER_CONSTANT);
 	\"		ACTION_ECHO; BEGIN(ACTION_STRING);
 	{NL}		{
 			++linenum;
@@ -946,13 +948,19 @@ nmstr[yyleng - 2 - end_is_ws] = '\0';  /* chop trailing brace */
 
 <ACTION_STRING>{
 	[^\]\"\\\n\[MmY]+	ACTION_ECHO;
+	\"		ACTION_ECHO; BEGIN(ACTION);
+}
+<CHARACTER_CONSTANT>{
+	[^\[\]\'\\\nMmY]+       ACTION_ECHO;
+        \'              ACTION_ECHO; yy_pop_state();
+}
+<ACTION_STRING,CHARACTER_CONSTANT>{
 	\\.		ACTION_ECHO;
 	{NL}		++linenum; ACTION_ECHO;
-	\"		ACTION_ECHO; BEGIN(ACTION);
 	.		ACTION_ECHO;
 }
 
-<COMMENT,COMMENT_DISCARD,ACTION,ACTION_STRING><<EOF>>	{
+<COMMENT,COMMENT_DISCARD,ACTION,ACTION_STRING,CHARACTER_CONSTANT><<EOF>>	{
 			synerr( _( "EOF encountered inside an action" ) );
 			yyterminate();
 			}

--- a/src/scan.l
+++ b/src/scan.l
@@ -41,6 +41,9 @@ extern const char *escaped_qstart, *escaped_qend;
 #define M4QSTART "[["
 #define M4QEND "]]"
 
+#define SECT3_ESCAPED_QSTART "[" M4QEND M4QSTART "[" M4QEND M4QSTART
+#define SECT3_ESCAPED_QEND M4QEND "]" M4QSTART M4QEND "]" M4QSTART
+
 #define ACTION_ECHO add_action( yytext )
 #define ACTION_IFDEF(def, should_define) \
 	{ \
@@ -110,6 +113,7 @@ extern const char *escaped_qstart, *escaped_qend;
 %x GROUP_MINUS_PARAMS
 %x EXTENDED_COMMENT
 %x COMMENT_DISCARD
+%x SECT3_NOESCAPE
 
 WS		[[:blank:]]+
 OPTWS		[[:blank:]]*
@@ -241,7 +245,7 @@ M4QEND      "]]"
 	.		/* ignore spurious characters */
 }
 <ACTION,CODEBLOCK,ACTION_STRING,PERCENT_BRACE_ACTION,COMMENT>{
-   "M4"|"YY"|"m4" add_action(M4QSTART); ACTION_ECHO; add_action(M4QEND);
+   M4|YY|m4 add_action(M4QSTART); ACTION_ECHO; add_action(M4QEND);
    {M4QSTART}   ACTION_ECHO_QSTART;
    {M4QEND}     ACTION_ECHO_QEND;
 }
@@ -285,9 +289,9 @@ M4QEND      "]]"
        buf_strnappend(&top_buf, M4QEND, 2);
     }
 
-    [^{}\r\n]  {
-                buf_strnappend(&top_buf, yytext, yyleng);
-               }
+    ([^{}\r\nmMY\[\]]+)|[^{}\r\n]  {
+       buf_strnappend(&top_buf, yytext, yyleng);
+    }
 
     <<EOF>>     {
                 linenum = brace_start_line;
@@ -609,7 +613,11 @@ M4QEND      "]]"
 
 	^"%%".*		{
 			sectnum = 3;
-			BEGIN(SECT3);
+                        if (!no_section3_escape) {
+                           BEGIN(SECT3);
+                        } else {
+                           BEGIN(SECT3_NOESCAPE);
+                        }
 			outn("/* Begin user sect3 */");
                         //fwrite(M4QSTART, 1, 2, yyout);
 			yyterminate(); /* to stop the parser */
@@ -920,10 +928,10 @@ nmstr[yyleng - 2 - end_is_ws] = '\0';  /* chop trailing brace */
 <ACTION>{
 	"{"		ACTION_ECHO; ++bracelevel;
 	"}"		ACTION_ECHO; --bracelevel;
-	[^[:alpha:]_{}"'/\n\[\]]+	ACTION_ECHO;
+	[^[:alpha:]_{}\"'/\n\[\]]+	ACTION_ECHO;
     [\[\]]      ACTION_ECHO;
 	{NAME}		ACTION_ECHO;
-	"'"([^'\\\n]|\\.)*"'"	ACTION_ECHO; /* character constant */
+	"'"([^\'\\\n]|\\.)*"'"	ACTION_ECHO; /* character constant */
 	\"		ACTION_ECHO; BEGIN(ACTION_STRING);
 	{NL}		{
 			++linenum;
@@ -941,7 +949,7 @@ nmstr[yyleng - 2 - end_is_ws] = '\0';  /* chop trailing brace */
 }
 
 <ACTION_STRING>{
-	[^]"\\\n[]+	ACTION_ECHO;
+	[^\]\"\\\n\[MmY]+	ACTION_ECHO;
 	\\.		ACTION_ECHO;
 	{NL}		++linenum; ACTION_ECHO;
 	\"		ACTION_ECHO; BEGIN(ACTION);
@@ -967,20 +975,29 @@ nmstr[yyleng - 2 - end_is_ws] = '\0';  /* chop trailing brace */
 			return CHAR;
 			}
 
-
 <SECT3>{
-    /* "M4"|"m4"|"YY" fprintf (yyout, "[[%s]]", yytext); */
-    {M4QSTART}  fwrite (escaped_qstart, 1, strlen(escaped_qstart) - 0, yyout);
-    {M4QEND}    fwrite (escaped_qend, 1, strlen(escaped_qend) - 0, yyout);
-	[^\[\]\n]*(\n?) ECHO;
-	(.|\n)      ECHO;
-	<<EOF>>		{
-           //fwrite(M4QEND, 1, strlen(M4QEND), yyout);
-           sectnum = 0;
-           yyterminate();
-        }
+   {M4QSTART}  { fwrite (SECT3_ESCAPED_QSTART, 1,
+                         strlen(SECT3_ESCAPED_QSTART), yyout);
+               }
+   {M4QEND}    { fwrite (SECT3_ESCAPED_QEND, 1,
+                         strlen(SECT3_ESCAPED_QEND), yyout);
+               }
+    [^\[\]\n]*(\n?) ECHO;
+    (.|\n)      ECHO;
+    <<EOF>>		{
+       if (sectnum != 3)
+          abort();
+       sectnum = 0;
+       yyterminate();
+    }
 }
-
+<SECT3_NOESCAPE>{
+   (.|\n)* ECHO;
+   <<EOF>> {
+      sectnum = 0;
+      yyterminate();
+   }
+}
 <*>.|\n			format_synerr( _( "bad character: %s" ), yytext );
 
 %%

--- a/src/yylex.c
+++ b/src/yylex.c
@@ -39,7 +39,7 @@
 /* yylex - scan for a regular expression token */
 extern char *yytext;
 extern FILE *yyout;
-bool no_section3_escape;
+bool no_section3_escape = false;
 int     yylex (void)
 {
 	int     toktype;
@@ -47,10 +47,6 @@ int     yylex (void)
 
 	if (eofseen) {
 		toktype = EOF;
-        } else if (sectnum == 3 && !no_section3_escape) {
-                fputs("[[", yyout);
-                toktype = flexscan();
-                fputs("]]m4_dnl\n", yyout);
         } else {
 		toktype = flexscan ();
         }

--- a/src/yylex.c
+++ b/src/yylex.c
@@ -37,18 +37,23 @@
 
 
 /* yylex - scan for a regular expression token */
-
 extern char *yytext;
+extern FILE *yyout;
+bool no_section3_escape;
 int     yylex (void)
 {
 	int     toktype;
 	static int beglin = false;
 
-	if (eofseen)
+	if (eofseen) {
 		toktype = EOF;
-	else
+        } else if (sectnum == 3 && !no_section3_escape) {
+                fputs("[[", yyout);
+                toktype = flexscan();
+                fputs("]]m4_dnl\n", yyout);
+        } else {
 		toktype = flexscan ();
-
+        }
 	if (toktype == EOF || toktype == 0) {
 		eofseen = 1;
 

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -393,7 +393,7 @@ reject_ver.table$(EXEEXT): reject_ver.table.$(OBJEXT)
 	$(LINK) $^
 
 reject_ser.table.c: reject.l4 $(FLEX)
-	$(FLEX) -o $@ --tables-file=$(basename $@).tables $<
+	$(FLEX) -o $@ --unsafe-no-m4-sect3-escape --tables-file=$(basename $@).tables $<
 
 reject_ser.table.$(OBJEXT): reject_ser.table.c
 	$(COMPILE) -DTEST_HAS_TABLES_EXTERNAL -c -o $@ $<

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -369,13 +369,13 @@ posixly_correct.c: posixly_correct.l $(FLEX)
 	POSIXLY_CORRECT=1 $(FLEX) -o $@ $<
 
 reject_nr.reject.c: reject.l4 $(FLEX)
-	$(FLEX) -o $@ $<
+	$(FLEX) --unsafe-no-m4-sect3-escape -o $@ $<
 
 reject_nr.reject$(EXEEXT): reject_nr.reject.$(OBJEXT)
 	$(LINK) $^
 
 reject_r.reject.c: reject.l4 $(FLEX)
-	$(FLEX) --reentrant -o $@ $<
+	$(FLEX) --unsafe-no-m4-sect3-escape --reentrant -o $@ $<
 
 reject_r.reject.$(OBJEXT): reject_r.reject.c
 	$(COMPILE) -DTEST_IS_REENTRANT -c -o $@ $<
@@ -384,7 +384,7 @@ reject_r.reject$(EXEEXT): reject_r.reject.$(OBJEXT)
 	$(LINK) $^
 
 reject_ver.table.c: reject.l4 $(FLEX)
-	$(FLEX) -o $@ --tables-verify --tables-file=$(basename $@).tables $<
+	$(FLEX) --unsafe-no-m4-sect3-escape -o $@ --tables-verify --tables-file=$(basename $@).tables $<
 
 reject_ver.table.$(OBJEXT): reject_ver.table.c
 	$(COMPILE) -DTEST_HAS_TABLES_EXTERNAL -c -o $@ $<
@@ -427,13 +427,13 @@ OPT_LOG_COMPILER = $(srcdir)/testwrapper.sh
 AM_OPT_LOG_FLAGS = -d $(srcdir) -i $(srcdir)/tableopts.txt -r
 
 tableopts_opt_nr%.c: tableopts.l4 $(FLEX)
-	$(FLEX) -P $(subst -,_,$(basename $(*F))) $* -o $@ $<
+	$(FLEX) --unsafe-no-m4-sect3-escape -P $(subst -,_,$(basename $(*F))) $* -o $@ $<
 
 tableopts_opt_nr%.$(OBJEXT): tableopts_opt_nr%.c 
 	$(COMPILE) -c -o $@ $<
 
 tableopts_opt_r%.c: tableopts.l4 $(FLEX)
-	$(FLEX) -P $(subst -,_,$(basename $(*F))) --reentrant $*  -o $@ $<
+	$(FLEX) --unsafe-no-m4-sect3-escape -P $(subst -,_,$(basename $(*F))) --reentrant $*  -o $@ $<
 
 tableopts_opt_r%.$(OBJEXT):  tableopts_opt_r%.c 
 	$(COMPILE) -DTEST_IS_REENTRANT -c -o $@ $<
@@ -442,13 +442,13 @@ SER_LOG_COMPILER = $(srcdir)/testwrapper.sh
 AM_SER_LOG_FLAGS = -d $(builddir) -i $(srcdir)/tableopts.txt -r -t
 
 tableopts_ser_nr%.c: tableopts.l4 $(FLEX)
-	$(FLEX) -P $(subst -,_,$(basename $(*F))) --tables-file="tableopts_ser_nr$*.ser.tables"  $* -o $@ $<
+	$(FLEX) --unsafe-no-m4-sect3-escape -P $(subst -,_,$(basename $(*F))) --tables-file="tableopts_ser_nr$*.ser.tables"  $* -o $@ $<
 
 tableopts_ser_nr%.$(OBJEXT): tableopts_ser_nr%.c 
 	$(COMPILE) -DTEST_HAS_TABLES_EXTERNAL -c -o $@ $<
 
 tableopts_ser_r%.c: tableopts.l4 $(FLEX)
-	$(FLEX) -P $(subst -,_,$(basename $(*F))) -R --tables-file="tableopts_ser_r$*.ser.tables" $*  -o $@ $<
+	$(FLEX) --unsafe-no-m4-sect3-escape -P $(subst -,_,$(basename $(*F))) -R --tables-file="tableopts_ser_r$*.ser.tables" $*  -o $@ $<
 
 tableopts_ser_r%.$(OBJEXT):  tableopts_ser_r%.c
 	$(COMPILE) -DTEST_HAS_TABLES_EXTERNAL -DTEST_IS_REENTRANT -c -o $@ $<
@@ -457,7 +457,7 @@ VER_LOG_COMPILER = $(srcdir)/testwrapper.sh
 AM_VER_LOG_FLAGS = -d $(builddir) -i $(srcdir)/tableopts.txt -r -t
 
 tableopts_ver_nr%.c: tableopts.l4 $(FLEX)
-	$(FLEX) -P $(subst -,_,$(basename $(*F))) --tables-file="tableopts_ver_nr$*.ver.tables" --tables-verify $* -o $@ $<
+	$(FLEX) --unsafe-no-m4-sect3-escape -P $(subst -,_,$(basename $(*F))) --tables-file="tableopts_ver_nr$*.ver.tables" --tables-verify $* -o $@ $<
 
 tableopts_ver_nr%.$(OBJEXT): tableopts_ver_nr%.c 
 	$(COMPILE) -DTEST_HAS_TABLES_EXTERNAL -c -o $@ $<
@@ -466,7 +466,7 @@ tableopts_ver_nr%.ver$(EXEEXT): tableopts_ver_nr%.$(OBJEXT)
 	$(LINK) -o $@ $^
 
 tableopts_ver_r%.c: tableopts.l4 $(FLEX)
-	$(FLEX) -P $(subst -,_,$(basename $(*F))) -R --tables-file="tableopts_ver_r$*.ver.tables" --tables-verify $*  -o $@ $<
+	$(FLEX) --unsafe-no-m4-sect3-escape -P $(subst -,_,$(basename $(*F))) -R --tables-file="tableopts_ver_r$*.ver.tables" --tables-verify $*  -o $@ $<
 
 tableopts_ver_r%.$(OBJEXT):  tableopts_ver_r%.c  
 	$(COMPILE) -DTEST_HAS_TABLES_EXTERNAL -DTEST_IS_REENTRANT -c -o $@ $<

--- a/tests/alloc_extra.l
+++ b/tests/alloc_extra.l
@@ -75,8 +75,8 @@ main (void)
     testset_in(stdin, scanner);
     testset_out(stdout, scanner);
 
-    /* Test to confirm that yyalloc was called from
-     * yylex_init_extra with the yyextra argument.
+    /* Test to confirm that testalloc was called from
+     * testlex_init_extra with the testextra argument.
      */
     check_extra(scanner);
 
@@ -86,7 +86,7 @@ main (void)
     return 0;
 }
 
-void *yyalloc(size_t size, yyscan_t scanner)
+void *testalloc(size_t size, yyscan_t scanner)
 {
     struct Check *check;
     check = testget_extra(scanner);

--- a/tests/array_r.l
+++ b/tests/array_r.l
@@ -49,13 +49,13 @@ main (void)
 {
     yyscan_t lexer;
     
-	yylex_init(&lexer);
-    yyset_in(stdin, lexer);
-    yyset_out(stdout, lexer);
+	testlex_init(&lexer);
+    testset_in(stdin, lexer);
+    testset_out(stdout, lexer);
 	
-    yylex( lexer );
+    testlex( lexer );
 	
-    yylex_destroy( lexer);
+    testlex_destroy( lexer);
     printf("TEST RETURNING OK.\n");
 
     return 0;

--- a/tests/basic_r.l
+++ b/tests/basic_r.l
@@ -55,13 +55,13 @@ int main(void);
 int main (void)
 {
     yyscan_t  lexer;
-    yylex_init( &lexer );
-    yyset_out ( stdout,lexer);
-    yyset_in  ( stdin, lexer);
-    while( yylex(lexer) )
+    testlex_init( &lexer );
+    testset_out ( stdout,lexer);
+    testset_in  ( stdin, lexer);
+    while( testlex(lexer) )
     {
     }
-    yylex_destroy( lexer );
+    testlex_destroy( lexer );
     printf("TEST RETURNING OK.\n");
     return 0;
 }

--- a/tests/c_cxx_nr.lll
+++ b/tests/c_cxx_nr.lll
@@ -48,10 +48,10 @@ int main(void);
 int
 main ()
 {
-    yyin = stdin;
-    yyout = stdout;
-    yylex();
-    yylex_destroy();
+    testin = stdin;
+    testout = stdout;
+    testlex();
+    testlex_destroy();
     printf("TEST RETURNING OK.\n");
     return 0;
 }

--- a/tests/c_cxx_r.lll
+++ b/tests/c_cxx_r.lll
@@ -49,13 +49,13 @@ int
 main ()
 {
     yyscan_t  lexer;
-    yylex_init( &lexer );
-    yyset_out ( stdout,lexer);
-    yyset_in  ( stdin, lexer);
-    while( yylex(lexer) )
+    testlex_init( &lexer );
+    testset_out ( stdout,lexer);
+    testset_in  ( stdin, lexer);
+    while( testlex(lexer) )
     {
     }
-    yylex_destroy( lexer );
+    testlex_destroy( lexer );
     printf("TEST RETURNING OK.\n");
     return 0;
 }

--- a/tests/debug_r.l
+++ b/tests/debug_r.l
@@ -43,17 +43,17 @@ int main(void);
 int main (void)
 {
     yyscan_t  lexer;
-    yylex_init( &lexer );
-    yyset_out ( stdout,lexer);
-    yyset_in  ( stdin, lexer);
+    testlex_init( &lexer );
+    testset_out ( stdout,lexer);
+    testset_in  ( stdin, lexer);
     
     /* Just see if the next line compiles. */
     testset_debug (testget_debug(lexer), lexer);
     
-    while( yylex(lexer) )
+    while( testlex(lexer) )
     {
     }
-    yylex_destroy( lexer );
+    testlex_destroy( lexer );
     printf("TEST RETURNING OK.\n");
     return 0;
 }

--- a/tests/include_by_reentrant.direct.l
+++ b/tests/include_by_reentrant.direct.l
@@ -59,11 +59,11 @@ int error = 0;
         error = 1;
         yyterminate();
     }
-    yylex_init(&scanner);
-    yyset_in( fp, scanner);
-    yyset_out( stdout, scanner);
-    yylex(scanner);
-    yylex_destroy(scanner);
+    testlex_init(&scanner);
+    testset_in( fp, scanner);
+    testset_out( stdout, scanner);
+    testlex(scanner);
+    testlex_destroy(scanner);
 
     BEGIN(0);
     }
@@ -93,11 +93,11 @@ main ( int argc, char **argv )
         fprintf(stderr,"*** Error: fopen(%s) failed.\n",argv[1]);
         exit(-1);
     }
-    yylex_init(&scanner);
-    yyset_in( fp, scanner);
-    yyset_out( stdout, scanner);
-    yylex(scanner);
-    yylex_destroy(scanner);
+    testlex_init(&scanner);
+    testset_in( fp, scanner);
+    testset_out( stdout, scanner);
+    testlex(scanner);
+    testlex_destroy(scanner);
     if (!error)
         printf("TEST RETURNING OK.\n");
     else

--- a/tests/lineno_r.l
+++ b/tests/lineno_r.l
@@ -87,11 +87,11 @@ main (int argc, char **argv)
 
     else{
         yyscan_t s;
-        yylex_init(&s);
-        yyset_in(stdin,s);
-        yyset_out(stdout,s);
-        yylex(s);
-        yylex_destroy(s);
+        testlex_init(&s);
+        testset_in(stdin,s);
+        testset_out(stdout,s);
+        testlex(s);
+        testlex_destroy(s);
     }
     return 0;
 }

--- a/tests/mem_nr.l
+++ b/tests/mem_nr.l
@@ -166,8 +166,8 @@ main (void)
 
     yyin = stdin;
     yyout = stdout;
-    yylex();
-    yylex_destroy();
+    testlex();
+    testlex_destroy();
     free(ptrs);
 
     if ( nptrs > 0 || total_mem > 0){

--- a/tests/mem_r.l
+++ b/tests/mem_r.l
@@ -85,7 +85,7 @@ static void dump_mem(FILE* fp){
     fprintf(fp,"}\n");
 }
 
-void * yyalloc(yy_size_t n , void* yyscanner)
+void * testalloc(yy_size_t n , void* yyscanner)
 {
     (void)yyscanner;
 
@@ -116,7 +116,7 @@ void * yyalloc(yy_size_t n , void* yyscanner)
     return p;
 }
 
-void * yyrealloc(void* p, yy_size_t n , void* yyscanner)
+void * testrealloc(void* p, yy_size_t n , void* yyscanner)
 {
     (void)yyscanner;
 
@@ -139,7 +139,7 @@ void * yyrealloc(void* p, yy_size_t n , void* yyscanner)
     exit(1);
 }
 
-void yyfree(void* p , void* yyscanner)
+void testfree(void* p , void* yyscanner)
 {
     (void)yyscanner;
 
@@ -171,11 +171,11 @@ main (void)
     ptrs  = calloc(1, sizeof(struct memsz));
     nptrs = 0;
 
-    yylex_init(&scanner);
-    yyset_in(stdin,scanner);
-    yyset_out(stdout,scanner);
-    yylex(scanner);
-    yylex_destroy(scanner);
+    testlex_init(&scanner);
+    testset_in(stdin,scanner);
+    testset_out(stdout,scanner);
+    testlex(scanner);
+    testlex_destroy(scanner);
     free(ptrs);
 
     if ( nptrs > 0 || total_mem > 0){

--- a/tests/posix.l
+++ b/tests/posix.l
@@ -63,9 +63,9 @@ int main (void)
 
     /* Run the tests */
     for (i=0; i < NUM_TESTS; i++){
-        printf("Testing: yy_scan_string(%s): ", tests[i]);
-        state = yy_scan_string(tests[i]);
-        yylex();
+        printf("Testing: test_scan_string(%s): ", tests[i]);
+        state = test_scan_string(tests[i]);
+        testlex();
         yy_delete_buffer(state);
         printf("... %s\n", tests_ok[i] ? "OK" : "FAILED");
     }

--- a/tests/posixly_correct.l
+++ b/tests/posixly_correct.l
@@ -63,9 +63,9 @@ int main (void)
 
     /* Run the tests */
     for (i=0; i < NUM_TESTS; i++){
-        printf("Testing: yy_scan_string(%s): ", tests[i]);
-        state = yy_scan_string(tests[i]);
-        yylex();
+        printf("Testing: test_scan_string(%s): ", tests[i]);
+        state = test_scan_string(tests[i]);
+        testlex();
         yy_delete_buffer(state);
         printf("... %s\n", tests_ok[i] ? "OK" : "FAILED");
     }

--- a/tests/pthread.l
+++ b/tests/pthread.l
@@ -78,14 +78,14 @@ static int process_text(char* s, yyscan_t  scanner);
 <INITIAL,STATE_1,STATE_2>[[:space:]\r\n]+  { }
 %%
 
-int yywrap( yyscan_t  scanner) {
+int testwrap( yyscan_t  scanner) {
     (void)scanner;
     return 1;
 }
 static int process_text(char* s, yyscan_t  scanner)
 {
     (void)scanner;
-    return (int)(*s) + (int) *(s + yyget_leng(scanner)-1);
+    return (int)(*s) + (int) *(s + testget_leng(scanner)-1);
 }
 
 int main(int ARGC, char *ARGV[]);
@@ -136,19 +136,19 @@ static void * thread_func ( void* arg )
 
         pthread_mutex_lock ( &file_locks[ next ] );
 
-        yylex_init( &scanner );
+        testlex_init( &scanner );
         /*printf("Scanning file %s  #%d\n",filenames[next],i); fflush(stdout); */
         if((fp = fopen(filenames[next],"r"))==NULL) {
             perror("fopen");
             return NULL;
         }
-        yyset_in(fp,scanner);
+        testset_in(fp,scanner);
 
-        while( yylex( scanner) != 0)
+        while( testlex( scanner) != 0)
         {
         }
         fclose(fp);
-        yylex_destroy(scanner);
+        testlex_destroy(scanner);
         pthread_mutex_unlock ( &file_locks[ next ] );
     }
     return NULL;

--- a/tests/quotes.l
+++ b/tests/quotes.l
@@ -38,6 +38,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include "config.h"
+#include <assert.h>
 /*#include "parser.h" */
 
 /* sect 1 block    [ 1 ]        TEST_XXX */
@@ -74,6 +75,7 @@ f       return 1+foo(a[b[c[0]]]);
             /* action block  [[[ 3 ]]]      TEST_XXX */
             /* action block [[[[ 4 ]]]]     TEST_XXX */
             /* action block ]] unmatched [[ TEST_XXX */
+            assert(!strcmp("m4_define(alpha, beta)", "m4_""define(alpha, beta)"));
             return 1+foo(a[b[c[0]]]);  //   TEST_XXX
          }
 %%
@@ -88,13 +90,17 @@ static int bar (int i){
 }
 int main(void);
 
+#define CONCAT_IDENTS(a, b) a##b
 int
 main (void)
 {
-    yyin = stdin;
+    // m4_m4exit(100)
+    FILE *M4_YY_NOT_IN_HEADER = stdin;
+    yyin = CONCAT_IDENTS(M4_, YY_NOT_IN_HEADER);
     yyout = stdout;
     while (yylex())
         ;
+    assert(!strcmp("YY_G( alpha)", "Y""Y_G( alpha)"));
     printf("TEST RETURNING OK.\n");
     return bar(0);
 }

--- a/tests/reject.l4
+++ b/tests/reject.l4
@@ -47,7 +47,7 @@ int main ( int argc, char** argv )
     M4_YY_DECL_GUTS_VAR();
 
 #ifdef TEST_IS_REENTRANT
-    yylex_init(&yyscanner);
+    testlex_init(&yyscanner);
 #else
     (void)yyscanner;
 #endif
@@ -67,13 +67,13 @@ int main ( int argc, char** argv )
             YY_FATAL_ERROR("could not open input file for reading");
         yyin = fp;
     }
-    while(yylex(M4_YY_CALL_ONLY_ARG) != 0)
+    while(testlex(M4_YY_CALL_ONLY_ARG) != 0)
         ;
         
 #ifdef TEST_HAS_TABLES_EXTERNAL
-    yytables_destroy(M4_YY_CALL_ONLY_ARG);
+    testtables_destroy(M4_YY_CALL_ONLY_ARG);
 #endif
-    yylex_destroy(M4_YY_CALL_ONLY_ARG);
+    testlex_destroy(M4_YY_CALL_ONLY_ARG);
 
     if(argc < 0) /* silence the compiler */
         yyscanner = (void*)fp;

--- a/tests/rescan_nr.direct.l
+++ b/tests/rescan_nr.direct.l
@@ -58,14 +58,14 @@ main (int argc, char* const argv[])
         return 1;
     }
 
-    yyset_out ( stdout);
+    testset_out ( stdout);
 
     for (i=0; i <  4; ++i){
         rewind(fp);
-        yyset_in  ( fp);
-        while( yylex() )
+        testset_in  ( fp);
+        while( testlex() )
             ;
-        yylex_destroy();
+        testlex_destroy();
     }
     printf("TEST RETURNING OK.\n");
     return 0;

--- a/tests/rescan_r.direct.l
+++ b/tests/rescan_r.direct.l
@@ -60,18 +60,18 @@ main (int argc, char* const argv[])
     }
 
     printf("Test 1: Reusing same scanner.\n");
-    yylex_init( &yyscanner );
-    yyset_out ( stdout, yyscanner);
+    testlex_init( &yyscanner );
+    testset_out ( stdout, yyscanner);
 
     for (i=0; i <  4; ++i){
 
         rewind(fp);
-        yyset_in  ( fp, yyscanner);
+        testset_in  ( fp, yyscanner);
 
-        while( yylex(yyscanner) )
+        while( testlex(yyscanner) )
             ;
     }
-    yylex_destroy( yyscanner );
+    testlex_destroy( yyscanner );
     printf("Test 1 OK\n\n");
 
     printf("Test 2: Rescanning with new scanner each time.\n");
@@ -80,14 +80,14 @@ main (int argc, char* const argv[])
 
     for (i=0; i < 4; ++i){
         yyscan_t  s;
-        yylex_init( &s );
-        yyset_out ( stdout, s);
+        testlex_init( &s );
+        testset_out ( stdout, s);
         rewind(fp);
-        yyset_in  ( fp, s);
+        testset_in  ( fp, s);
 
-        while( yylex(s) )
+        while( testlex(s) )
             ;
-        yylex_destroy( s );
+        testlex_destroy( s );
     }
     printf("Test 2 OK\n\n");
 

--- a/tests/string_nr.l
+++ b/tests/string_nr.l
@@ -67,29 +67,29 @@ main (void)
 
 
     /* Scan a good string. */
-    printf("Testing: yy_scan_string(%s): ",INPUT_STRING_1); fflush(stdout);
-    state = yy_scan_string ( INPUT_STRING_1 );
-    yylex();
+    printf("Testing: test_scan_string(%s): ",INPUT_STRING_1); fflush(stdout);
+    state = test_scan_string ( INPUT_STRING_1 );
+    testlex();
     yy_delete_buffer(state);
 
     /* Scan only the first 12 chars of a string. */
-    printf("Testing: yy_scan_bytes(%s): ",INPUT_STRING_2); fflush(stdout);
-    state = yy_scan_bytes  ( INPUT_STRING_2, 12 );
-    yylex();
-    yy_delete_buffer(state);
+    printf("Testing: test_scan_bytes(%s): ",INPUT_STRING_2); fflush(stdout);
+    state = test_scan_bytes  ( INPUT_STRING_2, 12 );
+    testlex();
+    test_delete_buffer(state);
 
     /* Scan directly from a buffer.
        We make a copy, since the buffer will be modified by flex.*/
-    printf("Testing: yy_scan_buffer(%s): ",INPUT_STRING_1); fflush(stdout);
+    printf("Testing: test_scan_buffer(%s): ",INPUT_STRING_1); fflush(stdout);
     len = strlen(INPUT_STRING_1) + 2;
     buf = malloc(len);
     strcpy( buf, INPUT_STRING_1);
     buf[ len -2 ]  = 0; /* Flex requires two NUL bytes at end of buffer. */
     buf[ len -1 ] =0;
 
-    state = yy_scan_buffer( buf, len );
-    yylex();
-    yy_delete_buffer(state);
+    state = test_scan_buffer( buf, len );
+    testlex();
+    test_delete_buffer(state);
     
     printf("TEST RETURNING OK.\n");
     return 0;

--- a/tests/string_r.l
+++ b/tests/string_r.l
@@ -68,35 +68,35 @@ main (void)
 
 
     /* Scan a good string. */
-    printf("Testing: yy_scan_string(%s): ",INPUT_STRING_1); fflush(stdout);
-    yylex_init(&scanner);
-    state = yy_scan_string ( INPUT_STRING_1 ,scanner);
-    yylex(scanner);
-    yy_delete_buffer(state, scanner);
-    yylex_destroy(scanner);
+    printf("Testing: test_scan_string(%s): ",INPUT_STRING_1); fflush(stdout);
+    testlex_init(&scanner);
+    state = test_scan_string ( INPUT_STRING_1 ,scanner);
+    testlex(scanner);
+    test_delete_buffer(state, scanner);
+    testlex_destroy(scanner);
 
     /* Scan only the first 12 chars of a string. */
-    printf("Testing: yy_scan_bytes(%s): ",INPUT_STRING_2); fflush(stdout);
-    yylex_init(&scanner);
-    state = yy_scan_bytes  ( INPUT_STRING_2, 12 ,scanner);
-    yylex(scanner);
-    yy_delete_buffer(state,scanner);
-    yylex_destroy(scanner);
+    printf("Testing: test_scan_bytes(%s): ",INPUT_STRING_2); fflush(stdout);
+    testlex_init(&scanner);
+    state = test_scan_bytes  ( INPUT_STRING_2, 12 ,scanner);
+    testlex(scanner);
+    test_delete_buffer(state,scanner);
+    testlex_destroy(scanner);
 
     /* Scan directly from a buffer.
        We make a copy, since the buffer will be modified by flex.*/
-    printf("Testing: yy_scan_buffer(%s): ",INPUT_STRING_1); fflush(stdout);
+    printf("Testing: test_scan_buffer(%s): ",INPUT_STRING_1); fflush(stdout);
     len = strlen(INPUT_STRING_1) + 2;
     buf = malloc(len);
     strcpy( buf, INPUT_STRING_1);
     buf[ len -2 ]  = 0; /* Flex requires two NUL bytes at end of buffer. */
     buf[ len -1 ] =0;
 
-    yylex_init(&scanner);
-    state = yy_scan_buffer( buf, len ,scanner);
-    yylex(scanner);
-    yy_delete_buffer(state,scanner);
-    yylex_destroy(scanner);
+    testlex_init(&scanner);
+    state = test_scan_buffer( buf, len ,scanner);
+    testlex(scanner);
+    test_delete_buffer(state,scanner);
+    testlex_destroy(scanner);
     
     printf("TEST RETURNING OK.\n");
     return 0;


### PR DESCRIPTION
This patch fixes M4 quotation in section 3, using the same technique used elsewhere.  This uncovered numerous bugs in the test suite due to using `%option prefix="test"` but not prefixing all identifiers used by Flex correctly.