### PR TITLE
scanner: Clean up resources when done

### DIFF
--- a/src/buf.c
+++ b/src/buf.c
@@ -217,9 +217,20 @@ void buf_destroy (struct Buf *buf)
 	if (buf) {
 		free(buf->elts);
 		buf->elts = NULL;
+		buf->nelts = 0;
 	}
 }
 
+void buf_destroy_full(struct Buf * buf, DestroyFunc destroy)
+{
+	void **p;
+	if (!buf)
+		return;
+	for (p = (void **)buf->elts;
+	     p < (void **)buf->elts + buf->nelts; p++)
+		destroy(*p);
+	buf_destroy(buf);
+}
 
 /* appends ptr[] to buf, grow if necessary.
  * n_elem is number of elements in ptr[], NOT bytes.

--- a/src/dfa.c
+++ b/src/dfa.c
@@ -226,12 +226,12 @@ void dump_transitions (FILE *file, int state[])
  *  hashval is the hash value for the dfa corresponding to the state set.
  */
 
+static int did_stk_init = false, *stk;
 int    *epsclosure (int *t, int *ns_addr, int accset[], int *nacc_addr, int *hv_addr)
 {
 	int     stkpos, ns, tsp;
 	int     numstates = *ns_addr, nacc, hashval, transsym, nfaccnum;
 	int     stkend, nstate;
-	static int did_stk_init = false, *stk;
 
 #define MARK_STATE(state) \
 do{ trans1[state] = trans1[state] - MARKER_DIFFERENCE;} while(0)
@@ -790,6 +790,10 @@ void ntod (void)
 
 	free(accset);
 	free(nset);
+	if (did_stk_init) {
+		free(stk);
+		did_stk_init = false;
+	}
 }
 
 

--- a/src/filter.c
+++ b/src/filter.c
@@ -176,6 +176,7 @@ clearerr(stdin);
 
 			if ((r = chain->filter_func (chain)) == -1)
 				flexfatal (_("filter_func failed"));
+			filter_destroy_chain(output_chain);
 			exit (0);
 		}
 		else {
@@ -185,6 +186,7 @@ clearerr(stdin);
                     chain->argv[0]);
 		}
 
+		filter_destroy_chain(output_chain);
 		exit (1);
 	}
 
@@ -313,6 +315,7 @@ int filter_tee_header (struct filter *chain)
 			lerr (_("error closing output file %s"),
 				(char *) chain->extra);
 	}
+	filter_destroy_chain(output_chain);
 
 	fflush (to_c);
 	if (ferror (to_c))
@@ -432,6 +435,21 @@ int filter_fix_linedirs (struct filter *chain)
 			outfilename ? outfilename : "<stdout>");
 
 	return 0;
+}
+
+/** Free each member of the filter chain.
+ *  @param chain The head of the chain.
+ */
+void filter_destroy_chain (struct filter *chain)
+{
+	struct filter *curr, *next;
+	curr = chain;
+	while (curr != NULL) {
+		next = curr->next;
+		free(curr->argv);
+		free(curr);
+		curr = next;
+	}
 }
 
 /* vim:set expandtab cindent tabstop=4 softtabstop=4 shiftwidth=4 textwidth=0: */

--- a/src/filter.c
+++ b/src/filter.c
@@ -291,6 +291,7 @@ int filter_tee_header (struct filter *chain)
 		if (write_header)
 			fputs (buf, to_h);
 	}
+	free (buf);
 
 	if (write_header) {
 		fprintf (to_h, "\n");
@@ -420,6 +421,7 @@ int filter_fix_linedirs (struct filter *chain)
 		fputs (buf, stdout);
 		lineno++;
 	}
