### PR TITLE
Temporary protection against ccl overflow & overwriting

### DIFF
--- a/src/ccl.c
+++ b/src/ccl.c
@@ -73,6 +73,13 @@ void ccladd (int cclp, int ch)
 
 	newpos = ind + len;
 
+	/* For a non-last cclp, expanding the set will overflow and overwrite a
+	 * char in the next cclp.
+	 * FIXME: Need another allocation scheme for ccl's. */
+	if (cclp != lastccl) {
+		flexfatal(_("internal error: trying to add a char to a non-last ccl.\n"));
+	}
+
 	if (newpos >= current_max_ccl_tbl_size) {
 		current_max_ccl_tbl_size += MAX_CCL_TBL_SIZE_INCREMENT;
 


### PR DESCRIPTION
For ccladd(), if cclp given is a non-last ccl, adding a char into it
will overflow the buffer and overwrite the first char in the next ccl.

For now, add a temporary detection and protection code.
(Not sure if this could happen in user input, but if it could, then
you can expect some "corrupted" behavior for generated scanners.)