### PR TITLE
Makefile minor fixes

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -98,7 +98,7 @@ MAINTAINERCLEANFILES = skel.c
 
 skel.c: flex.skl mkskel.sh flexint_shared.h tables_shared.h tables_shared.c
 	$(SHELL) $(srcdir)/mkskel.sh $(srcdir) $(m4) $(VERSION) > $@.tmp
-	mv $@.tmp $@
+	mv -f $@.tmp $@
 
 if ENABLE_BOOTSTRAP
 stage1scan.c: scan.l stage1flex$(EXEEXT)
@@ -111,7 +111,7 @@ endif
 dist-hook: scan.l flex$(EXEEXT)
 	chmod u+w $(distdir) && \
 	./flex$(EXEEXT) -o scan.c $< && \
-	mv scan.c $(distdir)
+	mv -f scan.c $(distdir)
 
 # make needs to be told to make parse.h so that parallelized runs will
 # not fail.

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -109,7 +109,7 @@ stage1scan.c: scan.c
 endif
 
 dist-hook: scan.l flex$(EXEEXT)
-	chmod u+w $(distdir)/scan.c && \
+	chmod u+w $(distdir) && \
 	./flex$(EXEEXT) -o scan.c $< && \
 	mv scan.c $(distdir)
 

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -265,6 +265,7 @@ CLEANFILES = \
 	$(tableopts_tables)
 
 dist-hook:
+	chmod u+w $(distdir) && \
 	for file in $(CLEANFILES) ; do \
 	rm -f $(distdir)/$$file \
 	; done


### PR DESCRIPTION
1. Overwriting the files via `mv` command needs write permission on the directory, but the write permission on the file is not necessary. (In contrast, overwriting via `cp` command needs write permission on the file; write permission on the directory is optional.)
2. Make `mv` command more portable by specifying `-f` flag.