### PR TITLE
build: make it possible to disable the build of the flex program

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -62,8 +62,10 @@ ChangeLog: $(srcdir)/tools/git2cl
 indent:
 	cd src && $(MAKE) $(AM_MAKEFLAGS) indent
 
+if ENABLE_PROGRAM
 install-exec-hook:
 	cd $(DESTDIR)$(bindir) && \
 		$(LN_S) -f flex$(EXEEXT) flex++$(EXEEXT)
+endif
 
 .PHONY: ChangeLog indent

--- a/configure.ac
+++ b/configure.ac
@@ -75,6 +75,12 @@ AC_ARG_ENABLE([libfl],
   [], [enable_libfl=yes])
 AM_CONDITIONAL([ENABLE_LIBFL], [test "x$enable_libfl" = xyes])
 
+AC_ARG_ENABLE([program],
+  [AS_HELP_STRING([--disable-program],
+                  [do not build the flex program, only the libfl library])],
+  [], [enable_program=yes])
+AM_CONDITIONAL([ENABLE_PROGRAM], [test "x$enable_program" = xyes])
+
 # --disable-bootstrap is intended only to workaround problems with bootstrap
 # (e.g. when cross-compiling flex or when bootstrapping has bugs).
 # Ideally we should be able to bootstrap even when cross-compiling.

--- a/doc/Makefile.am
+++ b/doc/Makefile.am
@@ -1,7 +1,11 @@
 FLEX = $(top_builddir)/src/flex$(EXEEXT)
 
 info_TEXINFOS =	flex.texi
+
+if ENABLE_PROGRAM
 dist_man_MANS = flex.1
+endif
+
 MAINTAINERCLEANFILES = flex.1
 
 CLEANFILES = *.aux *.cp *.cps *.fn *.fns *.hk *.hks *.ky *.log \

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -4,7 +4,10 @@ LIBS = @LIBS@
 
 m4 = @M4@
 
+if ENABLE_PROGRAM
 bin_PROGRAMS = flex
+endif
+
 if ENABLE_BOOTSTRAP
 noinst_PROGRAMS = stage1flex
 endif


### PR DESCRIPTION
The flex program uses fork(), which isn't available on noMMU
systems. However, the libfl library does not use fork(), and be used
by other programs/libraries.

Therefore, it makes sense to provide an option to disable the build of
the flex program.

Signed-off-by: Thomas Petazzoni <thomas.petazzoni@free-electrons.com>