### PR TITLE
test: Remove redundant '-o $@' in tableopts.am

### DIFF
--- a/tests/tableopts.am
+++ b/tests/tableopts.am
@@ -1,332 +1,332 @@
 tableopts_opt_nr_Ca_opt_SOURCES = tableopts.l4
 
 tableopts_opt_nr-Ca.opt$(EXEEXT): tableopts_opt_nr-Ca.$(OBJEXT)
-	$(AM_V_CCLD)$(LINK) -o $@ $<
+	$(AM_V_CCLD)$(LINK) $<
 
 tableopts_opt_nr_Ce_opt_SOURCES = tableopts.l4
 
 tableopts_opt_nr-Ce.opt$(EXEEXT): tableopts_opt_nr-Ce.$(OBJEXT)
-	$(AM_V_CCLD)$(LINK) -o $@ $<
+	$(AM_V_CCLD)$(LINK) $<
 
 tableopts_opt_nr_Cf_opt_SOURCES = tableopts.l4
 
 tableopts_opt_nr-Cf.opt$(EXEEXT): tableopts_opt_nr-Cf.$(OBJEXT)
-	$(AM_V_CCLD)$(LINK) -o $@ $<
+	$(AM_V_CCLD)$(LINK) $<
 
 tableopts_opt_nr_C_F_opt_SOURCES = tableopts.l4
 
 tableopts_opt_nr-C_F.opt$(EXEEXT): tableopts_opt_nr-C_F.$(OBJEXT)
-	$(AM_V_CCLD)$(LINK) -o $@ $<
+	$(AM_V_CCLD)$(LINK) $<
 
 tableopts_opt_nr_Cm_opt_SOURCES = tableopts.l4
 
 tableopts_opt_nr-Cm.opt$(EXEEXT): tableopts_opt_nr-Cm.$(OBJEXT)
-	$(AM_V_CCLD)$(LINK) -o $@ $<
+	$(AM_V_CCLD)$(LINK) $<
 
 tableopts_opt_nr_Cem_opt_SOURCES = tableopts.l4
 
 tableopts_opt_nr-Cem.opt$(EXEEXT): tableopts_opt_nr-Cem.$(OBJEXT)
-	$(AM_V_CCLD)$(LINK) -o $@ $<
+	$(AM_V_CCLD)$(LINK) $<
 
 tableopts_opt_nr_Cae_opt_SOURCES = tableopts.l4
 
 tableopts_opt_nr-Cae.opt$(EXEEXT): tableopts_opt_nr-Cae.$(OBJEXT)
-	$(AM_V_CCLD)$(LINK) -o $@ $<
+	$(AM_V_CCLD)$(LINK) $<
 
 tableopts_opt_nr_Caef_opt_SOURCES = tableopts.l4
 
 tableopts_opt_nr-Caef.opt$(EXEEXT): tableopts_opt_nr-Caef.$(OBJEXT)
-	$(AM_V_CCLD)$(LINK) -o $@ $<
+	$(AM_V_CCLD)$(LINK) $<
 
 tableopts_opt_nr_Cae_F_opt_SOURCES = tableopts.l4
 
 tableopts_opt_nr-Cae_F.opt$(EXEEXT): tableopts_opt_nr-Cae_F.$(OBJEXT)
-	$(AM_V_CCLD)$(LINK) -o $@ $<
+	$(AM_V_CCLD)$(LINK) $<
 
 tableopts_opt_nr_Cam_opt_SOURCES = tableopts.l4
 
 tableopts_opt_nr-Cam.opt$(EXEEXT): tableopts_opt_nr-Cam.$(OBJEXT)
-	$(AM_V_CCLD)$(LINK) -o $@ $<
+	$(AM_V_CCLD)$(LINK) $<
 
 tableopts_opt_nr_Caem_opt_SOURCES = tableopts.l4
 
 tableopts_opt_nr-Caem.opt$(EXEEXT): tableopts_opt_nr-Caem.$(OBJEXT)
-	$(AM_V_CCLD)$(LINK) -o $@ $<
+	$(AM_V_CCLD)$(LINK) $<
 
 tableopts_opt_r_Ca_opt_SOURCES = tableopts.l4
 
 tableopts_opt_r-Ca.opt$(EXEEXT): tableopts_opt_r-Ca.$(OBJEXT)
