### PR TITLE
No need to generate lib/Makefile.in

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -42,7 +42,6 @@ EXTRA_DIST = \
 	autogen.sh
 
 SUBDIRS = \
-	lib \
 	src \
 	doc \
 	examples \

--- a/configure.ac
+++ b/configure.ac
@@ -175,7 +175,6 @@ doc/Makefile
 examples/Makefile
 examples/fastwc/Makefile
 examples/manual/Makefile
-lib/Makefile
 po/Makefile.in
 src/Makefile
 tools/Makefile

--- a/lib/Makefile.am
+++ b/lib/Makefile.am
@@ -1,3 +1,0 @@
-# Files in the lib/ subdirectory are picked up as needed by the flex
-# build system. As such, we don't need to specify anything beyond
-# having a Makefile.am for automake to generate a Makefile.in from.


### PR DESCRIPTION
Files in lib/ are picked up and built using using makefile directives
in src/Makefile.am. Remove the need to generate lib/Makefile.in and the
dummy lib/Makefile.am.

(I discoved this tweak on my attempt to change flex to use "non-
recursive makefile". I'm not sure if flex should be migrated to use
non-recursive makefile, but it's good to get rid of lib/Makefile.in
first. Should flex use non-recursive makefile eventually? That's
my question. BTW, Bison's build system is non-recursive make.)