+	free (buf);
 	fflush (stdout);
 	if (ferror (stdout))
 		lerr (_("error writing output file %s"),

--- a/src/filter.c
+++ b/src/filter.c
@@ -247,7 +247,6 @@ int filter_tee_header (struct filter *chain)
 
 	if ((to_cfd = dup (1)) == -1)
 		flexfatal (_("dup(1) failed"));
-	to_c = fdopen (to_cfd, "w");
 
 	if (write_header) {
 		if (freopen ((char *) chain->extra, "w", stdout) == NULL)
@@ -256,6 +255,8 @@ int filter_tee_header (struct filter *chain)
 		filter_apply_chain (chain->next);
 		to_h = stdout;
 	}
+
+	to_c = fdopen (to_cfd, "w");
 
 	/* Now to_c is a pipe to the C branch, and to_h is a pipe to the H branch.
 	 */

--- a/src/flexdef.h
+++ b/src/flexdef.h
@@ -1009,6 +1009,9 @@ extern void scinstal(const char *, int);	/* make a start condition */
 /* Lookup the number associated with a start condition. */
 extern int sclookup(const char *);
 
+/* Free symbol tables */
+void free_sym_tables (void);
+
 
 /* from file tblcmp.c */
 

--- a/src/flexdef.h
+++ b/src/flexdef.h
@@ -1174,6 +1174,7 @@ extern size_t _sf_top_ix, _sf_max; /**< stack of scanner flags. */
 extern void sf_init(void);
 extern void sf_push(void);
 extern void sf_pop(void);
+extern void sf_finalize(void);
 
 
 #endif /* not defined FLEXDEF_H */

--- a/src/flexdef.h
+++ b/src/flexdef.h
@@ -990,6 +990,9 @@ extern int flexscan(void);
 /* Open the given file (if NULL, stdin) for scanning. */
 extern void set_input_file(char *);
 
+/* Close the scanned file. */
+extern void close_input_file(void);
+
 
 /* from file sym.c */
 

--- a/src/flexdef.h
+++ b/src/flexdef.h
@@ -1146,6 +1146,7 @@ extern void filter_destroy_chain(struct filter *chain);
 
 extern regex_t regex_linedir, regex_blank_line;
 bool flex_init_regex(void);
+void flex_finalize_regex(void);
 void flex_regcomp(regex_t *preg, const char *regex, int cflags);
 char   *regmatch_dup (regmatch_t * m, const char *src);
 char   *regmatch_cpy (regmatch_t * m, char *dest, const char *src);

--- a/src/flexdef.h
+++ b/src/flexdef.h
@@ -1134,6 +1134,7 @@ extern bool filter_apply_chain(struct filter * chain);
 extern int filter_truncate(struct filter * chain, int max_len);
 extern int filter_tee_header(struct filter *chain);
 extern int filter_fix_linedirs(struct filter *chain);
+extern void filter_destroy_chain(struct filter *chain);
 
 
 /*

--- a/src/flexdef.h
+++ b/src/flexdef.h
@@ -1049,8 +1049,11 @@ struct Buf {
 	int     nmax;		/* max capacity of elements. */
 };
 
+typedef void (*DestroyFunc) (void *);
+
 extern void buf_init(struct Buf * buf, size_t elem_size);
 extern void buf_destroy(struct Buf * buf);
+extern void buf_destroy_full(struct Buf * buf, DestroyFunc destroy);
 extern struct Buf *buf_append(struct Buf * buf, const void *ptr, int n_elem);
 extern struct Buf *buf_concat(struct Buf* dest, const struct Buf* src);
 extern struct Buf *buf_strappend(struct Buf *, const char *str);

--- a/src/gen.c
+++ b/src/gen.c
@@ -1160,6 +1160,9 @@ void gentabs (void)
             yytbl_data_compress (yyacclist_tbl);
             if (yytbl_data_fwrite (&tableswr, yyacclist_tbl) < 0)
                 flexerror (_("Could not write yyacclist_tbl"));
+        }
+
+        if (yyacclist_tbl != NULL) {
             yytbl_data_destroy (yyacclist_tbl);
             yyacclist_tbl = NULL;
         }
@@ -1234,6 +1237,9 @@ void gentabs (void)
 		yytbl_data_compress (yyacc_tbl);
 		if (yytbl_data_fwrite (&tableswr, yyacc_tbl) < 0)
 			flexerror (_("Could not write yyacc_tbl"));
