### PR TITLE
introduce yycalloc and apply to internal scanner structs

### DIFF
--- a/doc/flex.texi
+++ b/doc/flex.texi
@@ -2993,6 +2993,7 @@ list of the names affected:
     yytext
     yywrap
     yyalloc
+    yycalloc
     yyrealloc
     yyfree
 @end verbatim
@@ -4848,10 +4849,11 @@ you call yylex_init(). It is destroyed when the user calls yylex_destroy().
 @section Overriding The Default Memory Management
 
 @cindex yyalloc, overriding
+@cindex yycalloc, overriding
 @cindex yyrealloc, overriding
 @cindex yyfree, overriding
 
-Flex calls the functions @code{yyalloc}, @code{yyrealloc}, and @code{yyfree}
+Flex calls the functions @code{yyalloc}, @code{yycalloc}, @code{yyrealloc}, and @code{yyfree}
 when it needs to allocate or free memory. By default, these functions are
 wrappers around the standard C functions, @code{malloc}, @code{realloc}, and
 @code{free}, respectively. You can override the default implementations by telling
@@ -4867,6 +4869,7 @@ following options:
 @itemize
 @opindex noyyalloc
 @item @code{%option noyyalloc}
+@item @code{%option noyycalloc}
 @item @code{%option noyyrealloc}
 @item @code{%option noyyfree}.
 @end itemize
@@ -4880,11 +4883,13 @@ You may, for example, override @code{yyrealloc}, but not @code{yyfree} or
 @verbatim
 // For a non-reentrant scanner
 void * yyalloc (size_t bytes);
+void * yycalloc (size_t n, size_t bytes);
 void * yyrealloc (void * ptr, size_t bytes);
 void   yyfree (void * ptr);
 
 // For a reentrant scanner
 void * yyalloc (size_t bytes, void * yyscanner);
+void * yycalloc (size_t n, size_t bytes, void * yyscanner);
 void * yyrealloc (void * ptr, size_t bytes, void * yyscanner);
 void   yyfree (void * ptr, void * yyscanner);
 @end verbatim
@@ -4905,7 +4910,7 @@ custom allocator through @code{yyextra}.
 %}
 
 /* Suppress the default implementations. */
-%option noyyalloc noyyrealloc noyyfree
+%option noyyalloc noyycalloc noyyrealloc noyyfree
 %option reentrant
 
 /* Initialize the allocator. */
