### PR TITLE
Faster is_blank_line() implementation

### DIFF
--- a/src/filter.c
+++ b/src/filter.c
@@ -326,7 +326,15 @@ int filter_tee_header (struct filter *chain)
 
 static bool is_blank_line (const char *str)
 {
-	return (regexec (&regex_blank_line, str, 0, NULL, 0) == 0);
+#if 1 /* faster */
+	while (isspace(*str))
+		str++;
+	return (*str == '\0');
+#endif
+#if 0 /* smaller */
+	char c;
+	return (sscanf(str, " %c", &c) < 1);
+#endif
 }
 
 /** Adjust the line numbers in the #line directives of the generated scanner.

--- a/src/filter.c
+++ b/src/filter.c
@@ -324,6 +324,11 @@ int filter_tee_header (struct filter *chain)
 	return 0;
 }
 
+static bool is_blank_line (const char *str)
+{
+	return (regexec (&regex_blank_line, str, 0, NULL, 0) == 0);
+}
+
 /** Adjust the line numbers in the #line directives of the generated scanner.
  * After the m4 expansion, the line numbers are incorrect since the m4 macros
  * can add or remove lines.  This only adjusts line numbers for generated code,
@@ -395,9 +400,7 @@ int filter_fix_linedirs (struct filter *chain)
 		}
 
 		/* squeeze blank lines from generated code */
-		else if (in_gen
-			 && regexec (&regex_blank_line, buf, 0, NULL,
-				     0) == 0) {
+		else if (in_gen && is_blank_line(buf)) {
 			if (last_was_blank)
 				continue;
 			else

--- a/src/flexdef.h
+++ b/src/flexdef.h
@@ -1131,7 +1131,7 @@ extern int filter_fix_linedirs(struct filter *chain);
  * From "regex.c"
  */
 
-extern regex_t regex_linedir, regex_blank_line;
+extern regex_t regex_linedir;
 bool flex_init_regex(void);
 void flex_regcomp(regex_t *preg, const char *regex, int cflags);
 char   *regmatch_dup (regmatch_t * m, const char *src);

--- a/src/regex.c
+++ b/src/regex.c
@@ -25,10 +25,8 @@
 
 
 static const char* REGEXP_LINEDIR = "^#line ([[:digit:]]+) \"(.*)\"";
-static const char* REGEXP_BLANK_LINE = "^[[:space:]]*$";
 
 regex_t regex_linedir; /**< matches line directives */
-regex_t regex_blank_line; /**< matches blank lines */
 
 
 /** Initialize the regular expressions.
@@ -37,8 +35,6 @@ regex_t regex_blank_line; /**< matches blank lines */
 bool flex_init_regex(void)
 {
     flex_regcomp(&regex_linedir, REGEXP_LINEDIR, REG_EXTENDED);
-    flex_regcomp(&regex_blank_line, REGEXP_BLANK_LINE, REG_EXTENDED);
-
     return true;
 }
 


### PR DESCRIPTION
Introduce static is_blank_line() function in filter.c.
Remove regex_blank_line and use is_blank_line() in place of its role.