### PR TITLE
build: fix Makefile parse.h dependency clauses

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -95,8 +95,15 @@ endif
 # make needs to be told to make parse.h so that parallelized runs will
 # not fail.
 
-main.c: parse.h
-yylex.c: parse.h
+# main.c
+stage1flex-main.$(OBJEXT): parse.h
+flex-main.$(OBJEXT): parse.h
+
+# yylex.c
+stage1flex-yylex.$(OBJEXT): parse.h
+flex-yylex.$(OBJEXT): parse.h
+
+# scan.c and stage1scan.c
 stage1flex-scan.$(OBJEXT): parse.h
 flex-stage1scan.$(OBJEXT): parse.h
 


### PR DESCRIPTION
(Oops. I should have caught this one when I implement the --disable-bootstrap thing. My fault.)

The current clauses stating "main.c: parse.h" and "yylex.c: parse.h" do
not work as expected. Make did not try to build parse.h upon building
flex-main.o as it would think main.c exist already and ignore the
clause. Fix this by explicitly stating that the .o files depend on
parse.h instead.

This dependency bug only happens if user builds flex from a checked-out
repository.

Note: Although it can achieve the same result by declaring the main.c
and yylex.c rules .PHONY, I would personally avoid a GNU-make-only
solution. So it's not used in this patch.