### PR TITLE
runtime for functional style code.

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -49,6 +49,18 @@ nodist_flex_SOURCES = \
 flex_CFLAGS = $(AM_CFLAGS) $(WARNINGFLAGS)
 
 COMMON_SOURCES = \
+	functional/boxes.c \
+	functional/boxes.h \
+	functional/character-class.c \
+	functional/character-class.h \
+	functional/function.c \
+	functional/function.h \
+	functional/gc.c \
+	functional/gc.h \
+	functional/list.c \
+	functional/list.h \
+	functional/operations.c \
+	functional/operations.h \
 	buf.c \
 	ccl.c \
 	dfa.c \
@@ -130,6 +142,18 @@ flex-stage1scan.$(OBJEXT): parse.h
 #   4. Run indent twice per file. The first time is a test.
 #      Otherwise, indent overwrites your file even if it fails!
 indentfiles = \
+	functional/boxes.c \
+	functional/boxes.h \
+	functional/character-class.c \
+	functional/character-class.h \
+	functional/function.c \
+	functional/function.h \
+	functional/gc.c \
+	functional/gc.h \
+	functional/list.c \
+	functional/list.h \
+	functional/operations.c \
+	functional/operations.h \
 	buf.c \
 	ccl.c \
 	dfa.c \

--- a/src/functional/boxes.c
+++ b/src/functional/boxes.c
@@ -1,0 +1,14 @@
+#include "boxes.h"
+#include "gc.h"
+
+int* int_number(int value) {
+	int* number = gc_malloc(sizeof *number);
+
+	return number ? (*number = value, number) : NULL;
+}
+
+unsigned char* unsigned_symbol(unsigned char value) {
+	unsigned char* symbol = gc_malloc(sizeof *symbol);
+
+	return symbol ? (*symbol = value, symbol) : NULL;
+}

--- a/src/functional/boxes.h
+++ b/src/functional/boxes.h
@@ -1,0 +1,7 @@
+#ifndef BOXES_H
+#define BOXES_H
+
+int* int_number(int value);
+unsigned char* unsigned_symbol(unsigned char value);
+
+#endif

--- a/src/functional/character-class.c
+++ b/src/functional/character-class.c
@@ -1,0 +1,83 @@
+#include "character-class.h"
+#include "boxes.h"
+#include "../flexdef.h"
+#include "operations.h"
+
+character_class_t  character_class_at_index_impl(size_t index) {
+	list_t* symbols = list_of(
+		unsigned char,
+		&ccltbl[cclmap[index]],
+		&ccltbl[cclmap[index] + ccllen[index]]
+	);
+	
+	return (character_class_t) { symbols, &ccllen[index] };
+}
+DEFINE_PUBLIC_FUNCTION(
+	character_class_at_index,
+	RETURN_VALUE(
+		character_class_at_index_impl,
+		character_class_t,
+		BIND_VALUE_ARG(size_t, 0)
+	)
+)
+
+
+static list_t* character_into_equivalence_symbols_impl(
+	list_t* accum,
+	unsigned char* character_class_symbol
+) {
+	int symbol = ecgroup[*character_class_symbol];
+
+	return symbol  > 0
+		? cons(unsigned_symbol(symbol), accum)
+		: accum;
+}
+DEFINE_PRIVATE_FUNCTION(
+	character_into_equivalence_symbols,
+	RETURN_POINTER(
+		character_into_equivalence_symbols_impl,
+		list_t,
+		BIND_POINTER_ARG(list_t, 0),
+		BIND_POINTER_ARG(unsigned char, 1)
+	)
+)
+
+
+character_class_t to_equivalence_class_impl(character_class_t klass) {
+	list_t* symbols = foldr(
+		character_into_equivalence_symbols,
+		list(),
+		klass.symbols
+	);
+
+	return (character_class_t) { symbols, int_number(length(symbols)) };
+}
+DEFINE_PUBLIC_FUNCTION(
+	to_equivalence_class,
+	RETURN_VALUE(
+		to_equivalence_class_impl,
+		character_class_t,
+		BIND_VALUE_ARG(character_class_t, 0)
+	)
+)
+
+
+static void deep_copy_symbols(list_t* destination, list_t* source) {
+    if (is_empty(source)) {
+        return;
+    }
+
+    unsigned char* from = head(source);
+    unsigned char* to = head(destination);
+
+    *to = *from;
+    deep_copy_symbols(tail(destination), tail(source));
+}
+
+void deep_copy_character_class(
+	character_class_t* destination,
+	character_class_t* source
+) {
+	deep_copy_symbols(destination->symbols, source->symbols);
+	*destination->length = *source->length;
+}