+	}
+
+	if (yyacc_tbl != NULL) {
 		yytbl_data_destroy (yyacc_tbl);
 		yyacc_tbl = NULL;
 	}
@@ -1291,6 +1297,9 @@ void gentabs (void)
 			if (yytbl_data_fwrite (&tableswr, yymeta_tbl) < 0)
 				flexerror (_
 					   ("Could not write yymeta_tbl"));
+		}
+
+		if (yymeta_tbl != NULL) {
 			yytbl_data_destroy (yymeta_tbl);
 			yymeta_tbl = NULL;
 		}
@@ -1350,6 +1359,9 @@ void gentabs (void)
 		yytbl_data_compress (yybase_tbl);
 		if (yytbl_data_fwrite (&tableswr, yybase_tbl) < 0)
 			flexerror (_("Could not write yybase_tbl"));
+	}
+
+	if (yybase_tbl != NULL) {
 		yytbl_data_destroy (yybase_tbl);
 		yybase_tbl = NULL;
 	}
@@ -1382,6 +1394,9 @@ void gentabs (void)
 		yytbl_data_compress (yydef_tbl);
 		if (yytbl_data_fwrite (&tableswr, yydef_tbl) < 0)
 			flexerror (_("Could not write yydef_tbl"));
+	}
+
+	if (yydef_tbl != NULL) {
 		yytbl_data_destroy (yydef_tbl);
 		yydef_tbl = NULL;
 	}
@@ -1420,6 +1435,9 @@ void gentabs (void)
 		yytbl_data_compress (yynxt_tbl);
 		if (yytbl_data_fwrite (&tableswr, yynxt_tbl) < 0)
 			flexerror (_("Could not write yynxt_tbl"));
+	}
+
+	if (yynxt_tbl != NULL) {
 		yytbl_data_destroy (yynxt_tbl);
 		yynxt_tbl = NULL;
 	}
@@ -1454,6 +1472,9 @@ void gentabs (void)
 		yytbl_data_compress (yychk_tbl);
 		if (yytbl_data_fwrite (&tableswr, yychk_tbl) < 0)
 			flexerror (_("Could not write yychk_tbl"));
+	}
+
+	if (yychk_tbl != NULL) {
 		yytbl_data_destroy (yychk_tbl);
 		yychk_tbl = NULL;
 	}

--- a/src/main.c
+++ b/src/main.c
@@ -159,6 +159,11 @@ void flex_atexit (void)
 
 	free_sym_tables ();
 
+	free (outfilename);
+	free (headerfilename);
+	free (prefix);
+	free (yyclass);
+
 	/* Free everything allocated in flexinit */
 	free (action_array);
 
@@ -406,7 +411,7 @@ void check_options (void)
 			snprintf (outfile_path, sizeof(outfile_path), outfile_template,
 				 prefix, suffix);
 
-			outfilename = outfile_path;
+			outfilename = xstrdup(outfile_path);
 		}
 
 		prev_stdout = freopen (outfilename, "w+", stdout);
@@ -1038,7 +1043,7 @@ void flexinit (int argc, char **argv)
 	reentrant = bison_bridge_lval = bison_bridge_lloc = false;
 	performance_report = 0;
 	did_outfilename = 0;
-	prefix = "yy";
+	prefix = xstrdup("yy");
 	yyclass = 0;
 	use_read = use_stdout = false;
 	tablesext = tablesverify = false;
@@ -1215,12 +1220,14 @@ void flexinit (int argc, char **argv)
 			break;
 
 		case OPT_OUTFILE:
-			outfilename = arg;
+			free (outfilename);
+			outfilename = xstrdup (arg);
 			did_outfilename = 1;
 			break;
 
 		case OPT_PREFIX:
-			prefix = arg;
+			free (prefix);
+			prefix = xstrdup (arg);
 			break;
 
 		case OPT_PERF_REPORT:
