### PR TITLE
Handle zero and negative bracecounts appropriately

### DIFF
--- a/src/scan.l
+++ b/src/scan.l
@@ -940,16 +940,16 @@ nmstr[yyleng - 2 - end_is_ws] = '\0';  /* chop trailing brace */
         "'"             ACTION_ECHO; BEGIN(CHARACTER_CONSTANT);
 	\"		ACTION_ECHO; BEGIN(ACTION_STRING);
 	{NL} {
-			++linenum;
-			ACTION_ECHO;
-			if (bracelevel == 0) {
-				if ( doing_rule_action )
-                    add_action( "\tYY_BREAK]""]\n" );
+                ++linenum;
+                ACTION_ECHO;
+                if (bracelevel <= 0) {
+                   if ( doing_rule_action )
+                      add_action( "\tYY_BREAK]""]\n" );
 
-                doing_rule_action = false;
-                BEGIN(SECT2);
-            }
-        }
+                   doing_rule_action = false;
+                   BEGIN(SECT2);
+                }
+             }
         .      ACTION_ECHO;
 }
 

--- a/src/scan.l
+++ b/src/scan.l
@@ -919,7 +919,7 @@ nmstr[yyleng - 2 - end_is_ws] = '\0';  /* chop trailing brace */
 	{NL}	{
 		++linenum;
 		ACTION_ECHO;
-		if (bracelevel == 0 || (doing_codeblock && indented_code)) {
+		if (bracelevel <= 0 || (doing_codeblock && indented_code)) {
             if ( doing_rule_action )
                 add_action( "\tYY_BREAK]""]\n" );
 
@@ -964,7 +964,7 @@ nmstr[yyleng - 2 - end_is_ws] = '\0';  /* chop trailing brace */
 <ACTION_STRING,CHARACTER_CONSTANT>{
         (\\\n)*         ACTION_ECHO;
 	\\(\\\n)*.	ACTION_ECHO;
-	{NL}	++linenum; ACTION_ECHO; BEGIN(ACTION);
+	{NL}	++linenum; ACTION_ECHO; if (bracelevel <= 0) { BEGIN(SECT2); } else { BEGIN(ACTION); }
         .	ACTION_ECHO;
 }
 


### PR DESCRIPTION
Negative bracecounts, and actions terminating while in state `ACTION_STRING` or `CHARACTER_CONSTANT`, can happen on valid input, because Flex doesn't parse `//` comments or C++11 raw string literals.