### PR TITLE
doc: Don't delete flex.1 during "make distclean"

### DIFF
--- a/doc/Makefile.am
+++ b/doc/Makefile.am
@@ -4,7 +4,7 @@ FLEX = $(top_builddir)/src/flex$(EXEEXT)
 
 info_TEXINFOS =	flex.texi
 dist_man_MANS = flex.1
-DISTCLEANFILES = flex.1
+MAINTAINERCLEANFILES = flex.1
 
 CLEANFILES = \
 	flex.aux \


### PR DESCRIPTION
flex.1 is pre-generated in release tarball. If we delete it, the next
"configure and make" on the source directory will then require help2man
unnecessarily.