### PR TITLE
test: Never unlist pthread test; add "skip" status for it.

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -119,12 +119,12 @@ AC_CHECK_HEADERS([inttypes.h libintl.h limits.h locale.h malloc.h netinet/in.h r
 # all we need is the preprocessor symbol defined since we don't need
 # LIBS to include libpthread for building flex.
 
+LIBPTHREAD=''
 AC_CHECK_LIB(pthread, pthread_mutex_lock,
-AC_DEFINE([HAVE_LIBPTHREAD], 1, [pthread library] ),
-AC_DEFINE([HAVE_LIBPTHREAD], 0, [pthread library] )
-)
-AC_CHECK_HEADERS([pthread.h])
-AM_CONDITIONAL([want_pthread], [test "x$ac_cv_lib_pthread_pthread_mutex_lock" = xyes])
+   [AC_CHECK_HEADERS([pthread.h], [LIBPTHREAD=-lpthread],
+      [AC_MSG_WARN([pthread tests will be skipped])])],
+   [AC_MSG_WARN([pthread tests will be skipped])])
+AC_SUBST([LIBPTHREAD])
 
 AC_CHECK_LIB(m, log10)
 

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -113,10 +113,8 @@ DIRECT_TESTS = \
 I3_TESTS = \
 	cxx_yywrap.i3
 
-if want_pthread
 PTHREAD_TESTS = \
 	pthread.pthread
-endif
 
 ONE_TESTS = \
 	lineno_nr.one \
@@ -331,7 +329,7 @@ dist_check_SCRIPTS = \
 	testwrapper-direct.sh \
 	testwrapper.sh
 
-pthread_pthread_LDADD = -lpthread
+pthread_pthread_LDADD = @LIBPTHREAD@
 
 # specify how to process .l files in order to test the flex built by make all
 

--- a/tests/pthread.l
+++ b/tests/pthread.l
@@ -27,7 +27,7 @@
 
    We create N_THREADS number of threads. Each thread has it's own scanner.
    Each thread selects one of the files specified in ARGV, scans it, then
-   closes it. This is repeated N_SCANS numebr of times for each thread.
+   closes it. This is repeated N_SCANS number of times for each thread.
 
    The idea is to press the scanner to break under threads.
    If we see  "Scanner Jammed", then we know
@@ -90,18 +90,18 @@ static int process_text(char* s, yyscan_t  scanner)
 
 int main(int ARGC, char *ARGV[]);
 
-#ifndef HAVE_LIBPTHREAD
-  int main (int ARGC, char *ARGV[]) {
-    printf(
+#ifndef HAVE_PTHREAD_H
+int main (int ARGC, char *ARGV[]) {
+    puts(
        "TEST ABORTED because pthread library not available \n"
-       "-- This is expected on some systems. It is not a flex error.\n" );
-    return 0;
-  }
+       "-- This is expected on some systems. It is not a flex error.");
+    /* Exit status for a skipped test */
+    return 77;
+}
 #else
 
 #define N_THREADS 4
 #define N_SCANS   20
-#define INPUT_FILE "test.input"
 
 /* Each thread selects the next file to scan in round-robin fashion.
    If there are less files than threads, some threads may block. */
@@ -204,5 +204,5 @@ int main (int ARGC, char *ARGV[])
     return 0;
 }
 
-#endif /* HAVE_LIBPTHREAD */
+#endif /* HAVE_PTHREAD_H */
 


### PR DESCRIPTION
"Unlisting" the pthread test when libpthread is not available is never
a good idea. Should let it compile into a stub program that returns the
"skip" status.

configure.ac and tests/Makefile.am are edited so that pthread test can
be built anyway, but only works (not as the stub) when both pthread.h
and libpthread are detected on the system.

Also fix a small typo in tests/pthread.l comments.