### PR TITLE
Allow "--" as option argument.

### DIFF
--- a/src/scanopt.c
+++ b/src/scanopt.c
@@ -733,8 +733,7 @@ int     scanopt (scanopt_t *svoid, char **arg, int *optindex)
 
 	/* Look ahead in argv[] to see if there is something
 	 * that we can use as an argument (if needed). */
-	has_next = s->index + 1 < s->argc
-		&& strcmp ("--", s->argv[s->index + 1]) != 0;
+	has_next = s->index + 1 < s->argc;
 
 	optp = s->options + opt_offset;
 	auxp = s->aux + opt_offset;


### PR DESCRIPTION
Fixes #285, where invocation like this would fail with "requires an
argument" error message:

    flex --outfile -- wc1.l