### PR TITLE
scan.l: fix ignoring start conditions

### DIFF
--- a/doc/flex.texi
+++ b/doc/flex.texi
@@ -1625,7 +1625,8 @@ will be active only when the current start condition is either
 @cindex start conditions, inclusive v.s.@: exclusive
 Start conditions are declared in the definitions (first) section of the
 input using unindented lines beginning with either @samp{%s} or
-@samp{%x} followed by a list of names.  The former declares
+@samp{%x} followed by a list of one or more names, delimited by
+blanks or tabs, until the end of line.  The former declares
 @dfn{inclusive} start conditions, the latter @dfn{exclusive} start
 conditions.  A start condition is activated using the @code{BEGIN}
 action.  Until the next @code{BEGIN} action is executed, rules with the

--- a/src/scan.l
+++ b/src/scan.l
@@ -174,8 +174,8 @@ M4QEND      "]""]"
 	^{WS}		START_CODEBLOCK(true);
 	^"/*"		add_action("/*[""["); yy_push_state( COMMENT );
 	^#{OPTWS}line{WS}	yy_push_state( LINEDIR );
-	^"%s"{NAME}?	return SCDECL;
-	^"%x"{NAME}?	return XSCDECL;
+	^"%s"       return SCDECL;
+	^"%x"       return XSCDECL;
 	^"%{".*{NL}	START_CODEBLOCK(false);
     ^"%top"[[:blank:]]*"{"[[:blank:]]*{NL}    {
                 brace_start_line = linenum;

--- a/tests/.gitignore
+++ b/tests/.gitignore
@@ -91,6 +91,8 @@ quote_in_comment
 quote_in_comment.c
 quotes
 quotes.c
+scname_excl_decl1.c
+scname_incl_decl1.c
 string_nr
 string_nr.c
 string_r

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -90,6 +90,8 @@ simple_tests = \
 	prefix_r \
 	quote_in_comment \
 	quotes \
+	scname_excl_decl1 \
+	scname_incl_decl1 \
 	string_nr \
 	string_r \
 	top \
@@ -177,6 +179,8 @@ reject_ver_table_SOURCES = reject.l4
 reject_ser_table_SOURCES = reject.l4
 rescan_nr_direct_SOURCES = rescan_nr.direct.l
 rescan_r_direct_SOURCES = rescan_r.direct.l
+scname_excl_decl1_SOURCES = scname_excl_decl1.l
+scname_incl_decl1_SOURCES = scname_incl_decl1.l
 string_nr_SOURCES = string_nr.l
 string_r_SOURCES = string_r.l
 top_SOURCES = top.l top_main.c
@@ -256,6 +260,8 @@ CLEANFILES = \
 	reject_ver.table.tables \
 	rescan_nr.direct.c \
 	rescan_r.direct.c \
+	scname_excl_decl1.c \
+	scname_incl_decl1.c \
 	string_nr.c \
 	string_r.c \
 	top.c \

--- a/tests/scname_excl_decl1.l
+++ b/tests/scname_excl_decl1.l
@@ -1,0 +1,22 @@
+%option noyywrap noinput nounput
+
+ /*
+   This test checks if a name of a start condition
+   which immediately follows '%x' is recognized as
+   such by flex.
+ */
+%xA B
+%%
+.
+%%
+int main()
+{
+	int i = 0;
+
+#ifndef A
+	fprintf(stderr, "FAILED - '%%x' start condition 'A' not defined\n");
+	i++;
+#endif
+
+	return i > 0;
+}

--- a/tests/scname_incl_decl1.l
+++ b/tests/scname_incl_decl1.l
@@ -1,0 +1,22 @@
+%option noyywrap noinput nounput
+
+ /*
+   This test checks if a name of a start condition
+   which immediately follows '%s' is recognized as
+   such by flex.
+ */
+%sA B
+%%
+.
+%%
+int main()
+{
+	int i = 0;
+
+#ifndef A
+	fprintf(stderr, "FAILED - '%%s' start condition 'A' not defined\n");
+	i++;
+#endif
+
+	return i > 0;
+}


### PR DESCRIPTION
Start condition definitions are ignored when directly glued to `%s` or `%x`, i.e. without any blank sitting inbetween. See example below:
```
/* check: flex -L -t <thisfile.l> | grep State */

%option noyywrap
%xStateX0 StateX1
%sStateS0 StateS1
%%
```
resulting in
```
#define StateX1 1
#define StateS1 2
case YY_STATE_EOF(StateX1):
case YY_STATE_EOF(StateS1):
```

The [manual](http://westes.github.io/flex/manual/Start-Conditions.html#Start-Conditions) is silent about the required blanks, so would be great it is was amended accordingly.