### PR TITLE
build: proper fix for ENABLE_NLS preprocessor check

### DIFF
--- a/src/flexdef.h
+++ b/src/flexdef.h
@@ -76,8 +76,10 @@
 #include <strings.h>
 #include "flexint.h"
 
-/* We use gettext. So, when we write strings which should be translated, we mark them with _() */
-#ifdef ENABLE_NLS
+/* We use gettext. So, when we write strings which should be translated, we
+ * mark them with _()
+ */
+#if defined(ENABLE_NLS) && ENABLE_NLS
 #ifdef HAVE_LOCALE_H
 #include <locale.h>
 #endif /* HAVE_LOCALE_H */

--- a/src/main.c
+++ b/src/main.c
@@ -197,7 +197,7 @@ int flex_main (int argc, char *argv[])
 /* Wrapper around flex_main, so flex_main can be built as a library. */
 int main (int argc, char *argv[])
 {
-#ifdef ENABLE_NLS
+#if defined(ENABLE_NLS) && ENABLE_NLS
 #if HAVE_LOCALE_H
 	setlocale (LC_MESSAGES, "");
         setlocale (LC_CTYPE, "");


### PR DESCRIPTION
Because ENABLE_NLS may be defined to 0 (manually, not through autoconf)
and it's semantically incorrect to only check whether it's defined.

This is a correction to commit 661d603b65385f62f372acd2017e5af2e0f0cd50.