### PR TITLE
Improved M4 quotation

### DIFF
--- a/src/dfa.c
+++ b/src/dfa.c
@@ -531,12 +531,12 @@ void ntod (void)
 		 */
 		if (gentables)
 			out_str_dec
-				("static yyconst %s yy_nxt[][%d] =\n    {\n",
+				("static const %s yy_nxt[][%d] =\n    {\n",
 				 long_align ? "flex_int32_t" : "flex_int16_t",
 				 num_full_table_rows);
 		else {
 			out_dec ("#undef YY_NXT_LOLEN\n#define YY_NXT_LOLEN (%d)\n", num_full_table_rows);
-			out_str ("static yyconst %s *yy_nxt =0;\n",
+			out_str ("static const %s *yy_nxt =0;\n",
 				 long_align ? "flex_int32_t" : "flex_int16_t");
 		}
 

--- a/src/gen.c
+++ b/src/gen.c
@@ -53,30 +53,30 @@ static int indent_level = 0;	/* each level is 8 spaces */
 static const char *get_int16_decl (void)
 {
 	return (gentables)
-		? "static yyconst flex_int16_t %s[%d] =\n    {   0,\n"
-		: "static yyconst flex_int16_t * %s = 0;\n";
+		? "static const flex_int16_t %s[%d] =\n    {   0,\n"
+		: "static const flex_int16_t * %s = 0;\n";
 }
 
 
 static const char *get_int32_decl (void)
 {
 	return (gentables)
-		? "static yyconst flex_int32_t %s[%d] =\n    {   0,\n"
-		: "static yyconst flex_int32_t * %s = 0;\n";
+		? "static const flex_int32_t %s[%d] =\n    {   0,\n"
+		: "static const flex_int32_t * %s = 0;\n";
 }
 
 static const char *get_state_decl (void)
 {
 	return (gentables)
-		? "static yyconst yy_state_type %s[%d] =\n    {   0,\n"
-		: "static yyconst yy_state_type * %s = 0;\n";
+		? "static const yy_state_type %s[%d] =\n    {   0,\n"
+		: "static const yy_state_type * %s = 0;\n";
 }
 
 static const char *get_yy_char_decl (void)
 {
 	return (gentables)
-		? "static yyconst YY_CHAR %s[%d] =\n    {   0,\n"
-		: "static yyconst YY_CHAR * %s = 0;\n";
+		? "static const YY_CHAR %s[%d] =\n    {   0,\n"
+		: "static const YY_CHAR * %s = 0;\n";
 }
 
 /* Indent to the current level. */
@@ -339,9 +339,9 @@ void genctbl (void)
 
 	/* Table of verify for transition and offset to next state. */
 	if (gentables)
-		out_dec ("static yyconst struct yy_trans_info yy_transition[%d] =\n    {\n", tblend + numecs + 1);
+		out_dec ("static const struct yy_trans_info yy_transition[%d] =\n    {\n", tblend + numecs + 1);
 	else
-		outn ("static yyconst struct yy_trans_info *yy_transition = 0;");
+		outn ("static const struct yy_trans_info *yy_transition = 0;");
 
 	/* We want the transition to be represented as the offset to the
 	 * next state, not the actual state number, which is what it currently
@@ -413,9 +413,9 @@ void genctbl (void)
 
 	/* Table of pointers to start states. */
 	if (gentables)
-		out_dec ("static yyconst struct yy_trans_info *yy_start_state_list[%d] =\n", lastsc * 2 + 1);
+		out_dec ("static const struct yy_trans_info *yy_start_state_list[%d] =\n", lastsc * 2 + 1);
 	else
-		outn ("static yyconst struct yy_trans_info **yy_start_state_list =0;");
+		outn ("static const struct yy_trans_info **yy_start_state_list =0;");
 
 	if (gentables) {
 		outn ("    {");
@@ -796,7 +796,7 @@ void gen_next_match (void)
 	else if (fullspd) {
 		indent_puts ("{");
 		indent_puts
-			("yyconst struct yy_trans_info *yy_trans_info;\n");
+			("const struct yy_trans_info *yy_trans_info;\n");
 		indent_puts ("YY_CHAR yy_c;\n");
 		indent_put2s ("for ( yy_c = %s;", char_map);
 		indent_puts
@@ -963,7 +963,7 @@ void gen_NUL_trans (void)
 		out_dec ("int yy_c = %d;\n", NUL_ec);
 
 		indent_puts
-			("yyconst struct yy_trans_info *yy_trans_info;\n");
+			("const struct yy_trans_info *yy_trans_info;\n");
 		indent_puts
 			("yy_trans_info = &yy_current_state[(unsigned int) yy_c];");
 		indent_puts ("yy_current_state += yy_trans_info->yy_nxt;");
@@ -2150,7 +2150,11 @@ void make_tables (void)
 
 	if (sectnum == 3) {
 		OUT_BEGIN_CODE ();
+                if (!no_section3_escape)
+                   fputs("[[", stdout);
 		(void) flexscan ();	/* copy remainder of input to output */
+                if (!no_section3_escape)
+                   fputs("]]", stdout);
 		OUT_END_CODE ();
 	}
 }

--- a/src/main.c
+++ b/src/main.c
@@ -127,8 +127,8 @@ static char outfile_path[MAXLINE];
 static int outfile_created = 0;
 static char *skelname = NULL;
 static int _stdout_closed = 0; /* flag to prevent double-fclose() on stdout. */
-const char *escaped_qstart = "[[]]M4_YY_NOOP[M4_YY_NOOP[M4_YY_NOOP[[]]";
-const char *escaped_qend   = "[[]]M4_YY_NOOP]M4_YY_NOOP]M4_YY_NOOP[[]]";
+const char *escaped_qstart = "]]M4_YY_NOOP[M4_YY_NOOP[M4_YY_NOOP[[";
+const char *escaped_qend   = "]]M4_YY_NOOP]M4_YY_NOOP]M4_YY_NOOP[[";
 
 /* For debugging. The max number of filters to apply to skeleton. */
 static int preproc_level = 1000;
@@ -640,7 +640,7 @@ void flexend (int exit_status)
 				"yypop_buffer_state",
 				"yyensure_buffer_stack",
                 "yyalloc",
-                "yyconst",
+                "const",
                 "yyextra",
                 "yyfree",
                 "yyget_debug",
@@ -1641,7 +1641,7 @@ void readin (void)
 
 	OUT_BEGIN_CODE ();
 	if (fullspd)
-		outn ("typedef yyconst struct yy_trans_info *yy_state_type;");
+		outn ("typedef const struct yy_trans_info *yy_state_type;");
 	else if (!C_plus_plus)
 		outn ("typedef int yy_state_type;");
 	OUT_END_CODE ();

--- a/src/nfa.c
+++ b/src/nfa.c
@@ -287,6 +287,7 @@ void    finish_rule (int mach, int variable_trail_rule, int headcnt, int trailcn
 		add_action ("YY_RULE_SETUP\n");
 
 	line_directive_out(NULL, 1);
+        add_action("[[");
 }
 
 

--- a/src/parse.y
+++ b/src/parse.y
@@ -140,7 +140,7 @@ goal		:  initlex sect1 sect1end sect2 initforrule
 			else
 				add_action( "ECHO" );
 
-			add_action( ";\n\tYY_BREAK\n" );
+			add_action( ";\n\tYY_BREAK]]\n" );
 			}
 		;
 
@@ -977,6 +977,7 @@ void build_eof_action(void)
 		}
 
 	line_directive_out(NULL, 1);
+        add_action("[[");
 
 	/* This isn't a normal rule after all - don't count it as
 	 * such, so we don't have any holes in the rule numbering

--- a/src/scan.l
+++ b/src/scan.l
@@ -38,8 +38,8 @@ extern bool tablesverify, tablesext;
 extern int trlcontxt; /* Set in  parse.y for each rule. */
 extern const char *escaped_qstart, *escaped_qend;
 
-#define M4QSTART "[["
-#define M4QEND "]]"
+#define M4QSTART "[""["
+#define M4QEND "]""]"
 
 #define SECT3_ESCAPED_QSTART "[" M4QEND M4QSTART "[" M4QEND M4QSTART
 #define SECT3_ESCAPED_QEND M4QEND "]" M4QSTART M4QEND "]" M4QSTART
@@ -51,8 +51,8 @@ extern const char *escaped_qstart, *escaped_qend;
 		action_define( def, 1 ); \
 	}
 
