### PR TITLE
consistent treatment of '--main' and '%option main'

### DIFF
--- a/src/flex.skl
+++ b/src/flex.skl
@@ -3412,9 +3412,9 @@ int main ()
 
 %if-reentrant
     yyscan_t lexer;
-    yylex_init(&lexer);
+    yylex_init( &lexer );
     yylex( lexer );
-    yylex_destroy( lexer);
+    yylex_destroy( lexer );
 
 %endif
 %if-not-reentrant

--- a/src/flexdef.h
+++ b/src/flexdef.h
@@ -969,7 +969,11 @@ extern void line_pinpoint(const char *, int);
 /* Report a formatted syntax error. */
 extern void format_synerr(const char *, const char *);
 extern void synerr(const char *);	/* report a syntax error */
-extern void format_warn(const char *, const char *);
+extern void format_warn(const char *fmt, ...)
+#if defined(__GNUC__) && __GNUC__ >= 3
+    __attribute__((__format__(__printf__, 1, 2)))
+#endif
+;
 extern void lwarn(const char *);	/* report a warning */
 extern void yyerror(const char *);	/* report a parse error */
 extern int yyparse(void);		/* the YACC parser */

--- a/src/flexdef.h
+++ b/src/flexdef.h
@@ -115,6 +115,12 @@
 
 #define unspecified -1
 
+enum option_e {
+	option_unspecified = unspecified,
+	option_true        = true,
+	option_false       = false,
+} ;
+
 /* Special chk[] values marking the slots taking by end-of-buffer and action
  * numbers.
  */
@@ -410,7 +416,7 @@ extern char *infilename, *outfilename, *headerfilename;
 extern int did_outfilename;
 extern char *prefix, *yyclass, *extra_type;
 extern int do_stdinit, use_stdout;
-extern int do_main;
+extern enum option_e do_main;
 extern char **input_files;
 extern int num_input_files;
 extern char *program_name;

--- a/src/flexdef.h
+++ b/src/flexdef.h
@@ -383,6 +383,7 @@ extern int trace_hex;
  * outfilename - name of output file
  * headerfilename - name of the .h file to generate
  * did_outfilename - whether outfilename was explicitly set
+ * do_main - create a default main function
  * prefix - the prefix used for externally visible names ("yy" by default)
  * yyclass - yyFlexLexer subclass to use for YY_DECL
  * do_stdinit - whether to initialize yyin/yyout to stdin/stdout
@@ -409,6 +410,7 @@ extern char *infilename, *outfilename, *headerfilename;
 extern int did_outfilename;
 extern char *prefix, *yyclass, *extra_type;
 extern int do_stdinit, use_stdout;
+extern int do_main;
 extern char **input_files;
 extern int num_input_files;
 extern char *program_name;

--- a/src/main.c
+++ b/src/main.c
@@ -54,6 +54,7 @@ int     interactive, lex_compat, posix_compat, do_yylineno,
 int     fullspd, gen_line_dirs, performance_report, backing_up_report;
 int     C_plus_plus, long_align, use_read, yytext_is_array, do_yywrap,
 	csize;
+int     do_main;
 int     reentrant, bison_bridge_lval, bison_bridge_lloc;
 int     yymore_used, reject, real_reject, continued_action, in_rule;
 int     yymore_really_used, reject_really_used;
