### PR TITLE
Correct C code sample within documentation.

### DIFF
--- a/doc/flex.texi
+++ b/doc/flex.texi
@@ -2182,7 +2182,7 @@ manages its own input buffer stack manually (instead of letting flex do it).
             }
 
     <<EOF>> {
-            if ( --include_stack_ptr  0 )
+            if ( --include_stack_ptr == 0 )
                 {
                 yyterminate();
                 }


### PR DESCRIPTION
**Issue:**
Documentation contains C code sample which generate compile time error.

**Root cause:**
Typographical error.

**Solution:**
Code sample provided with missing equality operator.

Ticket - https://github.com/westes/flex/issues/214