-#define ACTION_ECHO_QSTART add_action (escaped_qstart)
-#define ACTION_ECHO_QEND   add_action (escaped_qend)
+#define ACTION_ECHO_QSTART add_action (SECT3_ESCAPED_QSTART)
+#define ACTION_ECHO_QEND   add_action (SECT3_ESCAPED_QEND)
 
 #define ACTION_M4_IFDEF(def, should_define) \
     do{ \
@@ -101,6 +101,10 @@ extern const char *escaped_qstart, *escaped_qend;
 	if ( getenv("POSIXLY_CORRECT") ) \
 		posix_compat = true;
 
+#define START_CODEBLOCK do { add_action(M4QSTART); BEGIN(CODEBLOCK); } while(0)
+#define END_CODEBLOCK do { add_action(M4QEND); BEGIN(INITIAL); } while (0)
+#define CODEBLOCK_QSTART "[]""][""[""[]""][""["
+#define CODEBLOCK_QEND "]""]""][""[""]""]""][""["
 %}
 
 %option caseless nodefault noreject stack noyy_top_state
@@ -112,7 +116,7 @@ extern const char *escaped_qstart, *escaped_qend;
 %x GROUP_WITH_PARAMS
 %x GROUP_MINUS_PARAMS
 %x EXTENDED_COMMENT