@@ -1336,7 +1343,8 @@ void flexinit (int argc, char **argv)
 			break;
 
 		case OPT_HEADER_FILE:
-			headerfilename = arg;
+			free (headerfilename);
+			headerfilename = xstrdup (arg);
 			break;
 
 		case OPT_META_ECS:
@@ -1390,7 +1398,8 @@ void flexinit (int argc, char **argv)
 			break;
 
 		case OPT_YYCLASS:
-			yyclass = arg;
+			free (yyclass);
+			yyclass = xstrdup (arg);
 			break;
 
 		case OPT_YYLINENO:

--- a/src/main.c
+++ b/src/main.c
@@ -169,6 +169,8 @@ void flex_atexit (void)
 
 	flex_finalize_regex ();
 
+	close_input_file ();
+
 	buf_destroy (&userdef_buf);
 	buf_destroy_full (&defs_buf, (DestroyFunc)free);
 	buf_destroy (&yydmap_buf);

--- a/src/main.c
+++ b/src/main.c
@@ -157,6 +157,8 @@ void flex_atexit (void)
 			free (dfaacc[i].dfaacc_set);
 	}
 
+	free_sym_tables ();
+
 	/* Free everything allocated in flexinit */
 	free (action_array);
 

--- a/src/main.c
+++ b/src/main.c
@@ -518,6 +518,8 @@ void check_options (void)
 
 		if (yytbl_hdr_fwrite (&tableswr, &hdr) <= 0)
 			flexerror (_("could not write tables header"));
+
+		yytbl_hdr_finalize (&hdr);
 	}
 
 	if (skelname && (skelfile = fopen (skelname, "r")) == NULL)

--- a/src/main.c
+++ b/src/main.c
@@ -61,7 +61,7 @@ int     trace_hex = 0;
 int     datapos, dataline, linenum;
 FILE   *skelfile = NULL;
 int     skel_ind = 0;
-char   *action_array;
+char   *action_array = NULL;
 int     action_size, defs1_offset, prolog_offset, action_offset,
 	action_index;
 char   *infilename = NULL, *outfilename = NULL, *headerfilename = NULL;
@@ -133,12 +133,67 @@ const char *escaped_qend   = "]]M4_YY_NOOP]M4_YY_NOOP]M4_YY_NOOP[[";
 /* For debugging. The max number of filters to apply to skeleton. */
 static int preproc_level = 1000;
 
