### PR TITLE
Create libfl.pc target for pkgconfig

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -64,3 +64,6 @@ install-exec-hook:
 		$(LN_S) -f flex$(EXEEXT) flex++$(EXEEXT)
 
 .PHONY: ChangeLog indent
+
+pkgconfigdir = @pkgconfigdir@
+pkgconfig_DATA = libfl.pc

--- a/configure.ac
+++ b/configure.ac
@@ -54,6 +54,9 @@ AC_PROG_LN_S
 AC_PROG_AWK
 AC_PROG_INSTALL
 
+pkgconfigdir=${libdir}/pkgconfig
+AC_SUBST(pkgconfigdir)
+
 # allow passing a variable `WARNINGFLAGS',
 #   either when invoking `configure', or when invoking `make'
 # default to something useful if GCC was detected
@@ -180,6 +183,7 @@ po/Makefile.in
 src/Makefile
 tools/Makefile
 tests/Makefile
+libfl.pc
 )
 
 AC_OUTPUT

--- a/libfl.pc.in
+++ b/libfl.pc.in
@@ -1,0 +1,10 @@
+prefix=@prefix@
+exec_prefix=@exec_prefix@
+libdir=@libdir@
+includedir=@includedir@
+
+Name: libfl
+Description: The fast lexical analyser
+Version: @PACKAGE_VERSION@
+Libs: -L${libdir} -lfl
+Cflags: -I${includedir}


### PR DESCRIPTION
This adds a target to generate `libfl.pc`, a file used by `pkg-config` to locate shared objects and header files.