### PR TITLE
Delete comments from skeleton file

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -92,12 +92,7 @@ CLEANFILES = stage1scan.c stage1flex$(EXEEXT)
 MAINTAINERCLEANFILES = skel.c
 
 skel.c: flex.skl mkskel.sh flexint.h tables_shared.h tables_shared.c
-	sed 's/4_/a4_/g; s/m4preproc_/m4_/g' $(srcdir)/flex.skl | \
-	  $(m4) -P -I $(srcdir)						   \
-	    -DFLEX_MAJOR_VERSION=`   echo $(VERSION)|cut -f 1 -d .`	   \
-	    -DFLEX_MINOR_VERSION=`   echo $(VERSION)|cut -f 2 -d .`	   \
-	    -DFLEX_SUBMINOR_VERSION=`echo $(VERSION)|cut -f 3 -d .` |	   \
-	  $(SHELL) $(srcdir)/mkskel.sh > $@.tmp
+	$(SHELL) $(srcdir)/mkskel.sh $(srcdir) $(m4) $(VERSION) > $@.tmp
 	mv $@.tmp $@
 
 if ENABLE_BOOTSTRAP

--- a/src/misc.c
+++ b/src/misc.c
@@ -791,9 +791,6 @@ void skelout (void)
 				/* %e end linkage-only code. */
 				OUT_END_CODE ();
 			}
-			else if (buf[1] == '#') {
-				/* %# a comment in the skel. ignore. */
-			}
 			else {
 				flexfatal (_("bad line in skeleton file"));
 			}

--- a/src/mkskel.sh
+++ b/src/mkskel.sh
@@ -21,13 +21,31 @@
 #  WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
 #  PURPOSE.
 
+if test ! $# = 3; then
+   echo 'Usage: mkskel.sh srcdir m4 version' >&2
+   exit 1
+fi
 echo '/* File created from flex.skl via mkskel.sh */
 
 #include "flexdef.h"
 
 const char *skel[] = {'
-
-sed 's/m4_/m4preproc_/g
+srcdir=$1
+m4=$2
+VERSION=$3
+case $VERSION in
+   *[!0-9.]*) echo 'Invalid version number' >&2; exit 1;;
+esac
+IFS=.
+set $VERSION
+sed 's/4_/a4_/g
+s/m4preproc_/m4_/g
+' "$srcdir/flex.skl" |
+"$m4" -P -I "$srcdir" "-DFLEX_MAJOR_VERSION=$1" \
+   "-DFLEX_MINOR_VERSION=$2" \
+   "-DFLEX_SUBMINOR_VERSION=$3" |
+sed '/^%#/d
+s/m4_/m4preproc_/g
 s/a4_/4_/g
 s/[\\"]/\\&/g
 s/.*/  "&",/'


### PR DESCRIPTION
It's nearly trivial to do, and it saves space in the produced
executable.