### PR TITLE
scanner: Fix glibc features.h dependency in skeleton

### DIFF
--- a/src/flex.skl
+++ b/src/flex.skl
@@ -220,11 +220,21 @@ m4_ifdef( [[M4_YY_TABLES_EXTERNAL]],
 %if-c-only
 m4_ifdef( [[M4_YY_ALWAYS_INTERACTIVE]], ,
 [[m4_ifdef( [[M4_YY_NEVER_INTERACTIVE]], ,
-[[#ifndef _POSIX_C_SOURCE
-#define _POSIX_C_SOURCE 1 /* for fileno() */
-#ifndef _POSIX_SOURCE
-#define _POSIX_SOURCE 1
+[[/* Feature test macros. Flex uses functions that require a minimum set of
+ * macros defined. As defining some macros may hide function declarations that
+ * user code might use, be conservative and respect user's definitions as much
+ * as possible. In glibc, feature test macros may not be all set up until one
+ * of the libc header (that includes <features.h>) is included. This creates
+ * a circular dependency when we check the macros. <assert.h> is the safest
+ * header we can include and does not declare too many functions we don't need.
+ */
+#if !defined(__GNU_LIBRARY__) && defined(__STDC__)
+#include <assert.h>
 #endif
+#if !(defined(_POSIX_C_SOURCE) || defined(_XOPEN_SOURCE) || \
+    defined(_POSIX_SOURCE))
+# define _POSIX_C_SOURCE 1 /* Required for fileno() */
+# define _POSIX_SOURCE 1
 #endif]])]])
 #include <stdio.h>
 #include <string.h>


### PR DESCRIPTION
Commit a17d79e9c722a6735b6d2a8f152287404f27df32 defines `_POSIX_C_SOURCE`
to the minimum of 1 if it's not defined in the user's scanner code or
the compiling environment. However in glibc the macros are not yet set
up until one of the libc headers is included. This unfortunately have
made us overwrite the default `_POSIX_C_SOURCE` value that would be
defined by glibc (`200809L` at the time of writing), causing regressions
in user code.

Now in this patch:
1. Ensure feature test macros have been set up in glibc before checking
   or defining any of them in our skeleton code.
2. Have a more conservative logic when determining the need to define
   `_POSIX_C_SOURCE` (required for fileno()).

Fixes: #313

Note:
It could be tricky for application code to ensure feature test macros
have been set up in glibc, since <features.h> is no portable header and
not meant to be included directly by applications. The way to do it is
to include a libc header which in turn includes <features.h>. However,
many of the glibc headers check `__USE_POSIX` (a glibc internal macro
defined if `_POSIX_C_SOURCE` is defined) and determine which interfaces
to expose already, making the headers inappropriate for our goal.
Those which don't depend on `_POSIX_C_SOURCE`, and are also available
since ANSI C89, are only <assert.h>, <errno.h> and <math.h>.

<assert.h> is finally favored due to other considerations:
- <math.h> check for `__USE_XOPEN` in glibc, making a dependency on
  `_XOPEN_SOURCE`, besides it exposes much more interfaces than we need.
- In djgpp, <errno.h> depends on `_POSIX_SOURCE` to hide definitions of
  some errno values when it's defined.
- <assert.h> exposes the fewest interfaces among the 3 headers and, at
  the time of writing, checks for only C99 (for `__func__`), C11 (for
  `_Static_assert`), and `_GNU_SOURCE` when needed. (And the header had
  been available in as old as V7 Unix.)