### PR TITLE
Line directive correction package

### DIFF
--- a/src/buf.c
+++ b/src/buf.c
@@ -95,7 +95,7 @@ struct Buf *buf_linedir (struct Buf *buf, const char* filename, int lineno)
     const char *src;
     size_t tsz;
 
-    if (gen_line_dirs)
+    if (!gen_line_dirs)
 	return buf;
 
     tsz = strlen("#line \"\"\n")                +   /* constant parts */

--- a/src/buf.c
+++ b/src/buf.c
@@ -91,28 +91,13 @@ struct Buf *buf_prints (struct Buf *buf, const char *fmt, const char *s)
  */
 struct Buf *buf_linedir (struct Buf *buf, const char* filename, int lineno)
 {
-    char *dst, *t;
-    const char *src;
-    size_t tsz;
-
     if (!gen_line_dirs)
 	return buf;
 
-    tsz = strlen("#line \"\"\n")                +   /* constant parts */
-               2 * strlen (filename)            +   /* filename with possibly all backslashes escaped */
-               (size_t) (1 + ceil (log10 (abs (lineno)))) +   /* line number */
-               1;                                   /* NUL */
-    t = malloc(tsz);
-    if (!t)
-      flexfatal (_("Allocation of buffer for line directive failed"));
-    for (dst = t + snprintf (t, tsz, "#line %d \"", lineno), src = filename; *src; *dst++ = *src++)
-      if (*src == '\\')   /* escape backslashes */
-        *dst++ = '\\';
-    *dst++ = '"';
-    *dst++ = '\n';
-    *dst   = '\0';
-    buf = buf_strappend (buf, t);
-    free(t);
+    char directive[MAXLINE];
+    sprintf(directive, "#line %d \"%s\"\n", lineno, filename);
+    buf = buf_strappend(buf, directive);
+
     return buf;
 }
 

--- a/src/flexdef.h
+++ b/src/flexdef.h
@@ -1116,6 +1116,7 @@ struct filter {
 };
 
 /* output filter chain */
+extern const char* m4_line_dir_dummy;
 extern struct filter * output_chain;
 extern struct filter *filter_create_ext (struct filter * chain, const char *cmd, ...);
 struct filter *filter_create_int(struct filter *chain,

--- a/src/main.c
+++ b/src/main.c
@@ -492,7 +492,7 @@ void check_options (void)
 
     /* Place a bogus line directive, it will be fixed in the filter. */
     if (gen_line_dirs)
-        outn("#line 0 \"M4_YY_OUTFILE_NAME\"\n");
+        outn(m4_line_dir_dummy);
 
 	/* Dump the user defined preproc directives. */
 	if (userdef_buf.elts)

--- a/src/misc.c
+++ b/src/misc.c
@@ -345,45 +345,24 @@ void lerr_fatal (const char *msg, ...)
 
 void line_directive_out (FILE *output_file, int do_infile)
 {
-	char    directive[MAXLINE], filename[MAXLINE];
-	char   *s1, *s2, *s3;
-	static const char line_fmt[] = "#line %d \"%s\"\n";
+    char   directive[MAXLINE];
+    char   *d;
 
-	if (!gen_line_dirs)
-		return;
+    if (!gen_line_dirs)
+        return;
 
-	s1 = do_infile ? infilename : "M4_YY_OUTFILE_NAME";
+    if ( do_infile )
+    {
+        snprintf (directive, sizeof(directive), "#line %d \"%s\"\n", linenum, infilename ? infilename : "<stdin>");
+        d = &directive[0];
+    }
+    else
+        d = (char*) m4_line_dir_dummy;
 
-	if (do_infile && !s1)
-        s1 = "<stdin>";
-    
-	s2 = filename;
-	s3 = &filename[sizeof (filename) - 2];
-
-	while (s2 < s3 && *s1) {
-		if (*s1 == '\\' || *s1 == '"')
-			/* Escape the '\' or '"' */
-			*s2++ = '\\';
-
-		*s2++ = *s1++;
-	}
-
-	*s2 = '\0';
-
-	if (do_infile)
-		snprintf (directive, sizeof(directive), line_fmt, linenum, filename);
-	else {
-		snprintf (directive, sizeof(directive), line_fmt, 0, filename);
-	}
-
-	/* If output_file is nil then we should put the directive in
-	 * the accumulated actions.
-	 */
-	if (output_file) {
-		fputs (directive, output_file);
-	}
-	else
-		add_action (directive);
+    if (output_file)
+        fputs (d, output_file);
+    else
+        add_action (d);
 }
 
 

--- a/src/parse.y
+++ b/src/parse.y
@@ -136,11 +136,12 @@ goal		:  initlex sect1 sect1end sect2 initforrule
 
 			if ( spprdflt )
 				add_action(
-				"YY_FATAL_ERROR( \"flex scanner jammed\" )" );
+				"YY_FATAL_ERROR( \"flex scanner jammed\" );\n" );
 			else
