### PR TITLE
build: always include config.h before stdlib.h

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -99,18 +99,31 @@ skel.c: flex.skl mkskel.sh flexint.h tables_shared.h tables_shared.c
 	$(SHELL) $(srcdir)/mkskel.sh $(srcdir) $(m4) $(VERSION) > $@.tmp
 	mv $@.tmp $@
 
+scan.c: scan.l scan.template
+	$(LEX) $(AM_LFLAGS) $(LFLAGS) -o $@ $(srcdir)/scan.l
+	mv $@ $@.new
+	cat $(srcdir)/scan.template $@.new > $@
+	rm -f $@.new
+
 if ENABLE_BOOTSTRAP
-stage1scan.c: scan.l stage1flex$(EXEEXT)
+stage1scan.c: scan.l stage1flex$(EXEEXT) scan.template
 	./stage1flex$(EXEEXT) $(AM_LFLAGS) $(LFLAGS) -o $@ $(srcdir)/scan.l
+	mv $@ $@.new
+	cat $(srcdir)/scan.template $@.new > $@
+	rm -f $@.new
 else
 stage1scan.c: scan.c
 	sed 's|^\(#line .*\)"'`printf %s $< | sed 's|[][\\\\.*]|\\\\&|g'`'"|\1"$@"|g' $< > $@
 endif
 
-dist-hook: scan.l flex$(EXEEXT)
+dist-hook: scan.l flex$(EXEEXT) scan.template
 	chmod u+w $(distdir)/scan.c && \
 	./flex$(EXEEXT) -o scan.c $< && \
+	mv scan.c scan.c.new
+	cat $(srcdir)/scan.template scan.c.new > scan.c
+	rm -f scan.c.new
 	mv scan.c $(distdir)
+	cp $(srcdir)/scan.template $(distdir)
 
 # make needs to be told to make parse.h so that parallelized runs will
 # not fail.

--- a/src/scan.template
+++ b/src/scan.template
@@ -1,0 +1,5 @@
+
+#ifdef HAVE_CONFIG_H
+#include <config.h>
+#endif
+


### PR DESCRIPTION
`scan.c` included `stdlib.h` before `config.h`. This caused problems when using the fallback `rpl_malloc` and `rpl_realloc` functions, since the `#define malloc rpl_malloc` happened after the function prototypes, so the functions were used with no prototype. This somehow worked with GCC 6.2.1 but emitted warnings; with GCC 7.1.1 this caused `stage1flex` to segfault.

To fix this, create `stage1scan.c` and `scan.c` using a custom rule which prepends the generated files to ensure that they include config.h.

I've tested this by generated a distribution tarball and compiling (both normally and with the rpl_* functions), so hopefully things work right off the bat. There may be a cleaner way to distribute `scan.template`; I'm no automake expert so I just picked a method that worked.

Fixes #247.