### PR TITLE
Fix yyrestart(NULL) SEGV.

### DIFF
--- a/src/flex.skl
+++ b/src/flex.skl
@@ -2056,7 +2056,7 @@ static void yy_load_buffer_state  (M4_YY_DEF_ONLY_ARG)
 	b->yy_input_file = file;
 %endif
 %if-c++-only
-	b->yy_input_file = file.rdbuf();
+	b->yy_input_file = (&file == 0) ? NULL : file.rdbuf();
 %endif
 	b->yy_fill_buffer = 1;
 

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -74,6 +74,7 @@ simple_tests = \
 	ccl \
 	cxx_basic \
 	cxx_multiple_scanners \
+	cxx_restart \
 	debug_nr \
 	debug_r \
 	extended \
@@ -133,6 +134,7 @@ c_cxx_nr_SOURCES = c_cxx_nr.lll
 c_cxx_r_SOURCES = c_cxx_r.lll
 ccl_SOURCES = ccl.l
 cxx_basic_SOURCES = cxx_basic.ll
+cxx_restart_SOURCES = cxx_restart.ll
 cxx_multiple_scanners_SOURCES = cxx_multiple_scanners_main.cc cxx_multiple_scanners_1.ll cxx_multiple_scanners_2.ll
 cxx_yywrap_i3_SOURCES = cxx_yywrap.ll
 debug_nr_SOURCES = debug_nr.l
@@ -214,6 +216,7 @@ CLEANFILES = \
 	cxx_basic.cc \
 	cxx_multiple_scanners_1.cc \
 	cxx_multiple_scanners_2.cc \
+	cxx_restart.cc \
 	cxx_yywrap.cc \
 	debug_nr.c \
 	debug_r.c \
@@ -281,6 +284,7 @@ EXTRA_DIST = \
 	ccl.txt \
 	cxx_basic.txt \
 	cxx_multiple_scanners.txt \
+	cxx_restart.txt \
 	cxx_yywrap.txt \
 	debug_nr.txt \
 	debug_r.txt \

--- a/tests/cxx_restart.ll
+++ b/tests/cxx_restart.ll
@@ -1,0 +1,51 @@
+/*
+ * This file is part of flex.
+ * 
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 
+ * Neither the name of the University nor the names of its contributors
+ * may be used to endorse or promote products derived from this software
+ * without specific prior written permission.
+ * 
+ * THIS SOFTWARE IS PROVIDED ``AS IS'' AND WITHOUT ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, WITHOUT LIMITATION, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE.
+ */
+
+%{
+
+#include "config.h"
+
+%}
+
+%option 8bit prefix="test"
+%option warn c++
+%option nounput nomain noinput noyywrap 
+
+%%
+
+.              { }
+
+%%
+
+int main(void);
+
+int
+main (void)
+{
+    yyFlexLexer f;
+    f.switch_streams(&std::cin, &std::cout);
+    f.yylex();
+    f.yyrestart(NULL);
+    std::cout << "TEST RETURNING OK." << std::endl;
+    return 0;
+}

--- a/tests/cxx_restart.txt
+++ b/tests/cxx_restart.txt
@@ -1,0 +1,2 @@
+0000 foo 1111 foo 0000 bar
+0000 foo 1111 foo 0000 bar


### PR DESCRIPTION
When I made the scanner use C++ stream references, I screwed up the semantics of yyrestart(NULL). 

If I ever get finished with my C++ overhaul this will cease being a problem, but for now I've added a test and fixed my segfault.  Sorry, world!