+void flex_atexit (void)
+{
+	/* Free everything allocated in flexinit */
+	free (action_array);
+
+	buf_destroy (&userdef_buf);
+	buf_destroy (&defs_buf);
+	buf_destroy (&yydmap_buf);
+	buf_destroy (&top_buf);
+	buf_destroy (&m4defs_buf);
+
+	/* Free everything allocated in set_up_initial_allocations */
+	free (firstst);
+	free (lastst);
+	free (finalst);
+	free (transchar);
+	free (trans1);
+	free (trans2);
+	free (accptnum);
+	free (assoc_rule);
+	free (state_type);
+
+	free (rule_type);
+	free (rule_linenum);
+	free (rule_useful);
+	free (rule_has_nl);
+
+	free (scset);
+	free (scbol);
+	free (scxclu);
+	free (sceof);
+	free (scname);
+
+	free (cclmap);
+	free (ccllen);
+	free (cclng);
+	free (ccl_has_nl);
+
+	free (ccltbl);
+
+	free (nxt);
+	free (chk);
+
+	free (tnxt);
+
+	free (base);
+	free (def);
+	free (dfasiz);
+	free (accsiz);
+	free (dhash);
+	free (dss);
+	free (dfaacc);
+}
+
 int flex_main (int argc, char *argv[]);
 
 int flex_main (int argc, char *argv[])
 {
 	int     i, exit_status, child_status;
 
+	atexit(flex_atexit);
 	/* Set a longjmp target. Yes, I know it's a hack, but it gets worse: The
 	 * return value of setjmp, if non-zero, is the desired exit code PLUS ONE.
 	 * For example, if you want 'main' to return with code '2', then call

--- a/src/main.c
+++ b/src/main.c
@@ -144,6 +144,7 @@ void flex_atexit (void)
 		if (tablesout != NULL)
 			fclose (tablesout);
 		free (tablesname);
+		free (tablesfilename);
 	}
 
 	free (m4_path);
@@ -480,20 +481,19 @@ void check_options (void)
 
 	if (tablesext) {
 		struct yytbl_hdr hdr;
-		char   *pname = 0;
 		size_t  nbytes = 0;
 
 		buf_m4_define (&m4defs_buf, "M4_YY_TABLES_EXTERNAL", NULL);
 
 		if (!tablesfilename) {
 			nbytes = strlen (prefix) + strlen (tablesfile_template) + 2;
-			tablesfilename = pname = calloc(nbytes, 1);
-			snprintf (pname, nbytes, tablesfile_template, prefix);
+			tablesfilename = calloc(nbytes, 1);
+			snprintf (tablesfilename, nbytes, tablesfile_template, prefix);
 		}
 
 		if ((tablesout = fopen (tablesfilename, "w")) == NULL)
 			lerr (_("could not create %s"), tablesfilename);
-		free(pname);
+		free(tablesfilename);
 		tablesfilename = 0;
 
 		yytbl_writer_init (&tableswr, tablesout);
@@ -1264,7 +1264,8 @@ void flexinit (int argc, char **argv)
 
 		case OPT_TABLES_FILE:
 			tablesext = true;
-			tablesfilename = arg;
+			free (tablesfilename);
+			tablesfilename = xstrdup (arg);
 			break;
 
 		case OPT_TABLES_VERIFY:

--- a/src/main.c
+++ b/src/main.c
@@ -443,6 +443,8 @@ void check_options (void)
         filter_truncate(output_chain, preproc_level);
         filter_apply_chain(output_chain);
     }
+    filter_destroy_chain(output_chain);
+    output_chain = NULL;
     yyout = stdout;
 
 

--- a/src/main.c
+++ b/src/main.c
@@ -137,9 +137,17 @@ static char *m4_path = NULL;
 
 void flex_atexit (void)
 {
+	int i;
+
 	free (m4_path);
 	free (nultrans);
 	free (extra_type);
+
+	for (i = 1; i <= lastdfa; i++) {
+		free (dss[i]);
+		if (reject && (i != end_of_buffer_state))
+			free (dfaacc[i].dfaacc_set);
+	}
 
 	/* Free everything allocated in flexinit */
 	free (action_array);

--- a/src/main.c
+++ b/src/main.c
@@ -109,6 +109,7 @@ int     nlch = '\n';
 
 bool    tablesext, tablesverify, gentables;
 char   *tablesfilename=0,*tablesname=0;
+FILE   *tablesout = NULL;
 struct yytbl_writer tableswr;
 
 /* Make sure program_name is initialized so we don't crash if writing
@@ -138,6 +139,12 @@ static char *m4_path = NULL;
 void flex_atexit (void)
 {
 	int i;
+
+	if (tablesext) {
+		if (tablesout != NULL)
+			fclose (tablesout);
+		free (tablesname);
+	}
 
 	free (m4_path);
 	free (nultrans);
@@ -472,7 +479,6 @@ void check_options (void)
 
 
 	if (tablesext) {
-		FILE   *tablesout;
 		struct yytbl_hdr hdr;
 		char   *pname = 0;
 		size_t  nbytes = 0;

--- a/src/main.c
+++ b/src/main.c
@@ -139,6 +139,7 @@ void flex_atexit (void)
 {
 	free (m4_path);
 	free (nultrans);
+	free (extra_type);
 
 	/* Free everything allocated in flexinit */
 	free (action_array);

--- a/src/main.c
+++ b/src/main.c
@@ -139,10 +139,10 @@ void flex_atexit (void)
 	free (action_array);
 
 	buf_destroy (&userdef_buf);
-	buf_destroy (&defs_buf);
+	buf_destroy_full (&defs_buf, (DestroyFunc)free);
 	buf_destroy (&yydmap_buf);
 	buf_destroy (&top_buf);
-	buf_destroy (&m4defs_buf);
+	buf_destroy_full (&m4defs_buf, (DestroyFunc)free);
 
 	/* Free everything allocated in set_up_initial_allocations */
 	free (firstst);
@@ -543,7 +543,7 @@ void check_options (void)
 
     /* Dump the m4 definitions. */
     buf_print_strings(&m4defs_buf, stdout);
-    m4defs_buf.nelts = 0; /* memory leak here. */
+    buf_destroy_full(&m4defs_buf, (DestroyFunc)free);
 
     /* Place a bogus line directive, it will be fixed in the filter. */
     if (gen_line_dirs)
@@ -1037,8 +1037,9 @@ void flexinit (int argc, char **argv)
 	buf_init (&top_buf, sizeof (char));	    /* one long string */
 
     {
-        const char * m4defs_init_str[] = {"m4_changequote\n",
-                                          "m4_changequote([[, ]])\n"};
+        char * m4defs_init_str[2];
+        m4defs_init_str[0] = xstrdup ("m4_changequote\n");
+        m4defs_init_str[1] = xstrdup ("m4_changequote([[, ]])\n");
         buf_init (&m4defs_buf, sizeof (char *));
         buf_append (&m4defs_buf, &m4defs_init_str, 2);
     }

--- a/src/main.c
+++ b/src/main.c
@@ -88,7 +88,7 @@ char  **scname;
 int     current_max_dfa_size, current_max_xpairs;
 int     current_max_template_xpairs, current_max_dfas;
 int     lastdfa, *nxt, *chk, *tnxt;
-int    *base, *def, *nultrans, NUL_ec, tblend, firstfree, **dss, *dfasiz;
+int    *base, *def, *nultrans = NULL, NUL_ec, tblend, firstfree, **dss, *dfasiz;
 union dfaacc_union *dfaacc;
 int    *accsiz, *dhash, numas;
 int     numsnpairs, jambase, jamstate;
@@ -138,6 +138,7 @@ static char *m4_path = NULL;
 void flex_atexit (void)
 {
 	free (m4_path);
+	free (nultrans);
 
 	/* Free everything allocated in flexinit */
 	free (action_array);
@@ -1837,8 +1838,6 @@ void set_up_initial_allocations (void)
 	dhash = allocate_integer_array (current_max_dfas);
 	dss = allocate_int_ptr_array (current_max_dfas);
 	dfaacc = allocate_dfaacc_union (current_max_dfas);
-
-	nultrans = NULL;
 }
 
 

--- a/src/main.c
+++ b/src/main.c
@@ -171,6 +171,8 @@ void flex_atexit (void)
 
 	close_input_file ();
 
+	sf_finalize ();
+
 	buf_destroy (&userdef_buf);
 	buf_destroy_full (&defs_buf, (DestroyFunc)free);
 	buf_destroy (&yydmap_buf);

--- a/src/main.c
+++ b/src/main.c
@@ -167,6 +167,8 @@ void flex_atexit (void)
 	/* Free everything allocated in flexinit */
 	free (action_array);
 
+	flex_finalize_regex ();
+
 	buf_destroy (&userdef_buf);
 	buf_destroy_full (&defs_buf, (DestroyFunc)free);
 	buf_destroy (&yydmap_buf);

--- a/src/main.c
+++ b/src/main.c
@@ -1073,6 +1073,7 @@ void flexinit (int argc, char **argv)
 				 _
 				 ("Try `%s --help' for more information.\n"),
 				 program_name);
