### PR TITLE
Forward declare rpl_* functions.

### DIFF
--- a/src/flexdef.h
+++ b/src/flexdef.h
@@ -37,6 +37,12 @@
 
 #ifdef HAVE_CONFIG_H
 #include <config.h>
+#if defined(malloc) || defined(realloc)
+/* Must forward declare or scan.c would compile to wrong code. */
+#include <stddef.h>
+extern void *rpl_malloc(size_t);
+extern void *rpl_realloc(void *, size_t);
+#endif
 #endif
 
 #include <stdio.h>


### PR DESCRIPTION
Better than #248 approach.
Fixes #247.
Note to @hobbitalastair: I didn't get a segfault when I test bootstrapping this, but at least I killed compiler warnings.