### PR TITLE
Fix cross compiling

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -101,6 +101,16 @@ else
    AC_MSG_WARN(no indent program found: make indent target will not function)
 fi
 
+# Check for a modern flex.
+
+AC_MSG_CHECKING(if $LEX is $PACKAGE $PACKAGE_VERSION)
+AM_CONDITIONAL([STAGE1FLEX], [test "`$LEX --version`" != "$PACKAGE $PACKAGE_VERSION"])
+AM_COND_IF([STAGE1FLEX],
+           [AC_MSG_RESULT(no); \
+            test "x$build" != "x$host" && \
+            AC_MSG_WARN(cross compiling but using stage1flex)],
+           [AC_MSG_RESULT(yes)])
+
 # checks for headers
 
 AC_CHECK_HEADERS([inttypes.h libintl.h limits.h locale.h malloc.h netinet/in.h regex.h unistd.h])

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -6,16 +6,19 @@ LIBS = @LIBS@
 m4 = @M4@
 
 bin_PROGRAMS = flex
-noinst_PROGRAMS = stage1flex
 lib_LTLIBRARIES = \
 	libfl.la \
 	libfl_pic.la
+
+if STAGE1FLEX
+noinst_PROGRAMS = stage1flex
 
 stage1flex_SOURCES = \
 	scan.l \
 	$(COMMON_SOURCES)
 
 stage1flex_CFLAGS = $(AM_CFLAGS)
+endif
 
 flex_SOURCES = \
 	$(COMMON_SOURCES)
@@ -89,15 +92,21 @@ skel.c: flex.skl mkskel.sh flexint.h tables_shared.h tables_shared.c
 	  $(SHELL) $(srcdir)/mkskel.sh > $@.tmp
 	mv $@.tmp $@
 
+if STAGE1FLEX
 stage1scan.c: scan.l stage1flex$(EXEEXT)
 	./stage1flex$(EXEEXT) -o $@ $<
+stage1scan.c : parse.h
+else
+stage1scan.c: scan.l
+	$(LEX) -o $@ $<
+stage1scan.c : parse.h
+endif
 
 # make needs to be told to make parse.h so that parallelized runs will
 # not fail.
 
 main.c : parse.h
 scan.c : parse.h
-stage1scan.c : parse.h
 yylex.c : parse.h
 
 # Run GNU indent on sources. Don't run this unless all the sources compile cleanly.


### PR DESCRIPTION
Detect if the build lexer is sufficient. If not, build stage1flex but
warn if we are cross compiling as we may not be able to run the result.

This probably needs additional testing. I attempted to build a stage1flex using the build tools, however the changes became quite invasive as libcompat.la also needed to be rebuilt to use the build compiler and flags. This method seemed easier and is probably more acceptable for cross compiling.

Fixes #78.
