### PR TITLE
Update autogen.sh, add executable right for po/update_linguas.sh

### DIFF
--- a/autogen.sh
+++ b/autogen.sh
@@ -49,3 +49,8 @@ if ! test -f ChangeLog; then
 fi
 "$LIBTOOLIZE" --install --force
 autoreconf --install --force
+
+# add executable right for auxiliary scripts
+if test -f po/update_linguas.sh; then
+   chmod gu+x po/update_linguas.sh
+fi


### PR DESCRIPTION
Not sure if there are more to include here. The missing rights may produced by wrong copying, using GitHub's download as zip function or by using GitHubs svn bridge (I assume they are set as executable with the available git function).