### PR TITLE
Include flexdef.h at %top block of scan.l

### DIFF
--- a/src/scan.l
+++ b/src/scan.l
@@ -1,5 +1,11 @@
 /* scan.l - scanner for flex input -*-C-*- */
 
+%top{
+/* flexdef.h includes config.h, which may contain macros that alter the API */
+/* of libc functions. Must include first before any libc header. */
+#include "flexdef.h"
+}
+
 %{
 /*  Copyright (c) 1990 The Regents of the University of California. */
 /*  All rights reserved. */
@@ -32,7 +38,6 @@
 /*  WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR */
 /*  PURPOSE. */
 
-#include "flexdef.h"
 #include "parse.h"
 extern bool tablesverify, tablesext;
 extern int trlcontxt; /* Set in  parse.y for each rule. */


### PR DESCRIPTION
config.h may defines feature macros that alter the API of the standard
library functions, and so it should be included before any other
standard header, even before skeleton's standard header inclusion.

For example: config.h may #define _GNU_SOURCE that would expose
reallocarray() prototype from <stdlib.h> (glibc 2.26+). If we include
<stdlib.h> before config.h, reallocarray() would not be available for
use in lex file (second include doesn't help due to header guard).

For now our config.h might `#define malloc rpl_malloc` -- this
substitution must work before including stdlib.h, or else compiler will
complain about missing prototypes, and may result in wrong code in
scan.l (gcc warning: return makes pointer from integer without a cast
[-Wint-conversion]).

Proper way to fix #247.