### PR TITLE
flexint: include stdint.h before defining limit macros

### DIFF
--- a/src/flexint.h
+++ b/src/flexint.h
@@ -30,6 +30,7 @@ typedef unsigned short int flex_uint16_t;
 typedef unsigned int flex_uint32_t;
 
 /* Limits of integral types. */
+#include <stdint.h>
 #ifndef INT8_MIN
 #define INT8_MIN               (-128)
 #endif


### PR DESCRIPTION
These defines are provided by `stdint.h` and it should be included first
before trying to define them manually.

Fixes #307.

---
Cc: @jannick0 @Explorer09 