### PR TITLE
flex.skl: fix default of yy_top_state()

### DIFF
--- a/doc/flex.texi
+++ b/doc/flex.texi
@@ -1978,15 +1978,23 @@ as though you had used
 @deftypefun void yy_pop_state ()
 pops the top of the stack and switches to it via
 @code{BEGIN}.
+The program execution aborts, if there is no state on the stack.
 @end deftypefun
 
 @deftypefun int yy_top_state ()
-returns the top of the stack without altering the stack's contents.
+returns the top of the stack without altering the stack's contents
+if a top state on the stack exists or the current state via
+@code{YY_START}
+otherwise.
 @end deftypefun
 
 @cindex memory, for start condition stacks
 The start condition stack grows dynamically and so has no built-in size
 limitation.  If memory is exhausted, program execution aborts.
+The stack is not automatically reset.  The function
+@code{yylex_destroy}
+should be called to reset and destroy the state stack which then frees
+other resources used by the scanner.
 
 To use start condition stacks, your scanner must include a @code{%option
 stack} directive (@pxref{Scanner Options}).

--- a/src/flex.skl
+++ b/src/flex.skl
@@ -2455,7 +2455,7 @@ m4_ifdef( [[M4_YY_NO_TOP_STATE]],,
 %endif
 {
     M4_YY_DECL_GUTS_VAR();
-	return yy_start_stack_ptr > 0 ? YY_G(yy_start_stack)[YY_G(yy_start_stack_ptr) - 1] : YY_START;
+	return YY_G(yy_start_stack_ptr) > 0 ? YY_G(yy_start_stack)[YY_G(yy_start_stack_ptr) - 1] : YY_START;
 }
 ]])
 

--- a/src/flex.skl
+++ b/src/flex.skl
@@ -2455,7 +2455,7 @@ m4_ifdef( [[M4_YY_NO_TOP_STATE]],,
 %endif
 {
     M4_YY_DECL_GUTS_VAR();
-	return YY_G(yy_start_stack)[YY_G(yy_start_stack_ptr) - 1];
+	return yy_start_stack_ptr > 0 ? YY_G(yy_start_stack)[YY_G(yy_start_stack_ptr) - 1] : YY_START;
 }
 ]])
 


### PR DESCRIPTION
For a height 0 state stack, the top defaults to the state as if no state stack were present.

Fixes #175