-	$(AM_V_CCLD)$(LINK) -o $@ $<
+	$(AM_V_CCLD)$(LINK) $<
 
 tableopts_opt_r_Ce_opt_SOURCES = tableopts.l4
 
 tableopts_opt_r-Ce.opt$(EXEEXT): tableopts_opt_r-Ce.$(OBJEXT)
-	$(AM_V_CCLD)$(LINK) -o $@ $<
+	$(AM_V_CCLD)$(LINK) $<
 
 tableopts_opt_r_Cf_opt_SOURCES = tableopts.l4
 
 tableopts_opt_r-Cf.opt$(EXEEXT): tableopts_opt_r-Cf.$(OBJEXT)
-	$(AM_V_CCLD)$(LINK) -o $@ $<
+	$(AM_V_CCLD)$(LINK) $<
 
 tableopts_opt_r_C_F_opt_SOURCES = tableopts.l4
 
 tableopts_opt_r-C_F.opt$(EXEEXT): tableopts_opt_r-C_F.$(OBJEXT)
-	$(AM_V_CCLD)$(LINK) -o $@ $<
+	$(AM_V_CCLD)$(LINK) $<
 
 tableopts_opt_r_Cm_opt_SOURCES = tableopts.l4
 
 tableopts_opt_r-Cm.opt$(EXEEXT): tableopts_opt_r-Cm.$(OBJEXT)
-	$(AM_V_CCLD)$(LINK) -o $@ $<
+	$(AM_V_CCLD)$(LINK) $<
 
 tableopts_opt_r_Cem_opt_SOURCES = tableopts.l4
 
 tableopts_opt_r-Cem.opt$(EXEEXT): tableopts_opt_r-Cem.$(OBJEXT)
-	$(AM_V_CCLD)$(LINK) -o $@ $<
+	$(AM_V_CCLD)$(LINK) $<
 
 tableopts_opt_r_Cae_opt_SOURCES = tableopts.l4
 
 tableopts_opt_r-Cae.opt$(EXEEXT): tableopts_opt_r-Cae.$(OBJEXT)
-	$(AM_V_CCLD)$(LINK) -o $@ $<
+	$(AM_V_CCLD)$(LINK) $<
 
 tableopts_opt_r_Caef_opt_SOURCES = tableopts.l4
 
 tableopts_opt_r-Caef.opt$(EXEEXT): tableopts_opt_r-Caef.$(OBJEXT)
-	$(AM_V_CCLD)$(LINK) -o $@ $<
+	$(AM_V_CCLD)$(LINK) $<
 
 tableopts_opt_r_Cae_F_opt_SOURCES = tableopts.l4
 
 tableopts_opt_r-Cae_F.opt$(EXEEXT): tableopts_opt_r-Cae_F.$(OBJEXT)
-	$(AM_V_CCLD)$(LINK) -o $@ $<
+	$(AM_V_CCLD)$(LINK) $<
 
 tableopts_opt_r_Cam_opt_SOURCES = tableopts.l4
 
 tableopts_opt_r-Cam.opt$(EXEEXT): tableopts_opt_r-Cam.$(OBJEXT)
-	$(AM_V_CCLD)$(LINK) -o $@ $<
+	$(AM_V_CCLD)$(LINK) $<
 
 tableopts_opt_r_Caem_opt_SOURCES = tableopts.l4
 
 tableopts_opt_r-Caem.opt$(EXEEXT): tableopts_opt_r-Caem.$(OBJEXT)
-	$(AM_V_CCLD)$(LINK) -o $@ $<
+	$(AM_V_CCLD)$(LINK) $<
 
 tableopts_ser_nr_Ca_ser_SOURCES = tableopts.l4
 
 tableopts_ser_nr-Ca.ser$(EXEEXT): tableopts_ser_nr-Ca.$(OBJEXT)
-	$(AM_V_CCLD)$(LINK) -o $@ $<
+	$(AM_V_CCLD)$(LINK) $<
 
 tableopts_ser_nr_Ce_ser_SOURCES = tableopts.l4
 
 tableopts_ser_nr-Ce.ser$(EXEEXT): tableopts_ser_nr-Ce.$(OBJEXT)
-	$(AM_V_CCLD)$(LINK) -o $@ $<
+	$(AM_V_CCLD)$(LINK) $<
 
 tableopts_ser_nr_Cf_ser_SOURCES = tableopts.l4
 
 tableopts_ser_nr-Cf.ser$(EXEEXT): tableopts_ser_nr-Cf.$(OBJEXT)