@@ -215,6 +216,13 @@ void check_options (void)
 {
 	int     i;
     const char * m4 = NULL;
+
+	if ( do_main )
+	{
+		/* Override yywrap */
+		do_yywrap = false;
+		buf_m4_define( &m4defs_buf, "M4_YY_MAIN", NULL);
+	}
 
 	if (lex_compat) {
 		if (C_plus_plus)
@@ -959,6 +967,7 @@ void flexinit (int argc, char **argv)
 	yymore_really_used = reject_really_used = unspecified;
 	interactive = csize = unspecified;
 	do_yywrap = gen_line_dirs = usemecs = useecs = true;
+	do_main = false;
 	reentrant = bison_bridge_lval = bison_bridge_lloc = false;
 	performance_report = 0;
 	did_outfilename = 0;
@@ -1129,11 +1138,12 @@ void flexinit (int argc, char **argv)
 
 		case OPT_MAIN:
 			buf_strdefine (&userdef_buf, "YY_MAIN", "1");
-			do_yywrap = false;
+			do_main = true;
 			break;
 
 		case OPT_NO_MAIN:
 			buf_strdefine (&userdef_buf, "YY_MAIN", "0");
+			do_main = false;
 			break;
 
 		case OPT_NO_LINE:

--- a/src/main.c
+++ b/src/main.c
@@ -1137,12 +1137,10 @@ void flexinit (int argc, char **argv)
             break;
 
 		case OPT_MAIN:
-			buf_strdefine (&userdef_buf, "YY_MAIN", "1");
 			do_main = true;
 			break;
 
 		case OPT_NO_MAIN:
-			buf_strdefine (&userdef_buf, "YY_MAIN", "0");
 			do_main = false;
 			break;
 

--- a/src/main.c
+++ b/src/main.c
@@ -54,7 +54,7 @@ int     interactive, lex_compat, posix_compat, do_yylineno,
 int     fullspd, gen_line_dirs, performance_report, backing_up_report;
 int     C_plus_plus, long_align, use_read, yytext_is_array, do_yywrap,
 	csize;
-int     do_main;
+enum option_e do_main;
 int     reentrant, bison_bridge_lval, bison_bridge_lloc;
 int     yymore_used, reject, real_reject, continued_action, in_rule;
 int     yymore_really_used, reject_really_used;
@@ -217,7 +217,7 @@ void check_options (void)
 	int     i;
     const char * m4 = NULL;
 
-	if ( do_main )
+	if ( do_main == option_true )
 	{
 		/* Override yywrap */
 		do_yywrap = false;
@@ -839,7 +839,7 @@ void flexend (int exit_status)
 		if (strcmp (prefix, "yy"))
 			fprintf (stderr, " -P%s", prefix);
 
-		if (do_main)
+		if ( do_main == option_true )
 			fputs(" --main", stderr);
 
 		putc ('\n', stderr);
@@ -970,7 +970,7 @@ void flexinit (int argc, char **argv)
 	yymore_really_used = reject_really_used = unspecified;
 	interactive = csize = unspecified;
 	do_yywrap = gen_line_dirs = usemecs = useecs = true;
-	do_main = false;
+	do_main = option_unspecified;
 	reentrant = bison_bridge_lval = bison_bridge_lloc = false;
 	performance_report = 0;
 	did_outfilename = 0;
@@ -1140,11 +1140,11 @@ void flexinit (int argc, char **argv)
             break;
 
 		case OPT_MAIN:
-			do_main = true;
+			do_main = option_true;
 			break;
 
 		case OPT_NO_MAIN:
-			do_main = false;
+			do_main = option_false;
 			break;
 
 		case OPT_NO_LINE:

--- a/src/main.c
+++ b/src/main.c
@@ -839,6 +839,9 @@ void flexend (int exit_status)
 		if (strcmp (prefix, "yy"))
 			fprintf (stderr, " -P%s", prefix);
 
+		if (do_main)
+			fputs(" --main", stderr);
+
 		putc ('\n', stderr);
 
 		fprintf (stderr, _("  %d/%d NFA states\n"),

--- a/src/parse.y
+++ b/src/parse.y
@@ -1013,13 +1013,17 @@ void synerr( const char *str )
 
 /* format_warn - write out formatted warning */
 
-void format_warn( const char *msg, const char arg[] )
-	{
+void format_warn( const char *fmt, ...)
+{
 	char warn_msg[MAXLINE];
+	va_list ap;
 
-	snprintf( warn_msg, sizeof(warn_msg), msg, arg );
+	va_start(ap,fmt);
+	vsnprintf( warn_msg, sizeof(warn_msg), fmt, ap );
+	va_end(ap);
+
 	lwarn( warn_msg );
-	}
+}
 
 
 /* lwarn - report a warning, unless -w was given */

--- a/src/scan.l
+++ b/src/scan.l
@@ -393,12 +393,7 @@ M4QEND      "]""]"
 	lex-compat	lex_compat = option_sense;
 	posix-compat	posix_compat = option_sense;
 	line		gen_line_dirs = option_sense;
-	main		{
-			ACTION_M4_IFDEF( "M4""_YY_MAIN", option_sense);
-            /* Override yywrap */
-            if( option_sense == true )
-                do_yywrap = false;
-			}
+	main		do_main = option_sense;
 	meta-ecs	usemecs = option_sense;
 	never-interactive	{
 			ACTION_M4_IFDEF( "M4""_YY_NEVER_INTERACTIVE", option_sense );

--- a/src/scan.l
+++ b/src/scan.l
@@ -123,6 +123,17 @@ extern const char *escaped_qstart, *escaped_qend;
     if (!indented_code) line_directive_out(NULL, 0);\
 } while (0)
 
+/* define option flag and throw warning if redefined */
+#define OPTION_DEF_TEST(_do, _op)  do {                     \
+        if ( _do == option_unspecified )                    \
+            _do = _op;                                      \
+        else if ( _do != _op )                              \
+            format_warn(_("%%option '%s' redefined and "    \
+                "toggled to '%s'")                          \
+                , yytext                                    \
+                , (_do = _op) ? _("true") : _("false") );   \
+    } while(0)
+
 %}
 
 %option caseless nodefault noreject stack noyy_top_state
@@ -393,7 +404,7 @@ M4QEND      "]""]"
 	lex-compat	lex_compat = option_sense;
 	posix-compat	posix_compat = option_sense;
 	line		gen_line_dirs = option_sense;
-	main		do_main = option_sense;
+	main		OPTION_DEF_TEST(do_main, option_sense);
 	meta-ecs	usemecs = option_sense;
 	never-interactive	{
 			ACTION_M4_IFDEF( "M4""_YY_NEVER_INTERACTIVE", option_sense );


### PR DESCRIPTION
fixing bug #346 where command line flag `--main` is ignored when running `flex --main mini.l` with
```c
 /* mini.l */
%%
.
```
flex 2.6.4 does not provide a default main function in the generated code, although it does so if `%option main` is used instead.