### PR TITLE
Consistently use #ifdef for ENABLE_NLS check

### DIFF
--- a/src/gettext.h
+++ b/src/gettext.h
@@ -20,7 +20,7 @@
 #define _LIBGETTEXT_H 1
 
 /* NLS can be disabled through the configure --disable-nls option.  */
-#if ENABLE_NLS
+#ifdef ENABLE_NLS
 
 /* Get declarations of GNU message catalog functions.  */
 # include <libintl.h>

--- a/src/main.c
+++ b/src/main.c
@@ -197,7 +197,7 @@ int flex_main (int argc, char *argv[])
 /* Wrapper around flex_main, so flex_main can be built as a library. */
 int main (int argc, char *argv[])
 {
-#if ENABLE_NLS
+#ifdef ENABLE_NLS
 #if HAVE_LOCALE_H
 	setlocale (LC_MESSAGES, "");
         setlocale (LC_CTYPE, "");


### PR DESCRIPTION
config.h will have either define ENABLE_NLS or not define it. If it is not
defined we get a -Wundef warning due to using #if with an undefined macro