### PR TITLE
Remove unused BASENAME() macro

### DIFF
--- a/src/flexdef.h
+++ b/src/flexdef.h
@@ -45,7 +45,6 @@
 #include <setjmp.h>
 #include <ctype.h>
 #include <string.h>
-#define BASENAME(p)   strrchr(p, '/') ? strrchr(p, '/') + 1 : strrchr(p, '\\') ? strrchr(p, '\\') + 1 : p
 #include <math.h>
 
 #ifdef HAVE_ASSERT_H


### PR DESCRIPTION
(Simply forgot to do so in commit fb731ac0221e1866534dfe072b84b8af7a5d88f3)