### PR TITLE
scanner: Include-guard flexint_shared.h

### DIFF
--- a/src/flexint_shared.h
+++ b/src/flexint_shared.h
@@ -1,46 +1,50 @@
 /* flex integer type definitions */
 
+#ifndef YYFLEX_INTTYPES_DEFINED
+#define YYFLEX_INTTYPES_DEFINED
+
 /* Prefer C99 integer types if available. */
-#if defined(__STDC_VERSION__) && __STDC_VERSION__ >= 199901L
+# if defined(__STDC_VERSION__) && __STDC_VERSION__ >= 199901L
 /* Include <inttypes.h> and not <stdint.h> because Solaris 2.6 has the former
  * and not the latter.
  */
 #include <inttypes.h>
-# define YYFLEX_USE_STDINT
-#else
-# if defined(_MSC_VER) && _MSC_VER >= 1600
+#  define YYFLEX_USE_STDINT
+# else
+#  if defined(_MSC_VER) && _MSC_VER >= 1600
 /* Visual C++ 2010 does not define __STDC_VERSION__ and has <stdint.h> but not
  * <inttypes.h>.
  */
 #include <stdint.h>
-#  define YYFLEX_USE_STDINT
+#   define YYFLEX_USE_STDINT
+#  endif
 # endif
-#endif
-#ifdef YYFLEX_USE_STDINT
+# ifdef YYFLEX_USE_STDINT
 typedef int8_t flex_int8_t;
 typedef uint8_t flex_uint8_t;
 typedef int16_t flex_int16_t;
 typedef uint16_t flex_uint16_t;
 typedef int32_t flex_int32_t;
 typedef uint32_t flex_uint32_t;
-#else
+# else
 typedef unsigned char flex_uint8_t;
 typedef short int flex_int16_t;
 typedef unsigned short int flex_uint16_t;
-# ifdef __STDC__
+#  ifdef __STDC__
 typedef signed char flex_int8_t;
 /* ISO C only requires at least 16 bits for int. */
 #include <limits.h>
-#  if UINT_MAX >= 4294967295
-#   define YYFLEX_INT32_DEFINED
+#   if UINT_MAX >= 4294967295
+#    define YYFLEX_INT32_DEFINED
 typedef int flex_int32_t;
 typedef unsigned int flex_uint32_t;
-#  endif
-# else
+#   endif
+#  else
 typedef char flex_int8_t;
-# endif
-# ifndef YYFLEX_INT32_DEFINED
+#  endif
+#  ifndef YYFLEX_INT32_DEFINED
 typedef long int flex_int32_t;
 typedef unsigned long int flex_uint32_t;
+#  endif
 # endif
-#endif
+#endif /* YYFLEX_INTTYPES_DEFINED */


### PR DESCRIPTION
This prevents compiler's "redefinition of typedef" warnings or errors
when we could include flexint_shared.h twice, when building flex's own
scanner (scan.c) or in the "multiple_scanners" test in the testsuite.

(Depending on the compiler's flags this might or might not produce
errors, but it's good to guard it anyway.)

Fixes: #329