@@ -4921,6 +4926,10 @@ custom allocator through @code{yyextra}.
 /* Provide our own implementations. */
 void * yyalloc (size_t bytes, void* yyscanner) {
     return allocator_alloc (yyextra, bytes);
+}
+
+void * yycalloc (size_t n, size_t bytes, void* yyscanner) {
+    return allocator_calloc (yyextra, n, bytes);
 }
 
 void * yyrealloc (void * ptr, size_t bytes, void* yyscanner) {

--- a/doc/flex.texi
+++ b/doc/flex.texi
@@ -4358,7 +4358,7 @@ from within the scanner itself. They are defined as follows:
 
 In addition, an extra form of @code{yylex_init} is provided,
 @code{yylex_init_extra}. This function is provided so that the yyextra value can
-be accessed from within the very first yyalloc, used to allocate
+be accessed from within the very first yycalloc, used to allocate
 the scanner itself.
 
 By default, @code{YY_EXTRA_TYPE} is defined as type @code{void *}.  You

--- a/src/flex.skl
+++ b/src/flex.skl
@@ -82,6 +82,7 @@ m4_ifelse(M4_YY_PREFIX,yy,,
 #define yytext M4_YY_PREFIX[[text]]
 #define yywrap M4_YY_PREFIX[[wrap]]
 #define yyalloc M4_YY_PREFIX[[alloc]]
+#define yycalloc M4_YY_PREFIX[[calloc]]
 #define yyrealloc M4_YY_PREFIX[[realloc]]
 #define yyfree M4_YY_PREFIX[[free]]
 )
@@ -188,6 +189,7 @@ m4_ifdef( [[<M4_YY_BISON_LLOC>]],
 
 m4_ifelse(M4_YY_PREFIX,yy,,
     M4_GEN_PREFIX(`alloc')
+    M4_GEN_PREFIX(`calloc')
     M4_GEN_PREFIX(`realloc')
     M4_GEN_PREFIX(`free')
 )
@@ -613,6 +615,7 @@ YY_BUFFER_STATE yy_scan_bytes ( const char *bytes, int len M4_YY_PROTO_LAST_ARG 
 %endif
 
 void *yyalloc ( yy_size_t M4_YY_PROTO_LAST_ARG );
+void *yycalloc ( yy_size_t, yy_size_t M4_YY_PROTO_LAST_ARG );
 void *yyrealloc ( void *, yy_size_t M4_YY_PROTO_LAST_ARG );
 void yyfree ( void * M4_YY_PROTO_LAST_ARG );
 
@@ -2966,6 +2969,16 @@ void *yyalloc YYFARGS1( yy_size_t ,size)
 	M4_YY_DECL_GUTS_VAR();
 	M4_YY_NOOP_GUTS_VAR();
 	return malloc(size);
+}
+]])
+
+m4_ifdef( [[M4_YY_NO_FLEX_CALLOC]],,
+[[
+void *yycalloc YYFARGS2( yy_size_t, n, yy_size_t,size)
+{
+	M4_YY_DECL_GUTS_VAR();
+	M4_YY_NOOP_GUTS_VAR();
+	return calloc(n, size);
 }
 ]])
 

--- a/src/flex.skl
+++ b/src/flex.skl
@@ -2985,13 +2985,6 @@ void *yyrealloc  YYFARGS2( void *,ptr, yy_size_t ,size)
 	M4_YY_DECL_GUTS_VAR();
 	M4_YY_NOOP_GUTS_VAR();
 
-	/* The cast to (char *) in the following accommodates both
-	 * implementations that use char* generic pointers, and those
-	 * that use void* generic pointers.  It works with the latter
-	 * because both ANSI C and C++ allow castless assignment from
-	 * any pointer type to void*, and deal with argument conversions
-	 * as though doing an assignment.
-	 */
 	return realloc(ptr, size);
 }
 ]])
@@ -3002,7 +2995,15 @@ void yyfree YYFARGS1( void *,ptr)
 {
 	M4_YY_DECL_GUTS_VAR();
 	M4_YY_NOOP_GUTS_VAR();
-	free( (char *) ptr );	/* see yyrealloc() for (char *) cast */
+
+	/* The cast to (char *) in the following accommodates both
+	 * implementations that use char* generic pointers, and those
+	 * that use void* generic pointers.  It works with the latter
+	 * because both ANSI C and C++ allow castless assignment from
+	 * any pointer type to void*, and deal with argument conversions
+	 * as though doing an assignment.
+	 */
+	free( (char *) ptr );
 }
 ]])
 

--- a/src/flex.skl
+++ b/src/flex.skl
@@ -2013,7 +2013,7 @@ static void yy_load_buffer_state  (M4_YY_DEF_ONLY_ARG)
 	YY_BUFFER_STATE b;
     m4_dnl M4_YY_DECL_GUTS_VAR();
 
-	b = (YY_BUFFER_STATE) yyalloc( sizeof( struct yy_buffer_state ) M4_YY_CALL_LAST_ARG );
+	b = (YY_BUFFER_STATE) yycalloc( 1, sizeof( struct yy_buffer_state ) M4_YY_CALL_LAST_ARG );
 	if ( ! b )
 		YY_FATAL_ERROR( "out of dynamic memory in yy_create_buffer()" );
 
@@ -2251,14 +2251,11 @@ void yyFlexLexer::yyensure_buffer_stack(void)
 		 * immediate realloc on the next call.
          */
       num_to_alloc = 1; /* After all that talk, this was set to 1 anyways... */
