### PR TITLE
Translation tweaks

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -28,7 +28,7 @@ AC_INIT([the fast lexical analyser generator],[2.6.4],[flex-help@lists.sourcefor
 AC_CONFIG_SRCDIR([src/scan.l])
 AC_CONFIG_AUX_DIR([build-aux])
 LT_INIT
-AM_INIT_AUTOMAKE([-Wno-portability foreign check-news std-options dist-lzip parallel-tests subdir-objects 1.14.1])
+AM_INIT_AUTOMAKE([1.11.3 -Wno-portability foreign check-news std-options dist-lzip parallel-tests subdir-objects])
 AC_CONFIG_HEADER([src/config.h])
 AC_CONFIG_LIBOBJ_DIR([lib])
 AC_CONFIG_MACRO_DIR([m4])
@@ -38,7 +38,7 @@ AC_SUBST(SHARED_VERSION_INFO)
 # checks for programs
 
 AM_GNU_GETTEXT([external])
-AM_GNU_GETTEXT_VERSION([0.19])
+AM_GNU_GETTEXT_VERSION([0.18])
 AC_PROG_YACC
 AS_IF([test "$YACC" != 'bison -y'], [
 	YACC="\${top_srcdir}/build-aux/missing bison -y"

--- a/po/Makevars
+++ b/po/Makevars
@@ -8,7 +8,7 @@ subdir = po
 top_builddir = ..
 
 # These options get passed to xgettext.
-XGETTEXT_OPTIONS = --keyword=_ --keyword=N_
+XGETTEXT_OPTIONS = --language=C --keyword=_ --keyword=N_
 
 # This is the copyright holder that gets inserted into the header of the
 # $(DOMAIN).pot file.  Set this to the copyright holder of the surrounding
@@ -19,6 +19,13 @@ XGETTEXT_OPTIONS = --keyword=_ --keyword=N_
 # the public domain; in this case the translators are expected to disclaim
 # their copyright.
 COPYRIGHT_HOLDER = 
+
+# This tells whether or not to prepend "GNU " prefix to the package
+# name that gets inserted into the header of the $(DOMAIN).pot file.
+# Possible values are "yes", "no", or empty.  If it is empty, try to
+# detect it automatically by scanning the files in $(top_srcdir) for
+# "GNU packagename" string.
+PACKAGE_GNU = "no"
 
 # This is the email address or URL to which the translators shall report
 # bugs in the untranslated strings:
@@ -39,3 +46,33 @@ MSGID_BUGS_ADDRESS = flex-devel@lists.sourceforge.net
 # This is the list of locale categories, beyond LC_MESSAGES, for which the
 # message catalogs shall be used.  It is usually empty.
 EXTRA_LOCALE_CATEGORIES =
+
+# This tells whether the $(DOMAIN).pot file contains messages with an 'msgctxt'
+# context.  Possible values are "yes" and "no".  Set this to yes if the
+# package uses functions taking also a message context, like pgettext(), or
+# if in $(XGETTEXT_OPTIONS) you define keywords with a context argument.
+USE_MSGCTXT = no
+
+# These options get passed to msgmerge.
+# Useful options are in particular:
+#   --previous            to keep previous msgids of translated messages,
+#   --quiet               to reduce the verbosity.
+MSGMERGE_OPTIONS =
+
+# These options get passed to msginit.
+# If you want to disable line wrapping when writing PO files, add
+# --no-wrap to MSGMERGE_OPTIONS, XGETTEXT_OPTIONS, and
+# MSGINIT_OPTIONS.
+MSGINIT_OPTIONS =
+
+# This tells whether or not to regenerate a PO file when $(DOMAIN).pot
+# has changed.  Possible values are "yes" and "no".  Set this to no if
+# the POT file is checked in the repository and the version control
+# program ignores timestamps.
+PO_DEPENDS_ON_POT = yes
+
+# This tells whether or not to forcibly update $(DOMAIN).pot and
+# regenerate PO files on "make dist".  Possible values are "yes" and
+# "no".  Set this to no if the POT file and PO files are maintained
+# externally.
+DIST_DEPENDS_ON_UPDATE_PO = no

--- a/po/POTFILES.in
+++ b/po/POTFILES.in
@@ -9,8 +9,8 @@ src/main.c
 src/misc.c
 src/nfa.c
 src/options.c
-src/parse.y
-src/scan.l
+src/parse.c
+src/scan.c
 src/scanopt.c
 src/sym.c
 src/tblcmp.c

--- a/po/Rules-getpo
+++ b/po/Rules-getpo
@@ -1,9 +1,0 @@
-# Rules to fetch the translation project's po files for a domain
-
-# Just rsync the *.po files for a particular textual domain into the
-# po/ subdirectory of the project's source tree
-
-getpo:
-	rsync -Ltvz  translationproject.org::tp/latest/flex/*.po $(top_srcdir)/po
-
-.PHONY: getpo

--- a/po/update_linguas.sh
+++ b/po/update_linguas.sh
@@ -1,0 +1,26 @@
+#!/bin/sh
+# shell for updating the translations before a release
+
+# Let this be executed in the po/ subdir.
+cd "$(dirname "$0")" || exit
+
+echo "Updating translations via TP"
+rsync -Lrtvz  translationproject.org::tp/latest/flex/ . # || exit
+
+# Are there now PO files that are not in svn yet?
+NEWSTUFF=$(git status --porcelain *.po | grep "^??")
+
+if [ -n "${NEWSTUFF}" ]; then
+    echo "New languages found; updating LINGUAS"
+    echo "# List of available languages." >LINGUAS
+    echo $(printf '%s\n' *.po | LC_ALL=C sort | sed 's/\.po//g') >>LINGUAS
+fi
+
+echo "Regenerating POT file and remerging and recompiling PO files..."
+make update-po
+
+# Ensure that the PO files are newer than the POT.
+touch *.po
+
+# Compile PO files
+make


### PR DESCRIPTION
* POTFILES.in: use generated C files instead flex/bison sources to prevent warnings from xgettext
* replaced Rules-getpo by extra script to manually update and rebuild all po files
* Makevars: updated to recent version, don't auto-rebuild po-files during `make dist` 