### PR TITLE
Disallow '[' and ']' in prefix & overquote it

### DIFF
--- a/src/buf.c
+++ b/src/buf.c
@@ -166,7 +166,7 @@ struct Buf *buf_strdefine (struct Buf *buf, const char *str, const char *def)
  */
 struct Buf *buf_m4_define (struct Buf *buf, const char* def, const char* val)
 {
-    const char * fmt = "m4_define( [[%s]], [[%s]])m4_dnl\n";
+    const char * fmt = "m4_define( [[%s]], [[[[%s]]]])m4_dnl\n";
     char * str;
     size_t strsz;
 

--- a/src/main.c
+++ b/src/main.c
@@ -447,6 +447,8 @@ void check_options (void)
 	if ( bison_bridge_lloc)
         buf_m4_define (&m4defs_buf, "<M4_YY_BISON_LLOC>", NULL);
 
+    if (strchr(prefix, '[') || strchr(prefix, ']'))
+        flexerror(_("Prefix cannot include '[' or ']'"));
     buf_m4_define(&m4defs_buf, "M4_YY_PREFIX", prefix);
 
 	if (did_outfilename)

--- a/src/parse.y
+++ b/src/parse.y
@@ -199,7 +199,9 @@ option		:  TOK_OUTFILE '=' NAME
 		|  TOK_EXTRA_TYPE '=' NAME
 			{ extra_type = xstrdup(nmstr); }
 		|  TOK_PREFIX '=' NAME
-			{ prefix = xstrdup(nmstr); }
+			{ prefix = xstrdup(nmstr);
+                          if (strchr(prefix, '[') || strchr(prefix, ']'))
+                              flexerror(_("Prefix must not contain [ or ]")); }
 		|  TOK_YYCLASS '=' NAME
 			{ yyclass = xstrdup(nmstr); }
 		|  TOK_HEADER_FILE '=' NAME


### PR DESCRIPTION
Stop the infinite loop in #128 by overquoting the `M4_YY_PREFIX` macro, so that it is always treated as a literal by M4.  Also reject `[` or `]` in it (which would have caused a C syntax error anyway).

Fixes #128.