### PR TITLE
Define _POSIX_C_SOURCE when needed in skeleton.

### DIFF
--- a/src/flex.skl
+++ b/src/flex.skl
@@ -218,6 +218,14 @@ m4_ifdef( [[M4_YY_TABLES_EXTERNAL]],
 
 /* begin standard C headers. */
 %if-c-only
+m4_ifdef( [[M4_YY_ALWAYS_INTERACTIVE]], ,
+[[m4_ifdef( [[M4_YY_NEVER_INTERACTIVE]], ,
+[[#ifndef _POSIX_C_SOURCE
+#define _POSIX_C_SOURCE 1 /* for fileno() */
+#ifndef _POSIX_SOURCE
+#define _POSIX_SOURCE 1
+#endif
+#endif]])]])
 #include <stdio.h>
 #include <string.h>
 #include <errno.h>


### PR DESCRIPTION
This is a quick fix of #263 where we lack feature macro to expose the API of fileno().