-		YY_G(yy_buffer_stack) = (struct yy_buffer_state**)yyalloc
-								(num_to_alloc * sizeof(struct yy_buffer_state*)
+		YY_G(yy_buffer_stack) = (struct yy_buffer_state**)yycalloc
+								(num_to_alloc, sizeof(struct yy_buffer_state*)
 								M4_YY_CALL_LAST_ARG);
 		if ( ! YY_G(yy_buffer_stack) )
 			YY_FATAL_ERROR( "out of dynamic memory in yyensure_buffer_stack()" );
-
-
-		memset(YY_G(yy_buffer_stack), 0, num_to_alloc * sizeof(struct yy_buffer_state*));
 
 		YY_G(yy_buffer_stack_max) = num_to_alloc;
 		YY_G(yy_buffer_stack_top) = 0;
@@ -2308,18 +2305,14 @@ YY_BUFFER_STATE yy_scan_buffer  YYFARGS2( char *,base, yy_size_t ,size)
 		/* They forgot to leave room for the EOB's. */
 		return NULL;
 
-	b = (YY_BUFFER_STATE) yyalloc( sizeof( struct yy_buffer_state ) M4_YY_CALL_LAST_ARG );
+	b = (YY_BUFFER_STATE) yycalloc(1, sizeof( struct yy_buffer_state ) M4_YY_CALL_LAST_ARG );
 	if ( ! b )
 		YY_FATAL_ERROR( "out of dynamic memory in yy_scan_buffer()" );
 
 	b->yy_buf_size = (int) (size - 2);	/* "- 2" to take care of EOB's */
 	b->yy_buf_pos = b->yy_ch_buf = base;
-	b->yy_is_our_buffer = 0;
-	b->yy_input_file = NULL;
 	b->yy_n_chars = b->yy_buf_size;
-	b->yy_is_interactive = 0;
 	b->yy_at_bol = 1;
-	b->yy_fill_buffer = 0;
 	b->yy_buffer_status = YY_BUFFER_NEW;
 
 	yy_switch_to_buffer( b M4_YY_CALL_LAST_ARG );
@@ -2769,15 +2762,17 @@ int yylex_init(yyscan_t* ptr_yy_globals)
         return 1;
     }
 
-    *ptr_yy_globals = (yyscan_t) yyalloc ( sizeof( struct yyguts_t ), NULL );
+    *ptr_yy_globals = (yyscan_t) yycalloc ( 1, sizeof( struct yyguts_t ), NULL );
 
     if (*ptr_yy_globals == NULL){
         errno = ENOMEM;
         return 1;
     }
 
-    /* By setting to 0xAA, we expose bugs in yy_init_globals. Leave at 0x00 for releases. */
-    memset(*ptr_yy_globals,0x00,sizeof(struct yyguts_t));
+    #if 0
+    /* Debug mode - By setting to 0xAA, we expose bugs in yy_init_globals. */
+    memset(*ptr_yy_globals,0xAA,sizeof(struct yyguts_t));
+    #endif
 
     return yy_init_globals ( *ptr_yy_globals );
 }
@@ -2801,16 +2796,17 @@ int yylex_init_extra( YY_EXTRA_TYPE yy_user_defined, yyscan_t* ptr_yy_globals )
         return 1;
     }
 
-    *ptr_yy_globals = (yyscan_t) yyalloc ( sizeof( struct yyguts_t ), &dummy_yyguts );
+    *ptr_yy_globals = (yyscan_t) yycalloc ( 1, sizeof( struct yyguts_t ), &dummy_yyguts );
 
     if (*ptr_yy_globals == NULL){
         errno = ENOMEM;
         return 1;
     }
 
-    /* By setting to 0xAA, we expose bugs in
-    yy_init_globals. Leave at 0x00 for releases. */
-    memset(*ptr_yy_globals,0x00,sizeof(struct yyguts_t));
+    #if 0
+    /* Debug mode - By setting to 0xAA, we expose bugs in yy_init_globals. */
+    memset(*ptr_yy_globals,0xAA,sizeof(struct yyguts_t));
+    #endif
 
     yyset_extra (yy_user_defined, *ptr_yy_globals);
 

