### PR TITLE
Don't leak macro definitions into header files

### DIFF
--- a/src/flex.skl
+++ b/src/flex.skl
@@ -111,9 +111,10 @@ m4_ifdef( [[M4_YY_REENTRANT]],  [[m4_define([[M4_YY_HAS_START_STACK_VARS]])]])
 
 m4_ifdef( [[M4_YY_PREFIX]],, [[m4_define([[M4_YY_PREFIX]], [[yy]])]])
 
-m4preproc_define(`M4_GEN_PREFIX',
-    ``[[#define yy$1 ]]M4_YY_PREFIX[[$1]]
-%# m4_define([[yy$1]], [[M4_YY_PREFIX[[$1]]m4_ifelse($'`#,0,,[[($'`@)]])]])'')
+m4preproc_define(`M4_GEN_PREFIX',``
+[[#define yy$1 ]]M4_YY_PREFIX[[$1]]
+'m4preproc_divert(1)`
+[[#undef yy$1]]'m4preproc_divert(0)')
 
 %if-c++-only
     /* The c++ scanner is a mess. The FlexLexer.h header file relies on the
@@ -3415,4 +3416,5 @@ m4_ifdef( [[M4_YY_IN_HEADER]],
 #undef YY_DECL_IS_OURS
 #undef YY_DECL
 #endif
+m4preproc_undivert(1)
 ]])

--- a/src/flex.skl
+++ b/src/flex.skl
@@ -112,9 +112,15 @@ m4_ifdef( [[M4_YY_REENTRANT]],  [[m4_define([[M4_YY_HAS_START_STACK_VARS]])]])
 m4_ifdef( [[M4_YY_PREFIX]],, [[m4_define([[M4_YY_PREFIX]], [[yy]])]])
 
 m4preproc_define(`M4_GEN_PREFIX',``
-[[#define yy$1 ]]M4_YY_PREFIX[[$1]]
+[[#ifdef yy$1
+#define ]]M4_YY_PREFIX[[$1_ALREADY_DEFINED
+#else
+#define yy$1 ]]M4_YY_PREFIX[[$1
+#endif]]
 'm4preproc_divert(1)`
-[[#undef yy$1]]'m4preproc_divert(0)')
+[[#ifndef ]]M4_YY_PREFIX[[$1_ALREADY_DEFINED
+#undef yy$1
+#endif]]'m4preproc_divert(0)')
 
 %if-c++-only
     /* The c++ scanner is a mess. The FlexLexer.h header file relies on the

--- a/src/main.c
+++ b/src/main.c
@@ -310,8 +310,8 @@ void check_options (void)
 		}
 	}
 
-    if (extra_type)
-        buf_m4_define( &m4defs_buf, "M4_EXTRA_TYPE_DEFS", extra_type);
+	if (extra_type)
+		buf_m4_define( &m4defs_buf, "M4_EXTRA_TYPE_DEFS", extra_type);
 
 	if (!use_stdout) {
 		FILE   *prev_stdout;


### PR DESCRIPTION
This allowed unnamespaced definitions to leak into header files,
breaking client code.

Fixes #142