### PR TITLE
minor improvements for invocation of build tools

### DIFF
--- a/autogen.sh
+++ b/autogen.sh
@@ -44,6 +44,8 @@ fi
 #worried. (Don't worry, we *do* have a ChangeLog, we just need the
 #Makefile first.)
 
-touch ChangeLog
+if ! test -f ChangeLog; then
+   touch ChangeLog
+f
 "$LIBTOOLIZE" --install --force
 autoreconf --install --force

--- a/autogen.sh
+++ b/autogen.sh
@@ -46,6 +46,6 @@ fi
 
 if ! test -f ChangeLog; then
    touch ChangeLog
-f
+fi
 "$LIBTOOLIZE" --install --force
 autoreconf --install --force

--- a/autogen.sh
+++ b/autogen.sh
@@ -45,5 +45,5 @@ fi
 #Makefile first.)
 
 touch ChangeLog
-LIBTOOLIZE --install --force
+"$LIBTOOLIZE" --install --force
 autoreconf --install --force

--- a/autogen.sh
+++ b/autogen.sh
@@ -24,10 +24,26 @@
 # If you see no configure script, then run ./autogen.sh to create it
 # and procede with the "normal" build procedures.
 
+# use LIBTOOLIZE, if set
+LIBTOOLIZE_ORIG="$LIBTOOLIZE";
+if test "x$LIBTOOLIZE" = "x"; then LIBTOOLIZE=libtoolize; fi
+
+# test libtoolize
+$LIBTOOLIZE --version 2>/dev/null
+if test "$?" -ne 0; then
+   LIBTOOLIZE=glibtoolize
+   $LIBTOOLIZE --version 2>/dev/null
+   if test "$?" -ne 0; then
+      echo "error: libtoolize not working, re-run with LIBTOOLIZE=/path/to/libtoolize"
+      echo "       LIBTOOLIZE is currently \"$LIBTOOLIZE_ORIG\""
+      exit 1
+   fi
+fi
+
 #if we pretend to have a ChangeLog, then automake is less
 #worried. (Don't worry, we *do* have a ChangeLog, we just need the
 #Makefile first.)
 
 touch ChangeLog
-libtoolize --install --force || glibtoolize --install --force
+LIBTOOLIZE --install --force
 autoreconf --install --force

--- a/configure.ac
+++ b/configure.ac
@@ -28,7 +28,7 @@ AC_INIT([the fast lexical analyser generator],[2.6.4],[flex-help@lists.sourcefor
 AC_CONFIG_SRCDIR([src/scan.l])
 AC_CONFIG_AUX_DIR([build-aux])
 LT_INIT
-AM_INIT_AUTOMAKE([-Wno-portability foreign check-news std-options dist-lzip parallel-tests subdir-objects 1.14.1])
+AM_INIT_AUTOMAKE([1.14.1 -Wno-portability foreign check-news std-options dist-lzip parallel-tests subdir-objects])
 AC_CONFIG_HEADER([src/config.h])
 AC_CONFIG_LIBOBJ_DIR([lib])
 AC_CONFIG_MACRO_DIR([m4])

--- a/doc/Makefile.am
+++ b/doc/Makefile.am
@@ -1,32 +1,14 @@
-help2man = @HELP2MAN@
-
 FLEX = $(top_builddir)/src/flex$(EXEEXT)
 
 info_TEXINFOS =	flex.texi
 dist_man_MANS = flex.1
 MAINTAINERCLEANFILES = flex.1
 
-CLEANFILES = \
-	flex.aux \
-	flex.cp \
-	flex.cps \
-	flex.fn \
-	flex.fns \
-	flex.hk \
-	flex.hks \
-	flex.ky \
-	flex.log \
-	flex.op \
-	flex.ops \
-	flex.pg \
-	flex.toc \
-	flex.tp \
-	flex.tps \
-	flex.vr \
-	flex.vrs
+CLEANFILES = *.aux *.cp *.cps *.fn *.fns *.hk *.hks *.ky *.log \
+	*.op *.ops *.pg *.toc *.tp *.tps *.vr *.vrs
 
 flex.1: $(top_srcdir)/configure.ac $(top_srcdir)/src/flex.skl $(top_srcdir)/src/options.c $(top_srcdir)/src/options.h | $(FLEX)
-	$(help2man) --name='$(PACKAGE_NAME)' --section=1 \
+	$(HELP2MAN) --name='$(PACKAGE_NAME)' --section=1 \
 	--source='The Flex Project' --manual='Programming' \
 	--output=$@ $(FLEX) \
 	|| rm -f $@


### PR DESCRIPTION
autogen.sh:
* check for libtoolize / glibtoolize before anything else
* use LIBTOOLIZE environment var, if set

configure.ac:
* version number in `AM_INIT_AUTOMAKE` must come first (otherwise you get an error message for unrecognized option `dist-lzip`)