--- a/src/functional/character-class.h
+++ b/src/functional/character-class.h
@@ -1,0 +1,33 @@
+#ifndef CHARACTER_CLASS_H
+#define CHARACTER_CLASS_H
+
+#include "list.h"
+#include "function.h"
+
+typedef struct character_class_t character_class_t;
+
+struct character_class_t {
+    list_t* symbols;
+
+	/*
+	 * `length` field is redundant as it's value could be deduced
+	 * from `symbols` field.
+	 *
+	 * it is present here only for backward compatibility
+	 * since it points to element of `ccllen` array.
+	 */
+    int* length;
+};
+
+character_class_t  character_class_at_index_impl(size_t index);
+extern function_t* character_class_at_index;
+
+character_class_t to_equivalence_class_impl(character_class_t klass);
+extern function_t* to_equivalence_class;
+
+void deep_copy_character_class(
+	character_class_t* destination,
+	character_class_t* source
+);
+
+#endif

--- a/src/functional/function.c
+++ b/src/functional/function.c
@@ -1,0 +1,14 @@
+#include "function.h"
+#include "gc.h"
+
+function_t* bind_args_impl(function_t* fn, list_t* arguments) {
+	function_t* closure = gc_malloc(sizeof *closure);
+
+	return closure
+		? (*closure = (function_t) { fn->thunk, arguments }, closure)
+		: NULL;
+}
+
+void* apply(function_t* fn, list_t* arguments) {
+	return fn->thunk(concat(fn->arguments, arguments));
+}

--- a/src/functional/function.h
+++ b/src/functional/function.h
@@ -1,0 +1,52 @@
+#ifndef FUNCTION_H
+#define FUNCTION_H
+
+#include "gc.h"
+#include "list.h"
+
+typedef void* (*thunk_t)(list_t*);
+
+typedef struct function_t function_t;
+
+struct function_t {
+	thunk_t thunk;
+	list_t* arguments;
+};
+
+function_t* bind_args_impl(function_t* fn, list_t* arguments);
+#define bind_args(fn, ...) bind_args_impl(fn, list(__VA_ARGS__))
+
+#define CONCAT(a, b) a##b
+#define DEFINE_PUBLIC_FUNCTION(name, body)						\
+	static void* CONCAT(name, _thunk)(list_t* arguments) {		\
+		body													\
+	}															\
+	function_t* name = &(function_t) {							\
+		CONCAT(name, _thunk),									\
+		NULL													\
+	};
+#define DEFINE_PRIVATE_FUNCTION(name, body)						\
+	static void* CONCAT(name, _thunk)(list_t* arguments) {		\
+		body													\
+	}															\
+	static function_t* name = &(function_t) {					\
+		CONCAT(name, _thunk),									\
+		NULL													\
+	};
+
+#define BIND_VALUE_ARG(type, index) *(type*) nth(index, arguments)
+#define BIND_POINTER_ARG(type, index) (type*) nth(index, arguments)
+
+#define RETURN_NOTHING(fn, ...)							\
+	return fn(__VA_ARGS__), NULL;
+#define RETURN_POINTER(fn, type, ...)					\
+	return fn(__VA_ARGS__);
+#define RETURN_VALUE(fn, type, ...)						\
+	type value = fn(__VA_ARGS__);						\
+	type* result = gc_malloc(sizeof *result);			\
+	return result ? (*result = value, result) : NULL;
+
+void* apply(function_t* fn, list_t* arguments);
+#define call(fn, ...) apply(fn, list(__VA_ARGS__))
+
+#endif

--- a/src/functional/gc.c
+++ b/src/functional/gc.c
@@ -1,0 +1,54 @@
+#include "gc.h"
+
+#include <stdlib.h>
+
+typedef struct allocation_t allocation_t;
+
+struct allocation_t {
+	void* block;
+	finalizer_t finalize;
+	allocation_t* prev;
+};
+
+static allocation_t* allocation(
+	void* block,
+	finalizer_t finalize,
+	allocation_t* prev)
+{
+	allocation_t* record = malloc(sizeof *record);
+
+	return record
+		? (*record  = (allocation_t) { block, finalize, prev }, record)
+		: NULL;
+}
+
+static void gc_collect_from(allocation_t* allocation) {
+	if (allocation == NULL) {
+		return;
+	}
+
+	allocation->finalize(allocation->block);
+	allocation->block = NULL;
+
+	free(allocation);
+	gc_collect_from(allocation->prev);
+	allocation = NULL;
+}
+
+static allocation_t* allocations = NULL;
+
+void* gc_finalizable_malloc(size_t size, finalizer_t finalize) {
+	void* block = malloc(size);
+	allocations = allocation(block, finalize, allocations);
+	/* handle memory allocation fail */
+
+	return block;
+}
+
+void* gc_default_malloc(size_t size) {
+	return gc_malloc(size, free);
+}
+
+void gc_collect() {
+	gc_collect_from(allocations);
+}

