### PR TITLE
flex.skl: add missing update of yy_buf_size after yyrealloc()

### DIFF
--- a/src/flex.skl
+++ b/src/flex.skl
@@ -1676,6 +1676,8 @@ m4_ifdef( [[M4_YY_USES_REJECT]],
 			(void *) YY_CURRENT_BUFFER_LVALUE->yy_ch_buf, (yy_size_t) new_size M4_YY_CALL_LAST_ARG );
 		if ( ! YY_CURRENT_BUFFER_LVALUE->yy_ch_buf )
 			YY_FATAL_ERROR( "out of dynamic memory in yy_get_next_buffer()" );
+		/* "- 2" to take care of EOB's */
+		YY_CURRENT_BUFFER_LVALUE->yy_buf_size = (int) (new_size - 2);
 	}
 
 	YY_G(yy_n_chars) += number_to_move;


### PR DESCRIPTION
An alternate approach would be to allocate an extra 2 bytes in the yyrealloc() and set yy_buf_size to new_size.  The code in flex.skl is not consistent in this regard; sometimes an extra 2 bytes are allocated, other times yy_buf_size is adjusted by -2.