### PR TITLE
Ignore comment lines (%#) in skeleton files

### DIFF
--- a/src/misc.c
+++ b/src/misc.c
@@ -732,7 +732,10 @@ void skelout (void)
 			 */
 #define cmd_match(s) (strncmp(buf,(s),strlen(s))==0)
 
-			if (buf[1] == '%') {
+		if (buf[1] == '#') {
+                	/* %# indicates comment line to be ignored */
+            	} 
+		else if (buf[1] == '%') {
 				/* %% is a break point for skelout() */
 				return;
 			}


### PR DESCRIPTION
In skeleton files comments are indicated by leading `%#` and when directly read in using `flex -S <skeleton.skl>` they should be ignored. Example: `flex.skl`. 

Amending commit 2f21edac99b5efc432417233e6e53326d630e08f which removed this conditional branch.