### PR TITLE
build: $(WARNINGFLAGS) appended to AM_CFLAGS as a rule

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -1,5 +1,6 @@
 AM_YFLAGS = -d
 AM_CPPFLAGS = -DLOCALEDIR=\"$(localedir)\"
+AM_CFLAGS = $(WARNINGFLAGS)
 LIBS = @LIBS@
 pkgconfigdir = @pkgconfigdir@
 
@@ -47,8 +48,6 @@ flex_SOURCES = \
 
 nodist_flex_SOURCES = \
 	stage1scan.c
-
-flex_CFLAGS = $(AM_CFLAGS) $(WARNINGFLAGS)
 
 COMMON_SOURCES = \
 	buf.c \
@@ -116,13 +115,13 @@ dist-hook: scan.l flex$(EXEEXT)
 # not fail.
 
 stage1flex-main.$(OBJEXT): parse.h
-flex-main.$(OBJEXT): parse.h
+main.$(OBJEXT): parse.h
 
 stage1flex-yylex.$(OBJEXT): parse.h
-flex-yylex.$(OBJEXT): parse.h
+yylex.$(OBJEXT): parse.h
 
 stage1flex-scan.$(OBJEXT): parse.h
-flex-stage1scan.$(OBJEXT): parse.h
+stage1scan.$(OBJEXT): parse.h
 
 # Run GNU indent on sources. Don't run this unless all the sources compile cleanly.
 #


### PR DESCRIPTION
In src/Makefile.am, remove flex_CFLAGS variable, and append
$(WARNINGFLAGS) to AM_CFLAGS. The use of flex_CFLAGS has forced
Automake to rename flex's object files (.o) to have a 'flex-' prefix.
By preventing the rename, the generated src/Makefile.in can be smaller
(-35kB, 30%).

For now this commit brings only the benefit of a smaller Makefile, I
plan to simplify the process of the native build of flex by sharing
generated .o files whenever possible between 2 stages (so only the
scanner and linked executable will need to be rebuilt in stage 2). And
this commit will be a prerequisite for that goal.