### PR TITLE
Fix "make distcheck" failure and use Automake 1.16.1

### DIFF
--- a/.travis/install-automake.sh
+++ b/.travis/install-automake.sh
@@ -1,20 +1,21 @@
 #!/bin/bash -ex
 
-wget -nv https://ftp.gnu.org/gnu/automake/automake-1.15.1.tar.gz
+wget -nv https://ftp.gnu.org/gnu/automake/automake-1.16.1.tar.gz
 
 # Verify tarball against hard-coded hashes. GPG signatures require an external
 # keyserver which might be offline, which is undesirable for build server use.
 # It's equally secure to just hard-code hashes, provided they're trusted (i.e.
 # you verify a hash against a GPG signature once).
-echo 'd3cd5fc9bbea9f977b51799180cde5d253dcba96 *automake-1.15.1.tar.gz'|
-    sha1sum -c || :
-printf '%s *automake-1.15.1.tar.gz\n' \
-f0d4717ebe2c76cec5d487de090f6e1c0f784b0d382fd964ffa846287e2a364a\
-52531a26ab98b7033ac04ed302a247b3b114299def54819a03439bfc962ff61b|
+printf '%s *automake-1.16.1.tar.gz\n' \
+608a97523f97db32f1f5d5615c98ca69326ced2054c9f82e65bade7fc4c9dea8|
+    sha256sum -c || :
+printf '%s *automake-1.16.1.tar.gz\n' \
+47b0120a59e3e020529a6ce750297d7de1156fd2be38db5d101e50120f11b40c\
+28741ecd5eacf2790a9e25386713dcf7717339cfa5d7943d0dbf47c417383448|
     sha512sum -c || :
 
-tar xf automake-1.15.1.tar.gz
-cd automake-1.15.1
+tar xf automake-1.16.1.tar.gz
+cd automake-1.16.1
 # Don't flood Travis CI build log with dependency packages unless error occurs.
 ./configure --quiet --prefix="$HOME" ||
     { s=$? && cat config.log && (exit $s); }

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -407,6 +407,9 @@ posixly_correct.c: posixly_correct.l $(FLEX)
 reject_nr.reject.c: reject.l4 $(FLEX)
 	$(AM_V_LEX)$(FLEX) --unsafe-no-m4-sect3-escape -o $@ $<
 
+reject_nr.reject.$(OBJEXT): reject_nr.reject.c
+	$(AM_V_CC)$(COMPILE) -c -o $@ $<
+
 reject_nr.reject$(EXEEXT): reject_nr.reject.$(OBJEXT)
 	$(AM_V_CCLD)$(LINK) $^
 


### PR DESCRIPTION
Not sure if flex needs this, but I can update ".travis/install-automake.sh" to use Automake 1.16.1.
(Automake 1.16 would fail to build in this Travis server (which runs Ubuntu 14.04) due to [the compatibility bug](https://lists.gnu.org/archive/html/bug-automake/2018-03/msg00005.html).)