--- a/src/main.c
+++ b/src/main.c
@@ -641,6 +641,7 @@ void flexend (int exit_status)
 				"yypop_buffer_state",
 				"yyensure_buffer_stack",
                 "yyalloc",
+                "yycalloc",
                 "const",
                 "yyextra",
                 "yyfree",

--- a/src/scan.l
+++ b/src/scan.l
@@ -429,6 +429,7 @@ M4QEND      "]""]"
 	yy_scan_string	ACTION_M4_IFDEF("M4""_YY_NO_SCAN_STRING", ! option_sense);
 
     yyalloc         ACTION_M4_IFDEF("M4""_YY_NO_FLEX_ALLOC", ! option_sense);
+    yycalloc        ACTION_M4_IFDEF("M4""_YY_NO_FLEX_CALLOC", ! option_sense);
     yyrealloc       ACTION_M4_IFDEF("M4""_YY_NO_FLEX_REALLOC", ! option_sense);
     yyfree          ACTION_M4_IFDEF("M4""_YY_NO_FLEX_FREE", ! option_sense);
 

--- a/tests/alloc_extra.l
+++ b/tests/alloc_extra.l
@@ -50,7 +50,7 @@ static void check_extra ( yyscan_t  scanner );
 %option warn
 %option extra-type="struct Check *"
 %option reentrant
-%option noyyalloc
+%option noyyalloc noyycalloc
 
 
 %%
@@ -97,6 +97,11 @@ void *testalloc(size_t size, yyscan_t scanner)
     check_extra(scanner);
 
     return malloc(size);
+}
+
+void* yycalloc(size_t n, size_t bytes, yyscan_t yyscanner)
+{
+	return yyalloc( n * bytes, yyscanner );
 }
 
 /* Save char into junk array at next position. */

--- a/tests/alloc_extra.l
+++ b/tests/alloc_extra.l
@@ -30,8 +30,6 @@
 
 #include <stdio.h>
 #include <stdlib.h>
-#include "config.h"
-
 
 /* We'll store the entire input in this buffer, growing as necessary. */
 struct Check {
@@ -71,25 +69,25 @@ main (void)
     check.bar = NULL;
     check.qux = 'z';
  
-    testlex_init_extra(&check, &scanner);
-    testset_in(stdin, scanner);
-    testset_out(stdout, scanner);
+    yylex_init_extra(&check, &scanner);
+    yyset_in(stdin, scanner);
+    yyset_out(stdout, scanner);
 
-    /* Test to confirm that testalloc was called from
-     * testlex_init_extra with the testextra argument.
+    /* Test to confirm that yyalloc was called from
+     * yylex_init_extra with the yyextra argument.
      */
     check_extra(scanner);
 
-    testlex(scanner);
+    yylex(scanner);
 
-    testlex_destroy(scanner);
+    yylex_destroy(scanner);
     return 0;
 }
 
