### PR TITLE
Travis CI build badge for master branch

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![Build Status](https://travis-ci.org/westes/flex.svg?branch=master)](https://travis-ci.org/westes/flex)
+
 This is flex, the fast lexical analyzer generator.
 
 flex is a tool for generating scanners: programs which recognize


### PR DESCRIPTION
**Issue**
GitHub users could not see whether most recent `flex` version builds or not.

**Root cause**
`README.md` does not include build badge generated by Travis CI.

**Solution**
Badge that corresponds to `master` branch has been added to markup.

With this update project page will look like one below
![screen](https://user-images.githubusercontent.com/6383065/37839329-d471e148-2ec2-11e8-98a7-a2be14ef6bfd.png)