### PR TITLE
--disable-libfl configure option 

### DIFF
--- a/CrossCompile.txt
+++ b/CrossCompile.txt
@@ -1,0 +1,37 @@
+Notes for building flex for cross-toolchain
+-------------------------------------------
+
+Flex generates scanner code for C and C++, and has no architecture-
+specific parts. Therefore flex's build system does not support
+'--target' option that people would use to configuring a cross-
+compiler. However, flex has one library, libfl, that is intended to be
+linked with flex-generated code and installed to the target system.
+
+If you are building flex intended to be used with a cross-toolchain,
+for the main flex program you should disable libfl while configuring:
+
+```bash
+./configure --disable-libfl && make && make install
+```
+
+This way you won't get a useless library built for your host system.
+
+You may run configure again and build libfl for the target.
+For example:
+
+```bash
+./configure --build=$(build-aux/config.guess) --host=${target} &&
+cd src &&
+make src/libfl.la &&
+make DESTDIR=${sysroot} install-libLTLIBRARIES
+```
+
+(For now the commands of building and installing libfl alone is tricky.
+This might be fixed in the future.)
+
+
+Notes for cross-compiling flex
+------------------------------
+
+To be documented
+

--- a/configure.ac
+++ b/configure.ac
@@ -60,6 +60,12 @@ AC_ARG_ENABLE([warnings],
 
 AC_SUBST([WARNINGFLAGS])
 
+AC_ARG_ENABLE([libfl],
+  [AS_HELP_STRING([--disable-libfl],
+                  [do not build -lfl runtime support library])],
+  [], [enable_libfl=yes])
+AM_CONDITIONAL([ENABLE_LIBFL], [test "$enable_libfl" = yes])
+
 AC_PATH_PROG([BISON], bison, no)
 AS_IF([test "$BISON" != no],[],
 	[ AC_SUBST([BISON], [\${top_srcdir}/build-aux/missing bison])

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -7,8 +7,14 @@ m4 = @M4@
 
 bin_PROGRAMS = flex
 noinst_PROGRAMS = stage1flex
-lib_LTLIBRARIES = \
-	libfl.la
+
+if ENABLE_LIBFL
+lib_LTLIBRARIES = libfl.la
+libfl_la_SOURCES = \
+	libmain.c \
+	libyywrap.c
+libfl_la_LDFLAGS = -version-info @SHARED_VERSION_INFO@
+endif
 
 stage1flex_SOURCES = \
 	scan.l \
@@ -54,12 +60,6 @@ COMMON_SOURCES = \
 	yylex.c
 
 LDADD = ../lib/libcompat.la @LIBINTL@
-
-libfl_la_SOURCES = \
-	libmain.c \
-	libyywrap.c
-
-libfl_la_LDFLAGS = -version-info @SHARED_VERSION_INFO@
 
 include_HEADERS = \
 	FlexLexer.h


### PR DESCRIPTION
Two commits in this pull request:

First commit adds --disable-libfl configure option as mentioned in GH-99. Note that I didn't add `$CC_FOR_TARGET` or `--enable-sysroot` or whatever because it would be better to keep it simple and leave those options for building a cross-compiler out.

Second commit is a draft note of building flex for a cross-toolchain. I mention how to build libfl for the target system (when flex's `configure` does not support `--target`) and install it to a so-called "sysroot" directory.

I'm not expecting flex maintainer to merge this PR directly. It's better to review my changes first. And by the way **I didn't yet update the NEWS file for this change** (so please update that for me).