-				add_action( "ECHO" );
+				add_action( "ECHO;\n" );
 
-			add_action( ";\n\tYY_BREAK]]\n" );
+			add_action(m4_line_dir_dummy);
+			add_action( "\tYY_BREAK]]\n" );
 			}
 		;
 

--- a/src/scan.l
+++ b/src/scan.l
@@ -241,10 +241,13 @@ M4QEND      "]""]"
 	\n		yy_pop_state();
 	[[:digit:]]+	linenum = myctoi( yytext );
 
-	\"[^"\n]*\"	{
+	\"[^"\n]+\"	{
 			free(infilename);
 			infilename = xstrdup(yytext + 1);
 			infilename[strlen( infilename ) - 1] = '\0';
+			/* convert '\' to '/' */
+			char* p = infilename;
+			while((p = strchr(p, '\\'))){*p++ = '/';}
 			}
 	.		/* ignore spurious characters */
 }
@@ -1017,6 +1020,8 @@ void set_input_file( char *file )
 		{
 		infilename = xstrdup(file);
 		yyin = fopen( infilename, "r" );
+		char* p= infilename;
+		while( (p=strchr(p,'\\'))){*p++='/';}
 
 		if ( yyin == NULL )
 			lerr( _( "can't open %s" ), file );

--- a/src/scan.l
+++ b/src/scan.l
@@ -101,23 +101,6 @@ extern const char *escaped_qstart, *escaped_qend;
 	if ( getenv("POSIXLY_CORRECT") ) \
 		posix_compat = true;
 
-#define START_CODEBLOCK(x) do { \
-    /* Emit the needed line directive... */\
-    if (indented_code == false) { \
-        linenum++; \
-        line_directive_out(NULL, 1); \
-    } \
-    add_action(M4QSTART); \
-    yy_push_state(CODEBLOCK); \
-    if ((indented_code = x)) ACTION_ECHO; \
-} while(0)
-
-#define END_CODEBLOCK do { \
-    yy_pop_state();\
-    add_action(M4QEND); \
-    if (!indented_code) line_directive_out(NULL, 0);\
-} while (0)
-
 %}
 
 %option caseless nodefault noreject stack noyy_top_state
