### PR TITLE
Update README.md, changed instructions to use a separate build directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,9 @@ GNU-style configure script to be able to work.
 From this point on, building flex follows the usual routine:
 
 ```bash
-configure && make && make install
+mkdir build
+cd build
+../configure && make && make install
 ```
 
 ---


### PR DESCRIPTION
Reasons for doing so:

* it is more clean
* I actually got a strange `configure: error: source directory already configured; run "make distclean" there first` error message when trying to configure from srcdir, running configure from a separate builddir dir work without any issues