-	$(AM_V_CCLD)$(LINK) -o $@ $<
+	$(AM_V_CCLD)$(LINK) $<
 
 tableopts_ser_nr_C_F_ser_SOURCES = tableopts.l4
 
 tableopts_ser_nr-C_F.ser$(EXEEXT): tableopts_ser_nr-C_F.$(OBJEXT)
-	$(AM_V_CCLD)$(LINK) -o $@ $<
+	$(AM_V_CCLD)$(LINK) $<
 
 tableopts_ser_nr_Cm_ser_SOURCES = tableopts.l4
 
 tableopts_ser_nr-Cm.ser$(EXEEXT): tableopts_ser_nr-Cm.$(OBJEXT)
-	$(AM_V_CCLD)$(LINK) -o $@ $<
+	$(AM_V_CCLD)$(LINK) $<
 
 tableopts_ser_nr_Cem_ser_SOURCES = tableopts.l4
 
 tableopts_ser_nr-Cem.ser$(EXEEXT): tableopts_ser_nr-Cem.$(OBJEXT)
-	$(AM_V_CCLD)$(LINK) -o $@ $<
+	$(AM_V_CCLD)$(LINK) $<
 
 tableopts_ser_nr_Cae_ser_SOURCES = tableopts.l4
 
 tableopts_ser_nr-Cae.ser$(EXEEXT): tableopts_ser_nr-Cae.$(OBJEXT)
-	$(AM_V_CCLD)$(LINK) -o $@ $<
+	$(AM_V_CCLD)$(LINK) $<
 
 tableopts_ser_nr_Caef_ser_SOURCES = tableopts.l4
 
 tableopts_ser_nr-Caef.ser$(EXEEXT): tableopts_ser_nr-Caef.$(OBJEXT)
-	$(AM_V_CCLD)$(LINK) -o $@ $<
+	$(AM_V_CCLD)$(LINK) $<
 
 tableopts_ser_nr_Cae_F_ser_SOURCES = tableopts.l4
 
 tableopts_ser_nr-Cae_F.ser$(EXEEXT): tableopts_ser_nr-Cae_F.$(OBJEXT)
-	$(AM_V_CCLD)$(LINK) -o $@ $<
+	$(AM_V_CCLD)$(LINK) $<
 
 tableopts_ser_nr_Cam_ser_SOURCES = tableopts.l4
 
 tableopts_ser_nr-Cam.ser$(EXEEXT): tableopts_ser_nr-Cam.$(OBJEXT)
-	$(AM_V_CCLD)$(LINK) -o $@ $<
+	$(AM_V_CCLD)$(LINK) $<
 
 tableopts_ser_nr_Caem_ser_SOURCES = tableopts.l4
 
 tableopts_ser_nr-Caem.ser$(EXEEXT): tableopts_ser_nr-Caem.$(OBJEXT)
-	$(AM_V_CCLD)$(LINK) -o $@ $<
+	$(AM_V_CCLD)$(LINK) $<
 
 tableopts_ser_r_Ca_ser_SOURCES = tableopts.l4
 
 tableopts_ser_r-Ca.ser$(EXEEXT): tableopts_ser_r-Ca.$(OBJEXT)
-	$(AM_V_CCLD)$(LINK) -o $@ $<
+	$(AM_V_CCLD)$(LINK) $<
 
 tableopts_ser_r_Ce_ser_SOURCES = tableopts.l4
 
 tableopts_ser_r-Ce.ser$(EXEEXT): tableopts_ser_r-Ce.$(OBJEXT)
-	$(AM_V_CCLD)$(LINK) -o $@ $<
+	$(AM_V_CCLD)$(LINK) $<
 
 tableopts_ser_r_Cf_ser_SOURCES = tableopts.l4
 
 tableopts_ser_r-Cf.ser$(EXEEXT): tableopts_ser_r-Cf.$(OBJEXT)
-	$(AM_V_CCLD)$(LINK) -o $@ $<
+	$(AM_V_CCLD)$(LINK) $<
 
 tableopts_ser_r_C_F_ser_SOURCES = tableopts.l4
 
 tableopts_ser_r-C_F.ser$(EXEEXT): tableopts_ser_r-C_F.$(OBJEXT)
-	$(AM_V_CCLD)$(LINK) -o $@ $<
+	$(AM_V_CCLD)$(LINK) $<
 
 tableopts_ser_r_Cm_ser_SOURCES = tableopts.l4
 
 tableopts_ser_r-Cm.ser$(EXEEXT): tableopts_ser_r-Cm.$(OBJEXT)