@@ -166,12 +149,12 @@ M4QEND      "]""]"
 
 
 <INITIAL>{
-	^{WS}		START_CODEBLOCK(true);
+	^{WS}		indented_code = true;add_action(M4QSTART);yy_push_state(CODEBLOCK);ACTION_ECHO;
 	^"/*"		add_action("/*[""["); yy_push_state( COMMENT );
 	^#{OPTWS}line{WS}	yy_push_state( LINEDIR );
 	^"%s"{NAME}?	return SCDECL;
 	^"%x"{NAME}?	return XSCDECL;
-	^"%{".*{NL}	START_CODEBLOCK(false);
+	^"%{".*{NL}	indented_code = false;linenum++;line_directive_out(NULL, 1);add_action(M4QSTART);yy_push_state(CODEBLOCK);
     ^"%top"[[:blank:]]*"{"[[:blank:]]*{NL}    {
                 brace_start_line = linenum;
                 ++linenum;
@@ -184,11 +167,13 @@ M4QEND      "]""]"
 
 	{WS}		/* discard */
 
-	^"%%".*		{
+	^"%%".*{NL}		{
 			sectnum = 2;
 			bracelevel = 0;
 			mark_defs1();
+			linenum++;
 			line_directive_out(NULL, 1);
+			indented_code = false;
 			BEGIN(SECT2PROLOG);
 			return SECTEND;
 			}
@@ -269,14 +254,9 @@ M4QEND      "]""]"
 }
 
 <CODEBLOCK>{
-	^"%}".*{NL}	++linenum; END_CODEBLOCK;
-	[^\n%\[\]]*         ACTION_ECHO;
+	^"%}".*{NL}	yy_pop_state();add_action(M4QEND);++linenum;line_directive_out(NULL, 0);
+	{NL}        ++linenum;ACTION_ECHO;if ( indented_code ) {yy_pop_state();add_action(M4QEND); }
         .		ACTION_ECHO;
-	{NL}		{
-			++linenum;
-			ACTION_ECHO;
-			if ( indented_code ) END_CODEBLOCK;
-			}
 }
 
 <CODEBLOCK_MATCH_BRACE>{
@@ -487,7 +467,7 @@ M4QEND      "]""]"
 	^"%{".*	++bracelevel; yyless( 2 );	/* eat only %{ */
 	^"%}".*	--bracelevel; yyless( 2 );	/* eat only %} */
 
-	^{WS} START_CODEBLOCK(true); /* indented code in prolog */
+	^{WS}   indented_code = true;add_action(M4QSTART);yy_push_state(CODEBLOCK);ACTION_ECHO; /* indented code in prolog */
 
 	^{NOT_WS}.*	{
         /* non-indented code */
@@ -498,7 +478,7 @@ M4QEND      "]""]"
             mark_prolog();
             BEGIN(SECT2);
         } else {
-            START_CODEBLOCK(true);
+            indented_code = true;add_action(M4QSTART);yy_push_state(CODEBLOCK);ACTION_ECHO;
         }
     }
 
@@ -519,6 +499,7 @@ M4QEND      "]""]"
 			indented_code = false;
 			doing_codeblock = true;
 			bracelevel = 1;
+			line_directive_out(NULL, 1);
 			BEGIN(PERCENT_BRACE_ACTION);
 			}
 
@@ -541,6 +522,7 @@ M4QEND      "]""]"
 
 	{WS}"%{"		{
 			bracelevel = 1;
+			line_directive_out(NULL, 1);
 			BEGIN(PERCENT_BRACE_ACTION);
 
 			if ( in_rule )

--- a/src/scan.l
+++ b/src/scan.l
@@ -908,7 +908,10 @@ nmstr[yyleng - 2 - end_is_ws] = '\0';  /* chop trailing brace */
 		ACTION_ECHO;
 		if (bracelevel <= 0 || (doing_codeblock && indented_code)) {
             if ( doing_rule_action )
+            {
+                add_action(m4_line_dir_dummy);
                 add_action( "\tYY_BREAK]""]\n" );
+            }
 
             doing_rule_action = doing_codeblock = false;
             BEGIN(SECT2);
@@ -931,7 +934,10 @@ nmstr[yyleng - 2 - end_is_ws] = '\0';  /* chop trailing brace */
                 ACTION_ECHO;
                 if (bracelevel <= 0) {
                    if ( doing_rule_action )
+                   {
+                      add_action(m4_line_dir_dummy);
                       add_action( "\tYY_BREAK]""]\n" );
+                   }
 
                    doing_rule_action = false;
                    BEGIN(SECT2);


### PR DESCRIPTION
Here a sequence of commits covering the `#line` directive issues (#235 and, potentially, #251) which leave the code created by flex untouched. I hope the changes are well chopped to pieces to make the changes understandable.

Separately - and in case someone wants to compare two versions of `flex` - attached a small [zip package](https://github.com/westes/flex/files/1247262/line-dir_2017-08-24.zip) for a `#line` directive consistency check and a code text regression test (based on a `make` file invoking two `awk` scripts). Note that you need `make`, `gawk`, `sed` and `diff` to run the tests. Both of them run against the test `.l` files in the `tests` folder show that the commits do not change the code generated by `flex` as such.

Some summarizing notes:

* the line directives created by flex are now consistent for `.l` files and can be used for debugging; I partially rolled back commit  4bffa41 for code transparency reasons. It took me awfully long to check things before I decided to eliminate the macros introduced by this commit, whereas after making them explicit again it was kind of easy to see what is going on ... and wrong. I hope this is fine with the author of the mentioned commit.
* the case statements in the function `yylex` are now closed by `#line` directives relative to the flex generated code (in line with `bison`'s output)
* cleaning up the functions `buf_linedir` and `filter_fix_linedirs`; the latter is now independent of `<regex.h>` after Explorer09 took the first step in that direction in commit e784a80.  The full removal of this dependency is not contained in the package, but should be easy I believe. However, I must admit that I better keep away from the `autotools` monster.
* various bugs fixed and some minor edits applied 

Hope this is useful.