### PR TITLE
Only regenerate the man page when required

### DIFF
--- a/doc/Makefile.am
+++ b/doc/Makefile.am
@@ -23,8 +23,8 @@ CLEANFILES = \
 	flex.vr \
 	flex.vrs
 
-flex.1: ../src/flex$(EXEEXT)
+flex.1: $(top_srcdir)/configure.ac $(top_srcdir)/src/flex.skl $(top_srcdir)/src/options.c $(top_srcdir)/src/options.h | $(top_builddir)/src/flex$(EXEEXT)
 	$(help2man) --name='$(PACKAGE_NAME)' --section=1 \
 	--source='The Flex Project' --manual='Programming' \
-	--output=$@ $< \
+	--output=$@ $| \
 	|| rm -f $@


### PR DESCRIPTION
Make the flex binary an order-only prerequisite, and add back the prerequisites from before 7cfb440. This prevents rebuilding the man page whenever the flex binary is rebuilt, which causes problems if <code>help2man</code> is not installed and will never work when cross compiling.

Fixes #108.