-	$(AM_V_CCLD)$(LINK) -o $@ $<
+	$(AM_V_CCLD)$(LINK) $<
 
 tableopts_ser_r_Cem_ser_SOURCES = tableopts.l4
 
 tableopts_ser_r-Cem.ser$(EXEEXT): tableopts_ser_r-Cem.$(OBJEXT)
-	$(AM_V_CCLD)$(LINK) -o $@ $<
+	$(AM_V_CCLD)$(LINK) $<
 
 tableopts_ser_r_Cae_ser_SOURCES = tableopts.l4
 
 tableopts_ser_r-Cae.ser$(EXEEXT): tableopts_ser_r-Cae.$(OBJEXT)
-	$(AM_V_CCLD)$(LINK) -o $@ $<
+	$(AM_V_CCLD)$(LINK) $<
 
 tableopts_ser_r_Caef_ser_SOURCES = tableopts.l4
 
 tableopts_ser_r-Caef.ser$(EXEEXT): tableopts_ser_r-Caef.$(OBJEXT)
-	$(AM_V_CCLD)$(LINK) -o $@ $<
+	$(AM_V_CCLD)$(LINK) $<
 
 tableopts_ser_r_Cae_F_ser_SOURCES = tableopts.l4
 
 tableopts_ser_r-Cae_F.ser$(EXEEXT): tableopts_ser_r-Cae_F.$(OBJEXT)
-	$(AM_V_CCLD)$(LINK) -o $@ $<
+	$(AM_V_CCLD)$(LINK) $<
 
 tableopts_ser_r_Cam_ser_SOURCES = tableopts.l4
 
 tableopts_ser_r-Cam.ser$(EXEEXT): tableopts_ser_r-Cam.$(OBJEXT)
-	$(AM_V_CCLD)$(LINK) -o $@ $<
+	$(AM_V_CCLD)$(LINK) $<
 
 tableopts_ser_r_Caem_ser_SOURCES = tableopts.l4
 
 tableopts_ser_r-Caem.ser$(EXEEXT): tableopts_ser_r-Caem.$(OBJEXT)
-	$(AM_V_CCLD)$(LINK) -o $@ $<
+	$(AM_V_CCLD)$(LINK) $<
 
 tableopts_ver_nr_Ca_ver_SOURCES = tableopts.l4
 
 tableopts_ver_nr-Ca.ver$(EXEEXT): tableopts_ver_nr-Ca.$(OBJEXT)
-	$(AM_V_CCLD)$(LINK) -o $@ $<
+	$(AM_V_CCLD)$(LINK) $<
 
 tableopts_ver_nr_Ce_ver_SOURCES = tableopts.l4
 
 tableopts_ver_nr-Ce.ver$(EXEEXT): tableopts_ver_nr-Ce.$(OBJEXT)
-	$(AM_V_CCLD)$(LINK) -o $@ $<
+	$(AM_V_CCLD)$(LINK) $<
 
 tableopts_ver_nr_Cf_ver_SOURCES = tableopts.l4
 
 tableopts_ver_nr-Cf.ver$(EXEEXT): tableopts_ver_nr-Cf.$(OBJEXT)
-	$(AM_V_CCLD)$(LINK) -o $@ $<
+	$(AM_V_CCLD)$(LINK) $<
 
 tableopts_ver_nr_C_F_ver_SOURCES = tableopts.l4
 
 tableopts_ver_nr-C_F.ver$(EXEEXT): tableopts_ver_nr-C_F.$(OBJEXT)
-	$(AM_V_CCLD)$(LINK) -o $@ $<
+	$(AM_V_CCLD)$(LINK) $<
 
 tableopts_ver_nr_Cm_ver_SOURCES = tableopts.l4
 
 tableopts_ver_nr-Cm.ver$(EXEEXT): tableopts_ver_nr-Cm.$(OBJEXT)
-	$(AM_V_CCLD)$(LINK) -o $@ $<
+	$(AM_V_CCLD)$(LINK) $<
 
 tableopts_ver_nr_Cem_ver_SOURCES = tableopts.l4
 
 tableopts_ver_nr-Cem.ver$(EXEEXT): tableopts_ver_nr-Cem.$(OBJEXT)
-	$(AM_V_CCLD)$(LINK) -o $@ $<
+	$(AM_V_CCLD)$(LINK) $<
 
 tableopts_ver_nr_Cae_ver_SOURCES = tableopts.l4
 
 tableopts_ver_nr-Cae.ver$(EXEEXT): tableopts_ver_nr-Cae.$(OBJEXT)