-%x COMMENT_DISCARD
+%x COMMENT_DISCARD CODE_COMMENT
 %x SECT3_NOESCAPE
 %x CHARACTER_CONSTANT
 
@@ -149,8 +153,8 @@ M4QEND      "]]"
 
 
 <INITIAL>{
-	^{WS}		indented_code = true; BEGIN(CODEBLOCK);
-	^"/*"		ACTION_ECHO; yy_push_state( COMMENT );
+	^{WS}		indented_code = true; START_CODEBLOCK;
+	^"/*"		add_action("/*[""["); yy_push_state( COMMENT );
 	^#{OPTWS}line{WS}	yy_push_state( LINEDIR );
 	^"%s"{NAME}?	return SCDECL;
 	^"%x"{NAME}?	return XSCDECL;
@@ -158,7 +162,7 @@ M4QEND      "]]"
 			++linenum;
 			line_directive_out(NULL, 1);
 			indented_code = false;
-			BEGIN(CODEBLOCK);
+			START_CODEBLOCK;
 			}
     ^"%top"[[:blank:]]*"{"[[:blank:]]*{NL}    {
                 brace_start_line = linenum;
@@ -213,11 +217,17 @@ M4QEND      "]]"
 }
 
 
-<COMMENT>{
-	"*/"		ACTION_ECHO; yy_pop_state();
-	"*"		ACTION_ECHO;
-	[^*\n]      ACTION_ECHO;
+<COMMENT,CODE_COMMENT>{ /* */
+        [^\[\]\*\n]*  ACTION_ECHO;
+        .           ACTION_ECHO;
+
 	{NL}	    ++linenum; ACTION_ECHO;
+}
+<COMMENT>{
+	"*/"	    add_action("*/]""]"); yy_pop_state();
+}
+<CODE_COMMENT>{
+        "*/"        ACTION_ECHO; yy_pop_state();
 }
 
 <COMMENT_DISCARD>{
@@ -245,21 +255,20 @@ M4QEND      "]]"
 			}
 	.		/* ignore spurious characters */
 }
