### PR TITLE
test: Skip bison tests if bison is not available

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -40,6 +40,11 @@ AC_SUBST(SHARED_VERSION_INFO)
 AM_GNU_GETTEXT([external])
 AM_GNU_GETTEXT_VERSION([0.19])
 AC_PROG_YACC
+AS_IF([test "$YACC" != 'bison -y'], [
+	YACC="\${top_srcdir}/build-aux/missing bison -y"
+	AC_MSG_NOTICE(no bison program found: only required for maintainers)
+	])
+AM_CONDITIONAL([HAVE_BISON], [test "$YACC" = 'bison -y'])
 AM_PROG_LEX
 AC_PROG_CC
 AC_PROG_CXX
@@ -74,12 +79,6 @@ AC_ARG_ENABLE([bootstrap],
                   [don't perform a bootstrap when building flex])],
   [], [enable_bootstrap=yes])
 AM_CONDITIONAL([ENABLE_BOOTSTRAP], [test "x$enable_bootstrap" = xyes])
-
-AC_PATH_PROG([BISON], bison, no)
-AS_IF([test "$BISON" != no],[],
-	[ AC_SUBST([BISON], [\${top_srcdir}/build-aux/missing bison])
-	  AC_MSG_NOTICE(no bison program found: only required for maintainers)
-	])
 
 AC_PATH_PROG([HELP2MAN], help2man, [\${top_srcdir}/build-aux/missing help2man])
   AS_IF([test "$HELP2MAN" = "\${top_srcdir}/build-aux/missing help2man"],

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -129,12 +129,18 @@ array_nr_SOURCES = array_nr.l
 array_r_SOURCES = array_r.l
 basic_nr_SOURCES = basic_nr.l
 basic_r_SOURCES = basic_r.l
+if HAVE_BISON
 bison_nr_SOURCES = bison_nr_scanner.l bison_nr_parser.y bison_nr_main.c
 nodist_bison_nr_SOURCES = bison_nr_parser.h bison_nr_scanner.h
 bison_yylloc_SOURCES = bison_yylloc_scanner.l bison_yylloc_parser.y bison_yylloc_main.c
 nodist_bison_yylloc_SOURCES = bison_yylloc_parser.h bison_yylloc_scanner.h
 bison_yylval_SOURCES = bison_yylval_scanner.l bison_yylval_parser.y bison_yylval_main.c
 nodist_bison_yylval_SOURCES = bison_yylval_parser.h bison_yylval_scanner.h
+else
+bison_nr_SOURCES = no_bison_stub.c
+bison_yylloc_SOURCES = no_bison_stub.c
+bison_yylval_SOURCES = no_bison_stub.c
+endif
 c_cxx_nr_SOURCES = c_cxx_nr.lll
 c_cxx_r_SOURCES = c_cxx_r.lll
 ccl_SOURCES = ccl.l

--- a/tests/no_bison_stub.c
+++ b/tests/no_bison_stub.c
@@ -1,0 +1,39 @@
+/* This stub will be used when Bison is not available on the user's host. */
+
+/*  This file is part of flex.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *  1. Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *  2. Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in the
+ *     documentation and/or other materials provided with the distribution.
+ *
+ *  Neither the name of the University nor the names of its contributors
+ *  may be used to endorse or promote products derived from this software
+ *  without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED ``AS IS'' AND WITHOUT ANY EXPRESS OR
+ *  IMPLIED WARRANTIES, INCLUDING, WITHOUT LIMITATION, THE IMPLIED
+ *  WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ *  PURPOSE.
+ */
+#include <stdio.h>
+
+int main (int argc, char *argv[])
+{
+    (void)argc;
+    (void)argv;
+    puts(
+        "This test requires Bison. Install Bison and re-run \"configure && make check\"\n"
+        "to perform this test. (This file is stub code.)"
+    );
+
+    /* Exit status for a skipped test */
+    return 77;
+}
+
+/* vim:set tabstop=8 softtabstop=4 shiftwidth=4: */


### PR DESCRIPTION
This pull request depends on #144 
Resolves #49, except that this configure script is not tolerant on other yacc implementations (byacc, for example). If someone wants byacc for building flex and/or the testsuite, just tweak the code then.