+			scanopt_destroy (sopt);
 			FLEX_EXIT (1);
 		}
 
@@ -1154,6 +1155,7 @@ void flexinit (int argc, char **argv)
 
 		case OPT_HELP:
 			usage ();
+			scanopt_destroy (sopt);
 			FLEX_EXIT (0);
 
 		case OPT_INTERACTIVE:
@@ -1258,6 +1260,7 @@ void flexinit (int argc, char **argv)
 
 		case OPT_VERSION:
 			printf (_("%s %s\n"), program_name, flex_version);
+			scanopt_destroy (sopt);
 			FLEX_EXIT (0);
 
 		case OPT_WARN:

--- a/src/misc.c
+++ b/src/misc.c
@@ -88,6 +88,11 @@ static void sko_pop(bool* dc)
     if(sko_len < 0)
         flex_die("popped too many times in skeleton.");
 }
+static void sko_free(void)
+{
+    free(sko_stack);
+    sko_stack = NULL;
+}
 
 /* Append "#define defname value\n" to the running buffer. */
 void action_define (const char *defname, int value)
@@ -829,6 +834,9 @@ void skelout (void)
 		else if (do_copy) 
             outn (buf);
 	}			/* end while */
+
+	/* This point is only reached on the final call */
+	sko_free();
 }
 
 