-	$(AM_V_CCLD)$(LINK) -o $@ $<
+	$(AM_V_CCLD)$(LINK) $<
 
 tableopts_ver_nr_Caef_ver_SOURCES = tableopts.l4
 
 tableopts_ver_nr-Caef.ver$(EXEEXT): tableopts_ver_nr-Caef.$(OBJEXT)
-	$(AM_V_CCLD)$(LINK) -o $@ $<
+	$(AM_V_CCLD)$(LINK) $<
 
 tableopts_ver_nr_Cae_F_ver_SOURCES = tableopts.l4
 
 tableopts_ver_nr-Cae_F.ver$(EXEEXT): tableopts_ver_nr-Cae_F.$(OBJEXT)
-	$(AM_V_CCLD)$(LINK) -o $@ $<
+	$(AM_V_CCLD)$(LINK) $<
 
 tableopts_ver_nr_Cam_ver_SOURCES = tableopts.l4
 
 tableopts_ver_nr-Cam.ver$(EXEEXT): tableopts_ver_nr-Cam.$(OBJEXT)
-	$(AM_V_CCLD)$(LINK) -o $@ $<
+	$(AM_V_CCLD)$(LINK) $<
 
 tableopts_ver_nr_Caem_ver_SOURCES = tableopts.l4
 
 tableopts_ver_nr-Caem.ver$(EXEEXT): tableopts_ver_nr-Caem.$(OBJEXT)
-	$(AM_V_CCLD)$(LINK) -o $@ $<
+	$(AM_V_CCLD)$(LINK) $<
 
 tableopts_ver_r_Ca_ver_SOURCES = tableopts.l4
 
 tableopts_ver_r-Ca.ver$(EXEEXT): tableopts_ver_r-Ca.$(OBJEXT)
-	$(AM_V_CCLD)$(LINK) -o $@ $<
+	$(AM_V_CCLD)$(LINK) $<
 
 tableopts_ver_r_Ce_ver_SOURCES = tableopts.l4
 
 tableopts_ver_r-Ce.ver$(EXEEXT): tableopts_ver_r-Ce.$(OBJEXT)
-	$(AM_V_CCLD)$(LINK) -o $@ $<
+	$(AM_V_CCLD)$(LINK) $<
 
 tableopts_ver_r_Cf_ver_SOURCES = tableopts.l4
 
 tableopts_ver_r-Cf.ver$(EXEEXT): tableopts_ver_r-Cf.$(OBJEXT)
-	$(AM_V_CCLD)$(LINK) -o $@ $<
+	$(AM_V_CCLD)$(LINK) $<
 
 tableopts_ver_r_C_F_ver_SOURCES = tableopts.l4
 
 tableopts_ver_r-C_F.ver$(EXEEXT): tableopts_ver_r-C_F.$(OBJEXT)
-	$(AM_V_CCLD)$(LINK) -o $@ $<
+	$(AM_V_CCLD)$(LINK) $<
 
 tableopts_ver_r_Cm_ver_SOURCES = tableopts.l4
 
 tableopts_ver_r-Cm.ver$(EXEEXT): tableopts_ver_r-Cm.$(OBJEXT)
-	$(AM_V_CCLD)$(LINK) -o $@ $<
+	$(AM_V_CCLD)$(LINK) $<
 
 tableopts_ver_r_Cem_ver_SOURCES = tableopts.l4
 
 tableopts_ver_r-Cem.ver$(EXEEXT): tableopts_ver_r-Cem.$(OBJEXT)
-	$(AM_V_CCLD)$(LINK) -o $@ $<
+	$(AM_V_CCLD)$(LINK) $<
 
 tableopts_ver_r_Cae_ver_SOURCES = tableopts.l4
 
 tableopts_ver_r-Cae.ver$(EXEEXT): tableopts_ver_r-Cae.$(OBJEXT)
-	$(AM_V_CCLD)$(LINK) -o $@ $<
+	$(AM_V_CCLD)$(LINK) $<
 
 tableopts_ver_r_Caef_ver_SOURCES = tableopts.l4
 
 tableopts_ver_r-Caef.ver$(EXEEXT): tableopts_ver_r-Caef.$(OBJEXT)
-	$(AM_V_CCLD)$(LINK) -o $@ $<
+	$(AM_V_CCLD)$(LINK) $<
 
 tableopts_ver_r_Cae_F_ver_SOURCES = tableopts.l4
 
 tableopts_ver_r-Cae_F.ver$(EXEEXT): tableopts_ver_r-Cae_F.$(OBJEXT)