--- a/src/functional/gc.h
+++ b/src/functional/gc.h
@@ -1,0 +1,16 @@
+#ifndef GC_H
+#define GC_H
+
+#include <stddef.h>
+
+typedef void (*finalizer_t)(void*);
+
+void* gc_default_malloc(size_t size);
+void* gc_finalizable_malloc(size_t size, finalizer_t finalize);
+void gc_collect();
+
+#define SELECT_GC_MALLOC(ARG1, ARG2, IMPL, ...) IMPL
+#define gc_malloc(...) SELECT_GC_MALLOC(__VA_ARGS__,		\
+	gc_finalizable_malloc, gc_default_malloc)(__VA_ARGS__)
+
+#endif

--- a/src/functional/list.c
+++ b/src/functional/list.c
@@ -1,0 +1,53 @@
+#include "list.h"
+#include "gc.h"
+
+list_t* cons(void* head, void* tail) {
+	list_t* list = gc_malloc(sizeof *list);
+
+	return list ? (*list = (list_t) { head, tail }, list) : NULL;
+}
+
+void* head(list_t* list) {
+	return list->head; 
+}
+
+void* tail(list_t* list) {
+	return list->tail; 
+}
+
+bool is_empty(list_t* list) {
+	return list == NULL;
+}
+
+list_t* concat(list_t* left, list_t* right) {
+	return is_empty(left)
+		? right
+		: cons(head(left), concat(tail(left), right));
+}
+
+void* nth(size_t index, list_t* list) {
+	return index == 0 ? head(list) : nth(index - 1, tail(list));
+}
+
+size_t length(list_t* list) {
+	return is_empty(list) ? 0 : 1 + length(tail(list));
+}
+
+list_t* list_of_impl(size_t element_size, void* first, void* last) {
+	list_t* head = NULL;
+	char* start = (char*) first - element_size;
+	char* stop = (char*) last - element_size;
+	char* cursor = stop;
+
+	for (; cursor != start; cursor -= element_size) {
+		head = cons(cursor, head);
+	}
+
+	return head;
+}
+
+list_t* list_from(void* elements[], size_t size) {
+	return size == 0
+		? NULL
+		: cons(elements[0], list_from(&elements[1], size - 1));
+}

--- a/src/functional/list.h
+++ b/src/functional/list.h
@@ -1,0 +1,31 @@
+#ifndef LIST_H
+#define LIST_H
+
+#include <stddef.h>
+#include <stdbool.h>
+
+typedef struct list_t list_t;
+
+struct list_t {
+	void* head;
+	void* tail;
+};
+
+list_t* cons(void* head, void* tail);
+void* head(list_t* list);
+void* tail(list_t* list);
+bool is_empty(list_t* list);
+list_t* concat(list_t* left, list_t* right);
+void* nth(size_t index, list_t* list);
+size_t length(list_t* list);
+list_t* list_of_impl(size_t element_size, void* first, void* last);
+list_t* list_from(void* elements[], size_t size);
+
+#define list_of(type, first, last)							\
+	list_of_impl(sizeof(type), first, last)
+
+#define list(...) list_from(								\
+	(void* []) { __VA_ARGS__ },								\
+	sizeof (void* []) { __VA_ARGS__ } / sizeof (void*) )
+
+#endif

