### PR TITLE
Fixed twice assigned value

### DIFF
--- a/src/scanopt.c
+++ b/src/scanopt.c
@@ -141,7 +141,6 @@ scanopt_t *scanopt_init (const optspec_t *options, int argc, char **argv, int fl
 	s = malloc(sizeof (struct _scanopt_t));
 
 	s->options = options;
-	s->optc = 0;
 	s->argc = argc;
 	s->argv = (char **) argv;
 	s->index = 1;


### PR DESCRIPTION
I'm a member of the Pinguem.ru competition on finding errors in open source projects. A warnings, found using PVS-Studio:
flex/src/scanopt.c  154     warn    V519 The 's->optc' variable is assigned values twice successively. Perhaps this is a mistake. Check lines: 144, 154.