-	$(AM_V_CCLD)$(LINK) -o $@ $<
+	$(AM_V_CCLD)$(LINK) $<
 
 tableopts_ver_r_Cam_ver_SOURCES = tableopts.l4
 
 tableopts_ver_r-Cam.ver$(EXEEXT): tableopts_ver_r-Cam.$(OBJEXT)
-	$(AM_V_CCLD)$(LINK) -o $@ $<
+	$(AM_V_CCLD)$(LINK) $<
 
 tableopts_ver_r_Caem_ver_SOURCES = tableopts.l4
 
 tableopts_ver_r-Caem.ver$(EXEEXT): tableopts_ver_r-Caem.$(OBJEXT)
-	$(AM_V_CCLD)$(LINK) -o $@ $<
+	$(AM_V_CCLD)$(LINK) $<
 
 TABLEOPTS_TESTS = tableopts_opt_nr-Ca.opt tableopts_opt_nr-Ce.opt tableopts_opt_nr-Cf.opt tableopts_opt_nr-C_F.opt tableopts_opt_nr-Cm.opt tableopts_opt_nr-Cem.opt tableopts_opt_nr-Cae.opt tableopts_opt_nr-Caef.opt tableopts_opt_nr-Cae_F.opt tableopts_opt_nr-Cam.opt tableopts_opt_nr-Caem.opt tableopts_opt_r-Ca.opt tableopts_opt_r-Ce.opt tableopts_opt_r-Cf.opt tableopts_opt_r-C_F.opt tableopts_opt_r-Cm.opt tableopts_opt_r-Cem.opt tableopts_opt_r-Cae.opt tableopts_opt_r-Caef.opt tableopts_opt_r-Cae_F.opt tableopts_opt_r-Cam.opt tableopts_opt_r-Caem.opt tableopts_ser_nr-Ca.ser tableopts_ser_nr-Ce.ser tableopts_ser_nr-Cf.ser tableopts_ser_nr-C_F.ser tableopts_ser_nr-Cm.ser tableopts_ser_nr-Cem.ser tableopts_ser_nr-Cae.ser tableopts_ser_nr-Caef.ser tableopts_ser_nr-Cae_F.ser tableopts_ser_nr-Cam.ser tableopts_ser_nr-Caem.ser tableopts_ser_r-Ca.ser tableopts_ser_r-Ce.ser tableopts_ser_r-Cf.ser tableopts_ser_r-C_F.ser tableopts_ser_r-Cm.ser tableopts_ser_r-Cem.ser tableopts_ser_r-Cae.ser tableopts_ser_r-Caef.ser tableopts_ser_r-Cae_F.ser tableopts_ser_r-Cam.ser tableopts_ser_r-Caem.ser tableopts_ver_nr-Ca.ver tableopts_ver_nr-Ce.ver tableopts_ver_nr-Cf.ver tableopts_ver_nr-C_F.ver tableopts_ver_nr-Cm.ver tableopts_ver_nr-Cem.ver tableopts_ver_nr-Cae.ver tableopts_ver_nr-Caef.ver tableopts_ver_nr-Cae_F.ver tableopts_ver_nr-Cam.ver tableopts_ver_nr-Caem.ver tableopts_ver_r-Ca.ver tableopts_ver_r-Ce.ver tableopts_ver_r-Cf.ver tableopts_ver_r-C_F.ver tableopts_ver_r-Cm.ver tableopts_ver_r-Cem.ver tableopts_ver_r-Cae.ver tableopts_ver_r-Caef.ver tableopts_ver_r-Cae_F.ver tableopts_ver_r-Cam.ver tableopts_ver_r-Caem.ver
 

--- a/tests/tableopts.sh
+++ b/tests/tableopts.sh
@@ -38,7 +38,7 @@ for kind in opt ser ver ; do
 tableopts_${kind}_${threading}_${bare_opt}_${kind}_SOURCES = tableopts.l4
 
 ${testname}\$(EXEEXT): tableopts_${kind}_${threading}-${bare_opt}.\$(OBJEXT)
-	\$(AM_V_CCLD)\$(LINK) -o \$@ \$<
+	\$(AM_V_CCLD)\$(LINK) \$<
 
 EOF
         done


### PR DESCRIPTION
`$(LINK)` in Automake already contains the `-o $@` arguments.