### PR TITLE
(Experimental) dist-hook to force remake scan.c

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -92,6 +92,10 @@ stage1scan.c: scan.c
 	sed 's|^\(#line .*\)"'`printf %s $< | sed 's|[][\\\\.*]|\\\\&|g'`'"|\1"$@"|g' $< > $@
 endif
 
+dist-hook: scan.l flex$(EXEEXT)
+	./flex$(EXEEXT) -o scan.c $< && \
+	mv scan.c $(distdir)
+
 # make needs to be told to make parse.h so that parallelized runs will
 # not fail.
 


### PR DESCRIPTION
Ensure the flex scanner included in release tarball being generated by exactly the flex version to be released.

(Because I found out that the scan.c included in flex-2.6.3 release is generated by flex-2.6.2)

(I label this pull request experimental because I'm not sure how automake's "make dist" rule exactly work, and I don't have the exact build environment as the maintainer's to test that completely.)