--- a/src/parse.y
+++ b/src/parse.y
@@ -193,19 +193,32 @@ optionlist	:  optionlist option
 
 option		:  TOK_OUTFILE '=' NAME
 			{
+			free(outfilename);
 			outfilename = xstrdup(nmstr);
 			did_outfilename = 1;
 			}
 		|  TOK_EXTRA_TYPE '=' NAME
-			{ extra_type = xstrdup(nmstr); }
+			{
+			free(extra_type);
+			extra_type = xstrdup(nmstr);
+			}
 		|  TOK_PREFIX '=' NAME
-			{ prefix = xstrdup(nmstr);
-                          if (strchr(prefix, '[') || strchr(prefix, ']'))
-                              flexerror(_("Prefix must not contain [ or ]")); }
+			{
+			free(prefix);
+			prefix = xstrdup(nmstr);
+			if (strchr(prefix, '[') || strchr(prefix, ']'))
+				flexerror(_("Prefix must not contain [ or ]"));
+			}
 		|  TOK_YYCLASS '=' NAME
-			{ yyclass = xstrdup(nmstr); }
+			{
+			free(yyclass);
+			yyclass = xstrdup(nmstr);
+			}
 		|  TOK_HEADER_FILE '=' NAME
-			{ headerfilename = xstrdup(nmstr); }
+			{
+			free(headerfilename);
+			headerfilename = xstrdup(nmstr);
+			}
 		|  TOK_TABLES_FILE '=' NAME
 			{
 			free(tablesfilename);

--- a/src/parse.y
+++ b/src/parse.y
@@ -141,6 +141,8 @@ goal		:  initlex sect1 sect1end sect2 initforrule
 				add_action( "ECHO" );
 
 			add_action( ";\n\tYY_BREAK]]\n" );
+
+			free(scon_stk);
 			}
 		;
 

--- a/src/parse.y
+++ b/src/parse.y
@@ -206,8 +206,12 @@ option		:  TOK_OUTFILE '=' NAME
 			{ yyclass = xstrdup(nmstr); }
 		|  TOK_HEADER_FILE '=' NAME
 			{ headerfilename = xstrdup(nmstr); }
-	    |  TOK_TABLES_FILE '=' NAME
-            { tablesext = true; tablesfilename = xstrdup(nmstr); }
+		|  TOK_TABLES_FILE '=' NAME
+			{
+			free(tablesfilename);
+			tablesext = true;
+			tablesfilename = xstrdup(nmstr);
+			}
 		;
 
 sect2		:  sect2 scon initforrule flexrule '\n'

--- a/src/regex.c
+++ b/src/regex.c
@@ -42,6 +42,12 @@ bool flex_init_regex(void)
     return true;
 }
 
