### PR TITLE
continuous integration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,24 @@
+language: c
+
+compiler:
+  - gcc
+
+addons:
+  apt:
+    sources:
+    - ubuntu-toolchain-r-test
+    packages:
+    - autoconf
+    - bison
+    - gcc-6
+    - help2man
+    - lzip
+    - texinfo
+    - texlive
+
+before_script:
+    - ./.travis/install-gettext.sh
+    - ./.travis/install-automake.sh
+    - export PATH=$HOME/bin:$PATH
+
+script: ./autogen.sh && ./configure && make && make check && make distcheck

--- a/.travis/install-automake.sh
+++ b/.travis/install-automake.sh
@@ -1,0 +1,10 @@
+#!/bin/bash -ex
+
+wget -nv https://ftp.gnu.org/gnu/automake/automake-1.15.1.tar.gz{,.sig}
+gpg2 --keyserver hkp://keys.gnupg.net --recv-keys 94604D37
+gpg2 automake-1.15.1.tar.gz.sig 
+tar xf automake-1.15.1.tar.gz
+cd automake-1.15.1
+./configure --prefix=$HOME
+make
+make install

--- a/.travis/install-gettext.sh
+++ b/.travis/install-gettext.sh
@@ -1,0 +1,10 @@
+#!/bin/bash -ex
+
+wget -nv https://ftp.gnu.org/gnu/gettext/gettext-0.19.8.1.tar.lz{,.sig}
+gpg2 --keyserver hkp://keys.gnupg.net --recv-keys D7E69871
+gpg2 gettext-0.19.8.1.tar.lz.sig 
+tar xf gettext-0.19.8.1.tar.lz
+cd gettext-0.19.8.1
+./configure --prefix=$HOME
+make
+make install

--- a/NEWS
+++ b/NEWS
@@ -21,6 +21,9 @@ flex NEWS
 
 *** A crash during building on NetBSD has been fixed.
 
+*** Flex is now automatically built by travis-ci. That should increase
+    the visibility of bugs and help prevent regressions.
+
 ** documentation
 
 *** a new Ukrainian translation has been submitted from the Translation Project.


### PR DESCRIPTION
There are a number of non-usual things about flex -- from the fact that most tool chains assume that flex exists, which isn't true when building flex itself -- to the fact that some parts of flex are just down right self referential. To aid contributors in assessing the effects of their changes, to aid the maintainer in assessing changes, to ensure that flex continues to do what we all think it does, let's start testing flex's build.