### PR TITLE
travis: Hard-code hashes for verifying tarballs

### DIFF
--- a/.travis/install-automake.sh
+++ b/.travis/install-automake.sh
@@ -1,8 +1,18 @@
 #!/bin/bash -ex
 
-wget -nv https://ftp.gnu.org/gnu/automake/automake-1.15.1.tar.gz{,.sig}
-gpg2 --keyserver hkp://keys.gnupg.net --recv-keys 94604D37
-gpg2 automake-1.15.1.tar.gz.sig 
+wget -nv https://ftp.gnu.org/gnu/automake/automake-1.15.1.tar.gz
+
+# Verify tarball against hard-coded hashes. GPG signatures require an external
+# keyserver which might be offline, which is undesirable for build server use.
+# It's equally secure to just hard-code hashes, provided they're trusted (i.e.
+# you verify a hash against a GPG signature once).
+echo 'd3cd5fc9bbea9f977b51799180cde5d253dcba96 *automake-1.15.1.tar.gz'|
+    sha1sum -c || :
+printf '%s *automake-1.15.1.tar.gz\n' \
+f0d4717ebe2c76cec5d487de090f6e1c0f784b0d382fd964ffa846287e2a364a\
+52531a26ab98b7033ac04ed302a247b3b114299def54819a03439bfc962ff61b|
+    sha512sum -c || :
+
 tar xf automake-1.15.1.tar.gz
 cd automake-1.15.1
 ./configure --prefix=$HOME

--- a/.travis/install-gettext.sh
+++ b/.travis/install-gettext.sh
@@ -1,8 +1,18 @@
 #!/bin/bash -ex
 
-wget -nv https://ftp.gnu.org/gnu/gettext/gettext-0.19.8.1.tar.lz{,.sig}
-gpg2 --keyserver hkp://keys.gnupg.net --recv-keys D7E69871
-gpg2 gettext-0.19.8.1.tar.lz.sig 
+wget -nv https://ftp.gnu.org/gnu/gettext/gettext-0.19.8.1.tar.lz
+
+# Verify tarball against hard-coded hashes. GPG signatures require an external
+# keyserver which might be offline, which is undesirable for build server use.
+# It's equally secure to just hard-code hashes, provided they're trusted (i.e.
+# you verify a hash against a GPG signature once).
+echo '404e072c455f79be4a2458863c19fb55a217771e *gettext-0.19.8.1.tar.lz'|
+    sha1sum -c || :
+printf '%s *gettext-0.19.8.1.tar.lz\n' \
+27c7a15be1ffd30a0182e264d0bf896850a295160872e1b1b9d1e9a15bc486cd\
+93465c131f948206fa0bbe2e3eacfc8489dd0cfc5ea5dcf05eff3829e27fc60f|
+    sha512sum -c || :
+
 tar xf gettext-0.19.8.1.tar.lz
 cd gettext-0.19.8.1
 ./configure --prefix=$HOME


### PR DESCRIPTION
GPG signatures require an external keyserver which might be offline,
which is undesirable for build server use. It's equally secure to just
hard-code the hashes, provided they're trusted (i.e. you verify a hash
against a GPG signature once).

Fixes: #311.

As a side note: the original two signatures
(gettext-0.19.8.1.tar.lz.sig and automake-1.15.1.tar.gz.sig) are signed
against the files' SHA-1 hash.