### PR TITLE
Obsolete yypad64() macro.

### DIFF
--- a/src/flex.skl
+++ b/src/flex.skl
@@ -3292,9 +3292,7 @@ static int yytbl_data_load YYFARGS2(struct yytbl_dmap *, dmap, struct yytbl_read
 
     /* Now eat padding. */
     {
-        int pad;
-        pad = yypad64(rd->bread);
-        while(--pad >= 0){
+        while (rd->bread % (8 * sizeof(flex_uint8_t)) > 0) {
             flex_int8_t t8;
             if(yytbl_read8(&t8,rd) != 0)
                 return -1;

--- a/src/tables.c
+++ b/src/tables.c
@@ -87,7 +87,7 @@ int yytbl_hdr_init (struct yytbl_hdr *th, const char *version_str,
 
 	th->th_magic = YYTBL_MAGIC;
 	th->th_hsize = (flex_uint32_t) (14 + strlen (version_str) + 1 + strlen (name) + 1);
-	th->th_hsize += yypad64 (th->th_hsize);
+	th->th_hsize += (8 - (th->th_hsize % 8)) % 8; // Pad to 64-bit boundary
 	th->th_ssize = 0;	// Not known at this point.
 	th->th_flags = 0;
 	th->th_version = xstrdup(version_str);
@@ -124,14 +124,14 @@ int yytbl_data_destroy (struct yytbl_data *td)
 /** Write enough padding to bring the file pointer to a 64-bit boundary. */
 static int yytbl_write_pad64 (struct yytbl_writer *wr)
 {
-	int     pad, bwritten = 0;
+	int bwritten = 0;
 
-	pad = yypad64 (wr->total_written);
-	while (pad-- > 0)
+	while (wr->total_written % (8 * sizeof(flex_uint8_t)) > 0) {
 		if (yytbl_write8 (wr, 0) < 0)
 			return -1;
 		else
 			bwritten++;
+	}
 	return bwritten;
 }
 

--- a/src/tables_shared.h
+++ b/src/tables_shared.h
@@ -63,12 +63,6 @@ dnl  flex code (hence the name "_shared").
 #define YYTBL_MAGIC 0xF13C57B1
 #endif
 
-/** Calculate (0-7) = number bytes needed to pad n to next 64-bit boundary. */
-#ifndef yypad64
-#define yypad64(n) ((8-((n)%8))%8)
-#endif
-
-
 #ifndef YYTABLES_TYPES
 #define YYTABLES_TYPES
 /** Possible values for td_id field. Each one corresponds to a


### PR DESCRIPTION
Slightly rewrite the logic in yytbl_data_load() and yytbl_write_pad64()
so they simply check if the bytes read/written are in 8-byte boundary.
No need to calculate how many bytes we need to pad. (Incidentally this
makes smaller code in x86_64.)

For yytbl_hdr_init(), just expand the calculation from the macro.