### PR TITLE
bug fix: bracket parsing in %top{...} code blocks 

### DIFF
--- a/doc/flex.texi
+++ b/doc/flex.texi
@@ -538,26 +538,36 @@ themselves.
 
 @cindex %top
 
-A @code{%top} block is similar to a @samp{%@{} ... @samp{%@}} block, except
+A @code{%top} block must be part of the Definitions Section and is
+similar to a @samp{%@{} ... @samp{%@}} block, except
 that the code in a @code{%top} block is relocated to the @emph{top} of the
-generated file, before any flex definitions @footnote{Actually,
-@code{yyIN_HEADER} is defined before the @samp{%top} block.}. 
+generated file, before any flex definitions. In the generated header file
+@code{yyIN_HEADER} is defined before the @samp{%top} block.
 The @code{%top} block is useful when you want certain preprocessor macros to be
 defined or certain files to be included before the generated code.
 The single characters, @samp{@{}  and @samp{@}} are used to delimit the
-@code{%top} block, as show in the example below:
+@code{%top} block, as shown in the example below:
 
 @example
 @verbatim
     %top{
-        /* This code goes at the "top" of the generated file. */
+        /* This code goes at the "top" of the generated file
+            the compiler should ignore as part of the
+            generated header file.
+        */
+        #ifndef yyIN_HEADER
         #include <stdint.h>
         #include <inttypes.h>
+        #endif
     }
 @end verbatim
 @end example
 
 Multiple @code{%top} blocks are allowed, and their order is preserved.
+Each @code{%top} block is required to have syntactically complete
+pairings of @samp{%@{} and @samp{%@}}, where the closing @samp{%@}}
+is not required to be unindented or on a separate code line, while
+@code{%top%@{} must not be indented.
 
 @node Rules Section, User Code Section, Definitions Section, Format
 @section Format of the Rules Section

--- a/doc/flex.texi
+++ b/doc/flex.texi
@@ -569,6 +569,9 @@ pairings of @samp{%@{} and @samp{%@}}, where the closing @samp{%@}}
 is not required to be unindented or on a separate code line, while
 @code{%top%@{} must not be indented.
 
+Alternatively, the @code{%top} block can be closed by an unindented
+@samp{%@}}.
+
 @node Rules Section, User Code Section, Definitions Section, Format
 @section Format of the Rules Section
 

--- a/src/main.c
+++ b/src/main.c
@@ -484,7 +484,11 @@ void check_options (void)
 
     /* Dump the %top code. */
     if( top_buf.elts)
+    {
+        if( ddebug )
+            out(" /* top code section(s) */\n\n");
         outn((char*) top_buf.elts);
+    }
 
     /* Dump the m4 definitions. */
     buf_print_strings(&m4defs_buf, stdout);

--- a/src/scan.l
+++ b/src/scan.l
@@ -137,7 +137,7 @@ extern const char *escaped_qstart, *escaped_qend;
 
 %x SECT2 SECT2PROLOG SECT3 CODEBLOCK PICKUPDEF SC CARETISBOL NUM QUOTE
 %x FIRSTCCL CCL ACTION RECOVER COMMENT ACTION_STRING PERCENT_BRACE_ACTION
-%x OPTION LINEDIR CODEBLOCK_MATCH_BRACE
+%x OPTION LINEDIR CODEBLOCK_TOP
 %x GROUP_WITH_PARAMS
 %x GROUP_MINUS_PARAMS
 %x EXTENDED_COMMENT
@@ -195,7 +195,7 @@ STRING_LITERAL   \"(\\\"|\\{NL}|[^"\r\n])*\"
                 ++linenum;
                 buf_linedir( &top_buf, infilename?infilename:"<stdin>", linenum);
                 brace_depth = 1;
-                yy_push_state(CODEBLOCK_MATCH_BRACE);
+                yy_push_state(CODEBLOCK_TOP);
             }
 
     ^"%top".*   synerr( _("malformed '%top' directive") );
@@ -297,7 +297,7 @@ STRING_LITERAL   \"(\\\"|\\{NL}|[^"\r\n])*\"
 			}
 }
 
-<CODEBLOCK_MATCH_BRACE>{
+<CODEBLOCK_TOP>{
     "'}'"      |
     "'{'"      |
     [^{}\r\n]  |
@@ -305,6 +305,8 @@ STRING_LITERAL   \"(\\\"|\\{NL}|[^"\r\n])*\"
 
     {STRING_LITERAL}  |
     {C_COMMENT}     LINENUM_UPDATE; buf_strnappend(&top_buf, yytext, yyleng);