--- a/src/functional/operations.c
+++ b/src/functional/operations.c
@@ -1,0 +1,113 @@
+#include "operations.h"
+#include "boxes.h"
+
+list_t* map(function_t* fn, list_t* list) {
+	return is_empty(list)
+		? list()
+		: cons(call(fn, head(list)), map(fn, tail(list)));
+}
+
+DEFINE_PUBLIC_FUNCTION(
+	map_fn,
+	RETURN_POINTER(
+		map,
+		list_t,
+		BIND_POINTER_ARG(function_t, 0),
+		BIND_POINTER_ARG(list_t, 1)
+	)
+)
+
+list_t* filter(function_t* predicate, list_t* list) {
+	return is_empty(list)
+		? list()
+		: concat(
+			*(bool*) call(predicate, head(list)) ? list(head(list)) : list(),
+			filter(predicate, tail(list))
+		);
+}
+
+DEFINE_PUBLIC_FUNCTION(
+	filter_fn,
+	RETURN_POINTER(
+		filter,
+		list_t,
+		BIND_POINTER_ARG(function_t, 0),
+		BIND_POINTER_ARG(list_t, 1)
+	)
+)
+
+void* fold(function_t* reducer, void* seed, list_t* list) {
+	return is_empty(list)
+		? seed
+		: fold(reducer, call(reducer, seed, head(list)), tail(list));
+}
+
+DEFINE_PUBLIC_FUNCTION(
+	fold_fn,
+	RETURN_POINTER(
+		fold,
+		void,
+		BIND_POINTER_ARG(function_t, 0),
+		BIND_POINTER_ARG(void, 1),
+		BIND_POINTER_ARG(list_t, 2)
+	)
+)
+
+void* foldr(function_t* reducer, void* seed, list_t* list) {
+	return is_empty(list)
+		? seed
+		: call(reducer, foldr(reducer, seed, tail(list)), head(list));
+}
+
+DEFINE_PUBLIC_FUNCTION(
+	foldr_fn,
+	RETURN_POINTER(
+		foldr,
+		void,
+		BIND_POINTER_ARG(function_t, 0),
+		BIND_POINTER_ARG(void, 1),
+		BIND_POINTER_ARG(list_t, 2)
+	)
+)
+
+list_t* generic_range(int begin, int end, int step) {
+	return begin >= end
+		? list()
+		: cons(int_number(begin), generic_range(begin + step, end, step));
+}
+
+list_t* canonical_range(int begin, int end) {
+	return generic_range(begin, end, 1);
+}
+
+static void* unary_call(void* value, function_t* fn) {
+	return call(fn, value);
+}
+
+DEFINE_PRIVATE_FUNCTION(
+	call_fn,
+	RETURN_POINTER(
+		unary_call,
+		void,
+		BIND_POINTER_ARG(function_t, 0),
+		BIND_POINTER_ARG(void, 1)
+	)
+)
+
+static void* compose_functions_impl(list_t* functions, void* value) {
+	return foldr(call_fn, value, functions);
+}
+
+DEFINE_PRIVATE_FUNCTION(
+	compose_functions,
+	RETURN_POINTER(
+		compose_functions_impl,
+		void,
+		BIND_POINTER_ARG(list_t, 0),
+		BIND_POINTER_ARG(void, 1)
+	)
+)
+
+function_t* composition_of(list_t* functions) {
+	return bind_args(compose_functions, functions);
+}

--- a/src/functional/operations.h
+++ b/src/functional/operations.h
@@ -1,0 +1,28 @@
+#ifndef FUNCTIONAL_H
+#define FUNCTIONAL_H
+
+#include "list.h"
+#include "function.h"
+
+list_t* map(function_t* fn, list_t* list);
+extern function_t* map_fn;
+
+list_t* filter(function_t* predicate, list_t* list);
+extern function_t* filter_fn;
+
+void* fold(function_t* reducer, void* seed, list_t* list);
+extern function_t* fold_fn;
+
+void* foldr(function_t* reducer, void* seed, list_t* list);
+extern function_t* foldr_fn;
+
+list_t* generic_range(int begin, int end, int step);
+list_t* canonical_range(int begin, int end);
+
+#define SELECT_RANGE(ARG1, ARG2, ARG3, IMPL, ...) IMPL
+#define range(...) SELECT_RANGE(__VA_ARGS__, generic_range, canonical_range)(__VA_ARGS__)
+
+function_t* composition_of(list_t* functions);
+#define compose(...) composition_of(list(__VA_ARGS__))
+
+#endif


### PR DESCRIPTION
**Issue:**
it is hard to read/analyze/modify code with deeply nested loops.

**Root cause:**
C language does not provide constructs for declarative computations.

**Solution:**
minimalistic FP runtime is introduced, small bit of code has loop
replaced with FP expressions as a showcase.

**Implementatin details:**
  * some operations defined recursively as gcc/clang compilers
    replace it with plain iterations under `-O2` flag which is
    utilized during build, see `-foptimize-sibling-calls` flag.
  * garbage collector justs track allocation and had to be
    launched manually, it will be replaced with conservative
    GC once whole FP idea will be accepted.

issue ticket - https://github.com/westes/flex/issues/250