### PR TITLE
Quickly fix backwards incompatible changes in 2.6.2

### DIFF
--- a/src/flex.skl
+++ b/src/flex.skl
@@ -106,7 +106,8 @@ m4_ifdef( [[M4_YY_REENTRANT]],  [[m4_define([[M4_YY_HAS_START_STACK_VARS]])]])
 m4_ifdef( [[M4_YY_PREFIX]],, [[m4_define([[M4_YY_PREFIX]], [[yy]])]])
 
 m4preproc_define(`M4_GEN_PREFIX',
-    ``m4_define(yy[[$1]], [[M4_YY_PREFIX[[$1]]m4_ifelse($'`#,0,,[[($'`@)]])]])'')
+    ``[[#define yy$1 ]]M4_YY_PREFIX[[$1]]
+m4_define([[yy$1]], [[M4_YY_PREFIX[[$1]]m4_ifelse($'`#,0,,[[($'`@)]])]])'')
 
 %if-c++-only
     /* The c++ scanner is a mess. The FlexLexer.h header file relies on the

--- a/tests/array_r.l
+++ b/tests/array_r.l
@@ -49,13 +49,13 @@ main (void)
 {
     yyscan_t lexer;
     
-	testlex_init(&lexer);
-    testset_in(stdin, lexer);
-    testset_out(stdout, lexer);
+	yylex_init(&lexer);
+    yyset_in(stdin, lexer);
+    yyset_out(stdout, lexer);
 	
-    testlex( lexer );
+    yylex( lexer );
 	
-    testlex_destroy( lexer);
+    yylex_destroy( lexer);
     printf("TEST RETURNING OK.\n");
 
     return 0;


### PR DESCRIPTION
This patch adds compatiblity `#defines` for all macros affected by`%prefix`.

Fixes #113.