### PR TITLE
Ditch libcompat.la. Link $(LIBOBJS) from src/ dir.

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -28,7 +28,7 @@ AC_INIT([the fast lexical analyser generator],[2.6.3],[flex-help@lists.sourcefor
 AC_CONFIG_SRCDIR([src/scan.l])
 AC_CONFIG_AUX_DIR([build-aux])
 LT_INIT
-AM_INIT_AUTOMAKE([-Wno-portability foreign check-news std-options dist-lzip parallel-tests 1.14.1])
+AM_INIT_AUTOMAKE([-Wno-portability foreign check-news std-options dist-lzip parallel-tests subdir-objects 1.14.1])
 AC_CONFIG_HEADER([src/config.h])
 AC_CONFIG_LIBOBJ_DIR([lib])
 AC_CONFIG_MACRO_DIR([m4])

--- a/configure.ac
+++ b/configure.ac
@@ -136,8 +136,14 @@ AC_TYPE_SIZE_T
 
 AC_FUNC_ALLOCA
 AC_FUNC_FORK
+dnl Autoconf bug: AC_FUNC_MALLOC and AC_FUNC_REALLOC might not warn of cross
+dnl compilation. Workaround this.
 AC_FUNC_MALLOC
+AS_IF([test "$cross_compiling" = yes],
+   AC_MSG_WARN([result $ac_cv_func_malloc_0_nonnull guessed because of cross compilation]))
 AC_FUNC_REALLOC
+AS_IF([test "$cross_compiling" = yes],
+   AC_MSG_WARN([result $ac_cv_func_realloc_0_nonnull guessed because of cross compilation]))
 
 AC_CHECK_FUNCS(dup2 dnl
 memset dnl

--- a/lib/Makefile.am
+++ b/lib/Makefile.am
@@ -1,4 +1,1 @@
-noinst_LTLIBRARIES = libcompat.la
-libcompat_la_SOURCES = lib.c
-libcompat_la_LIBADD = $(LTLIBOBJS)
-
+# dummy

--- a/lib/lib.c
+++ b/lib/lib.c
@@ -1,9 +1,0 @@
-/* Since building an empty library could cause problems, we provide a
- * function to go into the library. We could make this non-trivial by
- * moving something that flex treats as a library function into this
- * directory. */
-
-extern void do_nothing(void);
-
-void do_nothing(void){ return;}
-

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -59,7 +59,7 @@ COMMON_SOURCES = \
 	version.h \
 	yylex.c
 
-LDADD = ../lib/libcompat.la @LIBINTL@
+LDADD = $(LIBOBJS) @LIBINTL@
 
 include_HEADERS = \
 	FlexLexer.h


### PR DESCRIPTION
This helps bootstrapping flex as we no longer need AR or RANLIB for
such a little library.

All of its source files (malloc.c realloc.c reallocarray.c) are now
linked individually from the src/ directory.

By the way, the use of libtool on libcompat was not even recommended in
Automake manual [1], before this ditching.

[1] https://www.gnu.org/software/automake/manual/html_node/LIBOBJS.html
   "Because '$(LIBOBJS)' and '$(ALLOCA)' contain object file names that
    end with '.$(OBJEXT)', they are not suitable for Libtool libraries
    (where the expected object extension is .lo): LTLIBOBJS and LTALLOCA
    should be used instead."