### PR TITLE
Fix 'make indent' target

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -29,7 +29,6 @@
 # to DEFS.
 
 ACLOCAL_AMFLAGS = -I m4
-indent = @INDENT@
 
 dist_doc_DATA = \
 	AUTHORS \
@@ -58,8 +57,11 @@ ChangeLog: $(srcdir)/tools/git2cl
 		$(srcdir)/tools/git2cl > $@ \
 	; fi
 
+indent:
+	cd src && $(MAKE) $(AM_MAKEFLAGS) indent
+
 install-exec-hook:
 	cd $(DESTDIR)$(bindir) && \
 		$(LN_S) -f flex$(EXEEXT) flex++$(EXEEXT)
 
-.PHONY: ChangeLog tags indent
+.PHONY: ChangeLog indent

--- a/configure.ac
+++ b/configure.ac
@@ -102,19 +102,13 @@ AC_CACHE_CHECK([for m4 that supports -P], [ac_cv_path_M4],
 AC_SUBST([M4], [$ac_cv_path_M4])
 AC_DEFINE_UNQUOTED([M4], ["$M4"], [Define to the m4 executable name.])
 
-AC_PATH_PROG(INDENT, indent, indent)
-# if INDENT is set to 'indent' then we didn't find indent
-if test "$INDENT" != indent ; then
-   AC_MSG_CHECKING(if $INDENT is GNU indent)
-   if $INDENT --version 2>/dev/null | head -n 1|grep "GNU indent" > /dev/null ; then
-      AC_MSG_RESULT(yes)
-   else
-      AC_MSG_RESULT(no)
-      AC_MSG_WARN($INDENT does not appear to be GNU indent.)
-   fi
-else
-   AC_MSG_WARN(no indent program found: make indent target will not function)
-fi
+AC_PATH_PROG([INDENT], indent, [\${top_srcdir}/build-aux/missing indent])
+  AC_MSG_CHECKING(if $INDENT is GNU indent)
+  AS_IF([$INDENT --version 2>/dev/null | head -n 1 | grep "GNU indent" >/dev/null],
+    [AC_MSG_RESULT(yes)],
+    [AC_MSG_RESULT(no)
+     AC_MSG_WARN($INDENT does not appear to be GNU indent; 'make indent' may not function properly)
+    ])
 
 # checks for headers
 

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -135,12 +135,14 @@ indentfiles = \
 	tables_shared.h \
 	tblcmp.c
 
-indent:
-	if [ -f .indent.pro ] ; then \
-	for f in $(indentfiles);\
-	do\
-		echo indenting $$f ;\
-		f='$(srcdir)'/$$f; \
-		$(indent) < $$f >/dev/null && indent $$f || echo $$f FAILED to indent ;\
-	done \
-	fi
+indent: $(top_srcdir)/.indent.pro
+	cd $(top_srcdir) && \
+	for f in $(indentfiles); do \
+		f=src/$$f; \
+		echo indenting $$f; \
+		INDENT_PROFILE=.indent.pro $(INDENT) <$$f >/dev/null && \
+		INDENT_PROFILE=.indent.pro $(INDENT) $$f || \
+		echo $$f FAILED to indent; \
+	done;
+
+.PHONY: indent


### PR DESCRIPTION
This 'make indent' target has not been working for long since the
directories reorganization in flex 2.6.0. Now make it work again.
Unfortunately the current indent profile breaks many styles of existing
code.