### PR TITLE
scanner: remove BASENAME(); don't strip path from program_name

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -996,7 +996,7 @@ void flexinit (int argc, char **argv)
     flex_init_regex();
 
 	/* Enable C++ if program name ends with '+'. */
-	program_name = BASENAME(argv[0]);
+	program_name = argv[0];
 
 	if (program_name != NULL &&
 	    program_name[strlen (program_name) - 1] == '+')
@@ -1208,7 +1208,7 @@ void flexinit (int argc, char **argv)
 			break;
 
 		case OPT_VERSION:
-			printf (_("%s %s\n"), program_name, flex_version);
+			printf (_("%s %s\n"), (C_plus_plus ? "flex++" : "flex"), flex_version);
 			FLEX_EXIT (0);
 
 		case OPT_WARN:

--- a/src/main.c
+++ b/src/main.c
@@ -1208,7 +1208,7 @@ void flexinit (int argc, char **argv)
 			break;
 
 		case OPT_VERSION:
-			printf (_("%s %s\n"), (C_plus_plus ? "flex++" : "flex"), flex_version);
+			printf ("%s %s\n", (C_plus_plus ? "flex++" : "flex"), flex_version);
 			FLEX_EXIT (0);
 
 		case OPT_WARN:

--- a/src/scanopt.c
+++ b/src/scanopt.c
@@ -247,7 +247,7 @@ int     scanopt_usage (scanopt_t *scanner, FILE *fp, const char *usage)
 		fprintf (fp, "%s\n", usage);
 	}
 	else {
-		fprintf (fp, _("Usage: %s [OPTIONS]...\n"), BASENAME(s->argv[0]) );
+		fprintf (fp, _("Usage: %s [OPTIONS]...\n"), s->argv[0]);
 	}
 	fprintf (fp, "\n");
 


### PR DESCRIPTION
*Note: please test if help2man on flex still generates correct man page (i.e. no "../src/flex" or such) when building flex after this. I didn't yet test it.*

There's no technical need of stripping path from program_name. I think
the users should be fine if they see the path they use to invoke flex
is diagnostic messages and help texts.

Yes, users will see "Usage: ../flex [OPTIONS]..." now if they invoke
flex with the path "../flex".

The --version output has been changed so that the name field will be
always "flex" or "flex++". If the flex program has been renamed to
"lex" (for compatibility or other reason) this will allow identifying
the implementation name ("flex"). (And it's a recommended practice in
GNU Coding Standards)