### PR TITLE
test: Remove BUILT_SOURCES from tests/Makefile

### DIFF
--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -339,15 +339,24 @@ FLEX = $(top_builddir)/src/flex
 
 bison_nr_main.$(OBJEXT): bison_nr_parser.h bison_nr_scanner.h
 bison_nr_scanner.$(OBJEXT): bison_nr_parser.h
+
 bison_nr_scanner.h: bison_nr_scanner.c
+	@if test ! -f $@; then rm -f $<; else :; fi
+	@if test ! -f $@; then $(MAKE) $(AM_MAKEFLAGS) $<; else :; fi
 
 bison_yylloc_main.$(OBJEXT): bison_yylloc_parser.h bison_yylloc_scanner.h
 bison_yylloc_scanner.$(OBJEXT): bison_yylloc_parser.h
+
 bison_yylloc_scanner.h: bison_yylloc_scanner.c
+	@if test ! -f $@; then rm -f $<; else :; fi
+	@if test ! -f $@; then $(MAKE) $(AM_MAKEFLAGS) $<; else :; fi
 
 bison_yylval_main.$(OBJEXT): bison_yylval_parser.h bison_yylval_scanner.h
 bison_yylval_scanner.$(OBJEXT): bison_yylval_parser.h
+
 bison_yylval_scanner.h: bison_yylval_scanner.c
+	@if test ! -f $@; then rm -f $<; else :; fi
+	@if test ! -f $@; then $(MAKE) $(AM_MAKEFLAGS) $<; else :; fi
 
 # automake does not support compiling flex scanners output in C as C++
 # so we explicitly sayhow, using the .lll suffix for the lex input file
@@ -356,18 +365,36 @@ bison_yylval_scanner.h: bison_yylval_scanner.c
 	$(FLEX) -o $@ $<
 
 header_nr_main.$(OBJEXT): header_nr_scanner.h
+
 header_nr_scanner.h: header_nr_scanner.c
+	@if test ! -f $@; then rm -f $<; else :; fi
+	@if test ! -f $@; then $(MAKE) $(AM_MAKEFLAGS) $<; else :; fi
 
 header_r_main.$(OBJEXT): header_r_scanner.h
+
 header_r_scanner.h: header_r_scanner.c
+	@if test ! -f $@; then rm -f $<; else :; fi
+	@if test ! -f $@; then $(MAKE) $(AM_MAKEFLAGS) $<; else :; fi
 
 multiple_scanners_nr_main.$(OBJEXT): multiple_scanners_nr_1.h multiple_scanners_nr_2.h
+
 multiple_scanners_nr_1.h: multiple_scanners_nr_1.c
+	@if test ! -f $@; then rm -f $<; else :; fi
+	@if test ! -f $@; then $(MAKE) $(AM_MAKEFLAGS) $<; else :; fi
+
 multiple_scanners_nr_2.h: multiple_scanners_nr_2.c
+	@if test ! -f $@; then rm -f $<; else :; fi
+	@if test ! -f $@; then $(MAKE) $(AM_MAKEFLAGS) $<; else :; fi
 
 multiple_scanners_r_main.$(OBJEXT): multiple_scanners_r_1.h multiple_scanners_r_2.h
+
 multiple_scanners_r_1.h: multiple_scanners_r_1.c
+	@if test ! -f $@; then rm -f $<; else :; fi
+	@if test ! -f $@; then $(MAKE) $(AM_MAKEFLAGS) $<; else :; fi
+
 multiple_scanners_r_2.h: multiple_scanners_r_2.c
+	@if test ! -f $@; then rm -f $<; else :; fi
+	@if test ! -f $@; then $(MAKE) $(AM_MAKEFLAGS) $<; else :; fi
 
 posixly_correct.c: posixly_correct.l $(FLEX)
 	POSIXLY_CORRECT=1 $(FLEX) -o $@ $<

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -130,8 +130,11 @@ array_r_SOURCES = array_r.l
 basic_nr_SOURCES = basic_nr.l
 basic_r_SOURCES = basic_r.l
 bison_nr_SOURCES = bison_nr_scanner.l bison_nr_parser.y bison_nr_main.c
+nodist_bison_nr_SOURCES = bison_nr_parser.h bison_nr_scanner.h
 bison_yylloc_SOURCES = bison_yylloc_scanner.l bison_yylloc_parser.y bison_yylloc_main.c
+nodist_bison_yylloc_SOURCES = bison_yylloc_parser.h bison_yylloc_scanner.h
 bison_yylval_SOURCES = bison_yylval_scanner.l bison_yylval_parser.y bison_yylval_main.c