-void *testalloc(size_t size, yyscan_t scanner)
+void *yyalloc(size_t size, yyscan_t scanner)
 {
     struct Check *check;
-    check = testget_extra(scanner);
+    check = yyget_extra(scanner);
 
     if (!check->bar)
         check->bar = "Hello World";
@@ -108,7 +106,7 @@ void* yycalloc(size_t n, size_t bytes, yyscan_t yyscanner)
 static void check_extra(yyscan_t  scanner)
 {
     struct Check *check;
-    check = testget_extra(scanner);
+    check = yyget_extra(scanner);
 
     if (check->foo != 'a') {
         fprintf(stderr, "foo is not 'a'\n");

--- a/tests/mem_nr.l
+++ b/tests/mem_nr.l
@@ -29,7 +29,6 @@
  */
 #include <stdio.h>
 #include <stdlib.h>
-#include "config.h"
 
 /* Insanely small read buffer. This pretty much guarantees at least one realloc. */
 #ifdef YY_BUF_SIZE
@@ -171,8 +170,8 @@ main (void)
 
     yyin = stdin;
     yyout = stdout;
-    testlex();
-    testlex_destroy();
+    yylex();
+    yylex_destroy();
     free(ptrs);
 
     if ( nptrs > 0 || total_mem > 0){

--- a/tests/mem_nr.l
+++ b/tests/mem_nr.l
@@ -42,7 +42,7 @@
 %option 8bit prefix="test"
 %option nounput nomain noyywrap noinput noyy_top_state
 %option warn stack nodefault
-%option noyyalloc noyyrealloc noyyfree
+%option noyyalloc noyycalloc noyyrealloc noyyfree
 
 %x parens
 
@@ -112,6 +112,11 @@ void * yyalloc(yy_size_t n)
     printf("yyflex_alloc(%8ld) total=%8ld return=%#10lx\n",(long)n,(long)total_mem,(long)p);
     dump_mem(stdout);
     return p;
+}
+
+void* yycalloc(size_t n, size_t bytes)
+{
+	return yyalloc( n * bytes );
 }
 
 void * yyrealloc(void* p, yy_size_t n)

--- a/tests/mem_r.l
+++ b/tests/mem_r.l
@@ -29,7 +29,6 @@
  */
 #include <stdio.h>
 #include <stdlib.h>
-#include "config.h"
 
 /* Insanely small read buffer. This pretty much guarantees at least one realloc. */
 #ifdef YY_BUF_SIZE
@@ -85,7 +84,7 @@ static void dump_mem(FILE* fp){
     fprintf(fp,"}\n");
 }
 
-void * testalloc(yy_size_t n , void* yyscanner)
+void * yyalloc(yy_size_t n , yyscan_t yyscanner)
 {
     (void)yyscanner;
 
@@ -121,7 +120,7 @@ void* yycalloc(size_t n, size_t bytes, yyscan_t yyscanner)
 	return yyalloc( n * bytes, yyscanner );
 }
 
-void * testrealloc(void* p, yy_size_t n , void* yyscanner)
+void * yyrealloc(void* p, yy_size_t n, yyscan_t yyscanner)
 {
     (void)yyscanner;
 
@@ -144,7 +143,7 @@ void * testrealloc(void* p, yy_size_t n , void* yyscanner)
     exit(1);
 }
 
-void testfree(void* p , void* yyscanner)
+void yyfree(void* p , yyscan_t yyscanner)
 {
     (void)yyscanner;
 
@@ -176,11 +175,11 @@ main (void)
     ptrs  = calloc(1, sizeof(struct memsz));
     nptrs = 0;
 
-    testlex_init(&scanner);
-    testset_in(stdin,scanner);
-    testset_out(stdout,scanner);
-    testlex(scanner);
-    testlex_destroy(scanner);
+    yylex_init(&scanner);
+    yyset_in(stdin,scanner);
+    yyset_out(stdout,scanner);
+    yylex(scanner);
+    yylex_destroy(scanner);
     free(ptrs);
 
     if ( nptrs > 0 || total_mem > 0){

--- a/tests/mem_r.l
+++ b/tests/mem_r.l
@@ -42,7 +42,7 @@
 %option 8bit prefix="test"
 %option nounput nomain noyywrap noinput noyy_top_state
 %option warn stack nodefault reentrant
-%option noyyalloc noyyrealloc noyyfree
+%option noyyalloc noyycalloc noyyrealloc noyyfree
 
 %x parens
 
@@ -114,6 +114,11 @@ void * testalloc(yy_size_t n , void* yyscanner)
     printf("yyflex_alloc(%8ld) total=%8ld return=%#10lx\n",(long)n,(long)total_mem,(long)p);
     dump_mem(stdout);
     return p;
+}
+
+void* yycalloc(size_t n, size_t bytes, yyscan_t yyscanner)
+{
+	return yyalloc( n * bytes, yyscanner );
 }
 
 void * testrealloc(void* p, yy_size_t n , void* yyscanner)


### PR DESCRIPTION
Use zero-initialized memory block for default initialization of struct members. If accepted

- the default initialization of struct members by 0 could be dropped.
- struct members added to the code later would be zero-initialized.