+void flex_finalize_regex(void)
+{
+    regfree(&regex_linedir);
+    regfree(&regex_blank_line);
+}
+
 /** Compiles a regular expression or dies trying.
  * @param preg  Same as for regcomp().
  * @param regex Same as for regcomp().

--- a/src/scan.l
+++ b/src/scan.l
@@ -1046,3 +1046,16 @@ void set_input_file( char *file )
 
 	linenum = 1;
 	}
+
+void close_input_file(void)
+	{
+		if (yyin != NULL) {
+			fclose(yyin);
+			yyin = NULL;
+		}
+		if (infilename != NULL) {
+			free(infilename);
+			infilename = NULL;
+		}
+		yylex_destroy ();
+	}

--- a/src/scanflags.c
+++ b/src/scanflags.c
@@ -68,4 +68,12 @@ sf_init (void)
     _sf_stk[_sf_top_ix] = 0;
 }
 
+void
+sf_finalize (void)
+{
+    assert(_sf_stk != NULL);
+    free(_sf_stk);
+    _sf_stk = NULL;
+}
+
 /* vim:set expandtab cindent tabstop=4 softtabstop=4 shiftwidth=4 textwidth=0: */

--- a/src/sym.c
+++ b/src/sym.c
@@ -79,6 +79,8 @@ static int addsym (char sym[], char *str_def, int int_def, hash_table table, int
 
 	while (sym_entry) {
 		if (!strcmp (sym, sym_entry->name)) {	/* entry already exists */
+			free (sym);
+			free (str_def);
 			return -1;
 		}
 
@@ -246,4 +248,29 @@ str);
 int     sclookup (const char *str)
 {
 	return findsym (str, sctbl, START_COND_HASH_SIZE)->int_val;
+}
+
+static void free_hash_table (hash_table table, int table_size)
+{
+	int i;
+	struct hash_entry *curr, *next;
+
+	for (i = 0; i < table_size; i++) {
+		curr = table[i];
+		while (curr != NULL) {
+			next = curr->next;
+			free (curr->name);
+			free (curr->str_val);
+			free (curr);
+			curr = next;
+		}
+		table[i] = NULL;
+	}
+}
+
+void free_sym_tables (void)
+{
+	free_hash_table (ndtbl, NAME_TABLE_HASH_SIZE);
+	free_hash_table (sctbl, START_COND_HASH_SIZE);
+	free_hash_table (ccltab, CCL_HASH_SIZE);
 }

--- a/src/tables.c
+++ b/src/tables.c
@@ -95,6 +95,17 @@ int yytbl_hdr_init (struct yytbl_hdr *th, const char *version_str,
 	return 0;
 }
 
+/** Clean up name and version strings of table header.
+ *  @param th The table header to clean up
+ *  @return 0 on success
+ */
+int yytbl_hdr_finalize (struct yytbl_hdr *th)
+{
+	free (th->th_version);
+	free (th->th_name);
+	return 0;
+}
+
 /** Allocate and initialize a table data structure.
  *  @param td a pointer to an uninitialized table
  *  @param id  the table identifier

--- a/src/tables.h
+++ b/src/tables.h
@@ -61,6 +61,7 @@ struct yytbl_writer {
  */
 extern bool tablesext, tablesverify,gentables;
 extern char *tablesfilename, *tablesname;
+extern bool is_tablesfilename_alloc;
 extern struct yytbl_writer tableswr;
 
 int     yytbl_writer_init (struct yytbl_writer *, FILE *);

--- a/src/tables.h
+++ b/src/tables.h
@@ -67,6 +67,7 @@ extern struct yytbl_writer tableswr;
 int     yytbl_writer_init (struct yytbl_writer *, FILE *);
 int     yytbl_hdr_init (struct yytbl_hdr *th, const char *version_str,
 			const char *name);
+int     yytbl_hdr_finalize (struct yytbl_hdr *th);
 int     yytbl_data_init (struct yytbl_data *tbl, enum yytbl_id id);
 int     yytbl_data_destroy (struct yytbl_data *td);
 int     yytbl_hdr_fwrite (struct yytbl_writer *wr,


### PR DESCRIPTION
Running all the tests through valgrind revealed numerous locations where
pointers were being overwritten or simply not being freed.

After cleaning these up, the testsuite still runs cleanly.