+nodist_bison_yylval_SOURCES = bison_yylval_parser.h bison_yylval_scanner.h
 c_cxx_nr_SOURCES = c_cxx_nr.lll
 c_cxx_r_SOURCES = c_cxx_r.lll
 ccl_SOURCES = ccl.l
@@ -143,7 +146,9 @@ debug_nr_SOURCES = debug_nr.l
 debug_r_SOURCES = debug_r.l
 extended_SOURCES = extended.l
 header_nr_SOURCES = header_nr_scanner.l header_nr_main.c
+nodist_header_nr_SOURCES = header_nr_scanner.h
 header_r_SOURCES = header_r_scanner.l header_r_main.c
+nodist_header_r_SOURCES = header_r_scanner.h
 include_by_buffer_direct_SOURCES = include_by_buffer.direct.l
 include_by_push_direct_SOURCES = include_by_push.direct.l
 include_by_reentrant_direct_SOURCES = include_by_reentrant.direct.l
@@ -153,7 +158,9 @@ lineno_trailing_one_SOURCES = lineno_trailing.l
 mem_nr_SOURCES = mem_nr.l
 mem_r_SOURCES = mem_r.l
 multiple_scanners_nr_SOURCES = multiple_scanners_nr_main.c multiple_scanners_nr_1.l multiple_scanners_nr_2.l
+nodist_multiple_scanners_nr_SOURCES = multiple_scanners_nr_1.h multiple_scanners_nr_2.h
 multiple_scanners_r_SOURCES = multiple_scanners_r_main.c multiple_scanners_r_1.l multiple_scanners_r_2.l
+nodist_multiple_scanners_r_SOURCES = multiple_scanners_nr_1.h multiple_scanners_nr_2.h
 posix_SOURCES = posix.l
 posixly_correct_SOURCES = posixly_correct.l
 prefix_nr_SOURCES = prefix_nr.l
@@ -169,22 +176,8 @@ rescan_r_direct_SOURCES = rescan_r.direct.l
 string_nr_SOURCES = string_nr.l
 string_r_SOURCES = string_r.l
 top_SOURCES = top.l top_main.c
+nodist_top_SOURCES = top.h
 yyextra_SOURCES = yyextra.l
-
-BUILT_SOURCES = \
-	bison_nr_parser.h \
-	bison_nr_scanner.h \
-	bison_yylloc_parser.h \
-	bison_yylloc_scanner.h \
-	bison_yylval_parser.h \
-	bison_yylval_scanner.h \
-	header_nr_scanner.h \
-	header_r_scanner.h \
-	multiple_scanners_nr_1.h \
-	multiple_scanners_nr_2.h \
-	multiple_scanners_r_1.h \
-	multiple_scanners_r_2.h \
-	top.h
 
 # Normally, automake would distribute files built by flex. Since the
 # point of the test suite is to test the files that flex builds, and
@@ -196,6 +189,7 @@ BUILT_SOURCES = \
 # it.
 
 CLEANFILES = \
+	alloc_extra.c \
 	array_nr.c \
 	array_r.c \
 	basic_nr.c \
@@ -263,7 +257,6 @@ CLEANFILES = \
 	top.c \
 	top.h  \
 	yyextra.c \
-alloc_extra.c \
 	$(tableopts_c) \
 	$(tableopts_tables)
 
@@ -344,13 +337,16 @@ FLEX = $(top_builddir)/src/flex
 .ll.cc: $(FLEX)
 	$(FLEX) -+ -o $@ $<
 
-bison_nr_main.($OBJEXT): bison_nr_parser.h bison_nr_scanner.h
+bison_nr_main.$(OBJEXT): bison_nr_parser.h bison_nr_scanner.h
+bison_nr_scanner.$(OBJEXT): bison_nr_parser.h
 bison_nr_scanner.h: bison_nr_scanner.c
 
 bison_yylloc_main.$(OBJEXT): bison_yylloc_parser.h bison_yylloc_scanner.h
+bison_yylloc_scanner.$(OBJEXT): bison_yylloc_parser.h
 bison_yylloc_scanner.h: bison_yylloc_scanner.c
 
 bison_yylval_main.$(OBJEXT): bison_yylval_parser.h bison_yylval_scanner.h
+bison_yylval_scanner.$(OBJEXT): bison_yylval_parser.h
 bison_yylval_scanner.h: bison_yylval_scanner.c
 
 # automake does not support compiling flex scanners output in C as C++


### PR DESCRIPTION
This will prevent anything in tests/ from being built when using the default "make all" target.
Partial fix for #49 (the "get everything out of BUILT_SOURCES in the test suite" part)