### PR TITLE
Don't redefine C preprocessor macros

### DIFF
--- a/src/flex.skl
+++ b/src/flex.skl
@@ -112,7 +112,10 @@ m4_ifdef( [[M4_YY_REENTRANT]],  [[m4_define([[M4_YY_HAS_START_STACK_VARS]])]])
 m4_ifdef( [[M4_YY_PREFIX]],, [[m4_define([[M4_YY_PREFIX]], [[yy]])]])
 
 m4preproc_define(`M4_GEN_PREFIX',
-    ``[[#define yy$1 ]]M4_YY_PREFIX[[$1]]
+    ``[[#ifdef yy$1
+#undef yy$1
+#endif
+#define yy$1 ]]M4_YY_PREFIX[[$1]]
 %# m4_define([[yy$1]], [[M4_YY_PREFIX[[$1]]m4_ifelse($'`#,0,,[[($'`@)]])]])'')
 
 %if-c++-only

--- a/src/main.c
+++ b/src/main.c
@@ -310,8 +310,8 @@ void check_options (void)
 		}
 	}
 
-    if (extra_type)
-        buf_m4_define( &m4defs_buf, "M4_EXTRA_TYPE_DEFS", extra_type);
+	if (extra_type)
+		buf_m4_define( &m4defs_buf, "M4_EXTRA_TYPE_DEFS", extra_type);
 
 	if (!use_stdout) {
 		FILE   *prev_stdout;


### PR DESCRIPTION
Macro redefinition causes warnings on modern C compilers.  Undefine
each macro before redefining it.  But only do so if it *is* defined,
to prevent a "macro undefined that was never defined" warning.

Fixes #142 