### PR TITLE
misc.c: no YYTABLES_NAME macro unless requested

### DIFF
--- a/src/misc.c
+++ b/src/misc.c
@@ -776,8 +776,9 @@ void skelout (void)
 					outn ((char *) (yydmap_buf.elts));
 			}
             else if (cmd_match (CMD_DEFINE_YYTABLES)) {
-                out_str("#define YYTABLES_NAME \"%s\"\n",
-                        tablesname?tablesname:"yytables");
+                if ( tablesext )
+                    out_str( "#define YYTABLES_NAME \"%s\"\n",
+                           tablesname ? tablesname : "yytables" );
             }
 			else if (cmd_match (CMD_IF_CPP_ONLY)) {
 				/* only for C++ */


### PR DESCRIPTION
Like in all other flex output files the macro `#define YYTABLES_NAME "yytables"` is currently appearing in `stage1scan.c` regardless of the user's requests. The reason for the spurious macro is that there is no m4 guard for external tables in the skeleton, however this fix is in line with the approach how other external tables related statements are handled.