-<ACTION,CODEBLOCK,ACTION_STRING,PERCENT_BRACE_ACTION,COMMENT,CHARACTER_CONSTANT>{
-   M4|YY|m4 add_action(M4QSTART); ACTION_ECHO; add_action(M4QEND);
+<ACTION,CODEBLOCK,ACTION_STRING,PERCENT_BRACE_ACTION,CHARACTER_CONSTANT,
+COMMENT,CODE_COMMENT>{
    {M4QSTART}   ACTION_ECHO_QSTART;
    {M4QEND}     ACTION_ECHO_QEND;
 }
 
 <CODEBLOCK>{
-	^"%}".*{NL}	++linenum; BEGIN(INITIAL);
-	.	        ACTION_ECHO;
-
+	^"%}".*{NL}	++linenum; END_CODEBLOCK;
+	[^\n%\[\]]*         ACTION_ECHO;
+        .		ACTION_ECHO;
 	{NL}		{
 			++linenum;
 			ACTION_ECHO;
-			if ( indented_code )
-				BEGIN(INITIAL);
+			if ( indented_code ) END_CODEBLOCK;
 			}
 }
 
@@ -284,13 +293,7 @@ M4QEND      "]]"
 
     {M4QSTART}  buf_strnappend(&top_buf, escaped_qstart, (int) strlen(escaped_qstart));
     {M4QEND}    buf_strnappend(&top_buf, escaped_qend, (int) strlen(escaped_qend));
-    m4|M4|YY   {
-       buf_strnappend(&top_buf, M4QSTART, 2);
-       buf_strnappend(&top_buf, yytext, 2);
-       buf_strnappend(&top_buf, M4QEND, 2);
-    }
-
-    ([^{}\r\nmMY\[\]]+)|[^{}\r\n]  {
+    ([^{}\r\n\[\]]+)|[^{}\r\n]  {
        buf_strnappend(&top_buf, yytext, yyleng);
     }
 
@@ -545,6 +548,7 @@ M4QEND      "]]"
                             yyless(amt);
                         }
                         else {
+                            add_action("]""]");
                             continued_action = true;
                             ++linenum;
                             return '\n';
@@ -614,9 +618,8 @@ M4QEND      "]]"
 
 	^"%%".*		{
 			sectnum = 3;
-			BEGIN(SECT3);
+			BEGIN(no_section3_escape ? SECT3_NOESCAPE : SECT3);
 			outn("/* Begin user sect3 */");
-                        //fwrite(M4QSTART, 1, 2, yyout);
 			yyterminate(); /* to stop the parser */
 
 			}
@@ -891,7 +894,7 @@ nmstr[yyleng - 2 - end_is_ws] = '\0';  /* chop trailing brace */
 <PERCENT_BRACE_ACTION>{
 	{OPTWS}"%}".*		bracelevel = 0;
 
-	<ACTION>"/*"		ACTION_ECHO; yy_push_state( COMMENT );
+	<ACTION>"/*"		ACTION_ECHO; yy_push_state( CODE_COMMENT );
 
 	<CODEBLOCK,ACTION>{
 		"reject"	{
@@ -912,7 +915,7 @@ nmstr[yyleng - 2 - end_is_ws] = '\0';  /* chop trailing brace */
 			     (doing_codeblock && indented_code) )
 				{
 				if ( doing_rule_action )
-					add_action( "\tYY_BREAK\n" );
+					add_action( "\tYY_BREAK]]\n" );
 
 				doing_rule_action = doing_codeblock = false;
 				BEGIN(SECT2);
@@ -937,7 +940,7 @@ nmstr[yyleng - 2 - end_is_ws] = '\0';  /* chop trailing brace */
 			if ( bracelevel == 0 )
 				{
 				if ( doing_rule_action )
-					add_action( "\tYY_BREAK\n" );
+					add_action( "\tYY_BREAK]]\n" );
 
 				doing_rule_action = false;
 				BEGIN(SECT2);
@@ -960,7 +963,7 @@ nmstr[yyleng - 2 - end_is_ws] = '\0';  /* chop trailing brace */
 	.		ACTION_ECHO;
 }
 
-<COMMENT,COMMENT_DISCARD,ACTION,ACTION_STRING,CHARACTER_CONSTANT><<EOF>>	{
+<COMMENT,CODE_COMMENT,COMMENT_DISCARD,ACTION,ACTION_STRING,CHARACTER_CONSTANT><<EOF>>	{
 			synerr( _( "EOF encountered inside an action" ) );
 			yyterminate();
 			}
@@ -979,25 +982,26 @@ nmstr[yyleng - 2 - end_is_ws] = '\0';  /* chop trailing brace */
 			return CHAR;
 			}
 
-
 <SECT3>{
-    "M4"|"m4"|"YY" {
-        if (no_section3_escape) {
-           ECHO;
-        } else
-           fprintf (yyout, "[[%s]]", yytext);
+    {M4QSTART}   fputs(escaped_qstart, yyout);
+    {M4QEND}     fputs(escaped_qend, yyout);
+    [^\[\]\n]*(\n?) ECHO;
+    .|\n         ECHO;
+    <<EOF>>      {
+        sectnum = 0;
+        yyterminate();
     }
-    {M4QSTART}  fwrite (escaped_qstart, 1, strlen(escaped_qstart) - 0, yyout);
-    {M4QEND}    fwrite (escaped_qend, 1, strlen(escaped_qend) - 0, yyout);
-	[^\[\]MmY\n]*(\n?) ECHO;
-	(.|\n)      ECHO;
-	<<EOF>>		{
-           //fwrite(M4QEND, 1, strlen(M4QEND), yyout);
-           sectnum = 0;
-           yyterminate();
-        }
 }
-
+<SECT3_NOESCAPE>{
+    {M4QSTART}  fprintf(yyout, "[""[%s]""]", escaped_qstart);
+    {M4QEND}    fprintf(yyout, "[""[%s]""]", escaped_qend);
+    [^\[\]\n]*(\n?) ECHO;
+    (.|\n)      ECHO;
+    <<EOF>>		{
+       sectnum = 0;
+       yyterminate();
+    }
+}
 <*>.|\n			format_synerr( _( "bad character: %s" ), yytext );
 
 %%

--- a/src/scan.l
+++ b/src/scan.l
@@ -139,8 +139,8 @@ CCL_EXPR	("[:"^?[[:alpha:]]+":]")
 
 LEXOPT		[aceknopr]
 
-M4QSTART    "[["
-M4QEND      "]]"
+M4QSTART    "[""["
+M4QEND      "]""]"
 
 %%
 	static int bracelevel, didadef, indented_code;
@@ -915,7 +915,7 @@ nmstr[yyleng - 2 - end_is_ws] = '\0';  /* chop trailing brace */
 			     (doing_codeblock && indented_code) )
 				{
 				if ( doing_rule_action )
-					add_action( "\tYY_BREAK]]\n" );
+					add_action( "\tYY_BREAK]""]\n" );
 
 				doing_rule_action = doing_codeblock = false;
 				BEGIN(SECT2);
@@ -940,7 +940,7 @@ nmstr[yyleng - 2 - end_is_ws] = '\0';  /* chop trailing brace */
 			if ( bracelevel == 0 )
 				{
 				if ( doing_rule_action )
-					add_action( "\tYY_BREAK]]\n" );
+					add_action( "\tYY_BREAK]""]\n" );
 
 				doing_rule_action = false;
 				BEGIN(SECT2);

--- a/tests/bison_yylval_scanner.l
+++ b/tests/bison_yylval_scanner.l
@@ -52,7 +52,7 @@ enum yesno_t { no=0, yes=1 };
 "</"       { NEED_TAG_NAME= yes; yy_push_state( IN_TAG, yyscanner); return LTSLASH;}
 "<"[^[:alpha:]]  { yy_push_state(DISCARD_THRU_GT,yyscanner); }
 "<"        { NEED_TAG_NAME= yes; yy_push_state( IN_TAG, yyscanner); return  LT; }
-[^<]{1,512} { yyget_lval(yyscanner)->str = STRDUP(yytext); return TEXT;}
+[^<]{1,512} { testget_lval(yyscanner)->str = STRDUP(yytext); return TEXT;}
 }
 <IN_TAG>{
 ">"  { yy_pop_state( yyscanner ); return GT; }

--- a/tests/include_by_push.direct.l
+++ b/tests/include_by_push.direct.l
@@ -55,7 +55,7 @@ int error = 0;
         error = 1;
         yyterminate();
     }
-    yypush_buffer_state( yy_create_buffer( yyin, YY_BUF_SIZE ));
+    testpush_buffer_state( yy_create_buffer( yyin, YY_BUF_SIZE ));
     BEGIN(0);
     }
 .|\n  {
@@ -67,7 +67,7 @@ int error = 0;
 
 <<EOF>> {
            fclose(yyin);
-           yypop_buffer_state();
+           testpop_buffer_state();
            if(!YY_CURRENT_BUFFER)
                yyterminate();
         }


### PR DESCRIPTION
This fixes M4 quotation of certain strings beginning with `yy` (in
section 3 of the input file only) and character literals.  The new
quotation method is also less brittle and faster.

Tests that relied on the old behavior were fixed.

Also, `yyconst` is no longer defined; use `const` (which it
unconditionally was defined to) instead.