### PR TITLE
filter: Output correct #line value for current file

### DIFF
--- a/src/filter.c
+++ b/src/filter.c
@@ -391,7 +391,7 @@ int filter_fix_linedirs (struct filter *chain)
 				/* Adjust the line directives. */
 				in_gen = true;
 				snprintf (buf, readsz, "#line %d \"%s\"\n",
-					  lineno, filename);
+					  lineno + 1, filename);
 			}
 			else {
 				/* it's a #line directive for code we didn't write */


### PR DESCRIPTION
A #line pre-processor directive specifies the line number and source
file of the following lines. If the source file _is_ the current file,
the line number should be that of the line following the directive. So
the specified line number should be the current line number plus 1.