+
+    ^"%}"      buf_strnappend(&top_buf, "\n", 1); yy_pop_state();
 
     "}"     {
                 if( --brace_depth == 0){

--- a/src/scan.l
+++ b/src/scan.l
@@ -123,6 +123,13 @@ extern const char *escaped_qstart, *escaped_qend;
     if (!indented_code) line_directive_out(NULL, 0);\
 } while (0)
 
+#define LINENUM_UPDATE do {         \
+    int yy1 = 0;                    \
+    while(yy1 < yyleng)             \
+        if( yytext[yy1++] == '\n' ) \
+            linenum++;              \
+} while (0)
+
 %}
 
 %option caseless nodefault noreject stack noyy_top_state
@@ -159,6 +166,12 @@ LEXOPT		[aceknopr]
 
 M4QSTART    "[""["
 M4QEND      "]""]"
+
+ /* c-comment, potentially multiline */
+C_COMMENT	      [/][*]+([^*]|([*][^/]))*[*]+[/]
+
+ /* string literals, potentially multiline */
+STRING_LITERAL   \"(\\\"|\\{NL}|[^"\r\n])*\"
 
 %%
 	static int bracelevel, didadef, indented_code;
@@ -285,9 +298,17 @@ M4QEND      "]""]"
 }
 
 <CODEBLOCK_MATCH_BRACE>{
+    "'}'"      |
+    "'{'"      |
+    [^{}\r\n]  |
+    "//".*     buf_strnappend(&top_buf, yytext, yyleng);
+
+    {STRING_LITERAL}  |
+    {C_COMMENT}     LINENUM_UPDATE; buf_strnappend(&top_buf, yytext, yyleng);
+
     "}"     {
                 if( --brace_depth == 0){
-                    /* TODO: Matched. */
+                    buf_strnappend(&top_buf, "\n", 1);
                     yy_pop_state();
                 }else
                     buf_strnappend(&top_buf, yytext, yyleng);
@@ -305,9 +326,6 @@ M4QEND      "]""]"
 
     {M4QSTART}  buf_strnappend(&top_buf, escaped_qstart, (int) strlen(escaped_qstart));
     {M4QEND}    buf_strnappend(&top_buf, escaped_qend, (int) strlen(escaped_qend));
-    ([^{}\r\n\[\]]+)|[^{}\r\n]  {
-       buf_strnappend(&top_buf, yytext, yyleng);
-    }
 
     <<EOF>>     {
                 linenum = brace_start_line;

--- a/tests/.gitignore
+++ b/tests/.gitignore
@@ -97,7 +97,7 @@ string_r
 string_r.c
 top
 top.[ch]
-top[1-6].c
+top[1-7].c
 yyextra
 yyextra.c
 tableopts_*.c

--- a/tests/.gitignore
+++ b/tests/.gitignore
@@ -97,6 +97,7 @@ string_r
 string_r.c
 top
 top.[ch]
+top[1-6].c
 yyextra
 yyextra.c
 tableopts_*.c

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -93,6 +93,12 @@ simple_tests = \
 	string_nr \
 	string_r \
 	top \
+	top1 \
+	top2 \
+	top3 \
+	top4 \
+	top5 \
+	top6 \
 	yyextra
 
 reject_tests = \
@@ -180,6 +186,12 @@ rescan_r_direct_SOURCES = rescan_r.direct.l
 string_nr_SOURCES = string_nr.l
 string_r_SOURCES = string_r.l
 top_SOURCES = top.l top_main.c
+top1_SOURCES = top1.l
+top2_SOURCES = top2.l
+top3_SOURCES = top3.l
+top4_SOURCES = top4.l
+top5_SOURCES = top5.l
+top6_SOURCES = top6.l
 nodist_top_SOURCES = top.h
 yyextra_SOURCES = yyextra.l
 
@@ -260,6 +272,12 @@ CLEANFILES = \
 	string_r.c \
 	top.c \
 	top.h  \
+	top1.c \
+	top2.c \
+	top3.c \
+	top4.c \
+	top5.c \
+	top6.c \
 	yyextra.c \
 	$(tableopts_c) \
 	$(tableopts_tables)

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -99,6 +99,7 @@ simple_tests = \
 	top4 \
 	top5 \
 	top6 \
+	top7 \
 	yyextra
 
 reject_tests = \
@@ -192,6 +193,7 @@ top3_SOURCES = top3.l
 top4_SOURCES = top4.l
 top5_SOURCES = top5.l
 top6_SOURCES = top6.l
+top7_SOURCES = top7.l
 nodist_top_SOURCES = top.h
 yyextra_SOURCES = yyextra.l
 
@@ -278,6 +280,7 @@ CLEANFILES = \
 	top4.c \
 	top5.c \
 	top6.c \
+	top7.c \
 	yyextra.c \
 	$(tableopts_c) \
 	$(tableopts_tables)

--- a/tests/top1.l
+++ b/tests/top1.l
@@ -1,0 +1,21 @@
+
+%option noyywrap noinput nounput
+%option prefix="test"
+
+%top{
+ /* single-line c-comment with "}" */
+}
+
+%%
+.
+%%
+
+ /* add a simple main function,
+	since we only want to check if
+	the scanner code can be generated
+	by flex
+ */
+int main()
+{
+	return 0;
+}

--- a/tests/top2.l
+++ b/tests/top2.l
@@ -1,0 +1,23 @@
+
+%option noyywrap noinput nounput
+%option prefix="test"
+
+%top{
+ /*
+	multi-line c-comment with "}"
+ */
+}
+
+%%
+.
+%%
+
+ /* add a simple main function,
+	since we only want to check if
+	the scanner code can be generated
+	by flex
+ */
+int main()
+{
+	return 0;
+}

--- a/tests/top3.l
+++ b/tests/top3.l
@@ -1,0 +1,22 @@
+
+%option noyywrap noinput nounput
+%option prefix="test"
+
+%top {
+ // line comment with "}"
+}
+
+%%
+.
+%%
+
+ /* add a simple main function,
+	since we only want to check if
+	the scanner code can be generated
+	by flex
+ */
+int main()
+{
+	return 0;
+}
+

--- a/tests/top4.l
+++ b/tests/top4.l
@@ -1,0 +1,37 @@
+
+%option noyywrap noinput nounput
+%option prefix="test"
+
+%top{
+  /*
+  combined test if flex recognizes syntactically
+  correct pairings of curly brackets and characters
+  of curly brackets (closing curly brackets, in
+  particular).
+  */
+ static int f(void)
+ {
+	int c = 0;
+	if (c == '}')
+	{
+		return '{';
+	}
+	else
+		return '}';
+ }
+}
+
+%%
+.
+%%
+
+ /* add a simple main function,
+	since we only want to check if
+	the scanner code can be generated
+	by flex
+ */
+int main()
+{
+	return 0;
+}
+

--- a/tests/top5.l
+++ b/tests/top5.l
@@ -1,0 +1,22 @@
+
+%option noyywrap noinput nounput
+%option prefix="test"
+
+%top{
+	/* string literal with closing curly bracket */
+	const char* string_literal = "abc } def";
+}
+
+%%
+.
+%%
+
+/* add a simple main function,
+	since we only want to check if
+	the scanner code can be generated
+	by flex
+ */
+int main()
+{
+	return 0;
+}

--- a/tests/top6.l
+++ b/tests/top6.l
@@ -1,0 +1,25 @@
+
+%option noyywrap noinput nounput
+%option prefix="test"
+
+%top{
+	/* string literal with closing curly
+		bracket, broken by backslash at EOL */
+	const char* string_literal = "abc }\
+		def";
+}
+
+%%
+.
+%%
+
+ /* add a simple main function,
+	since we only want to check if
+	the scanner code can be generated
+	by flex
+ */
+int main()
+{
+	return 0;
+}
+

--- a/tests/top7.l
+++ b/tests/top7.l
@@ -1,0 +1,24 @@
+
+%option noyywrap noinput nounput
+%option prefix="test"
+
+%top{
+	/*
+		closing tag of top section is %}
+	*/
+%}
+
+%%
+.
+%%
+
+ /* add a simple main function,
+	since we only want to check if
+	the scanner code can be generated
+	by flex
+ */
+int main()
+{
+	return 0;
+}
+


### PR DESCRIPTION
The bracket parsing of %top{...} has flaws in flex 2.6.4 fixed by the package.

Unfortunately the test file top.l is (almost) completely replaced albeit some lines with sample code blocks for bracket parsing are added.

@westes Will, please amend as you find appropriate, the edits to the manual, in particular.