### PR TITLE
enhanced parsing of %{...%} code blocks

### DIFF
--- a/src/scan.l
+++ b/src/scan.l
@@ -123,6 +123,14 @@ extern const char *escaped_qstart, *escaped_qend;
     if (!indented_code) line_directive_out(NULL, 0);\
 } while (0)
 
+/* macro mimiques yylineno treatment */
+#define LINENUM_UPDATE do {				\
+    int _yy1;							\
+    for(_yy1=0; _yy1 < yyleng; _yy1++)	\
+        if( yytext[_yy1] == '\n' )		\
+            linenum++;					\
+} while (0)
+
 %}
 
 %option caseless nodefault noreject stack noyy_top_state
@@ -159,6 +167,9 @@ LEXOPT		[aceknopr]
 
 M4QSTART    "[""["
 M4QEND      "]""]"
+
+ /* c-comment, potentially multiline */
+C_COMMENT	[/][*]+([^*]|([*][^/]))*[*]+[/]
 
 %%
 	static int bracelevel, didadef, indented_code;
@@ -274,8 +285,9 @@ M4QEND      "]""]"
 }
 
 <CODEBLOCK>{
+	{C_COMMENT}	  LINENUM_UPDATE;  add_action(M4QEND); ACTION_ECHO; add_action(M4QSTART);
 	^"%}".*{NL}	++linenum; END_CODEBLOCK;
-	[^\n%\[\]]*         ACTION_ECHO;
+	[^\n%\[\]/]+   ACTION_ECHO;
         .		ACTION_ECHO;
 	{NL}		{
 			++linenum;

--- a/tests/.gitignore
+++ b/tests/.gitignore
@@ -27,6 +27,7 @@ c_cxx_r
 c_cxx_r.cc
 ccl
 ccl.c
+comment_with_code_block_closing_tags[12].c
 cxx_basic
 cxx_basic.cc
 cxx_multiple_scanners

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -72,6 +72,9 @@ simple_tests = \
 	c_cxx_nr \
 	c_cxx_r \
 	ccl \
+	c-comment-section1-option \
+	comment_with_code_block_closing_tags1 \
+	comment_with_code_block_closing_tags2 \
 	cxx_basic \
 	cxx_multiple_scanners \
 	cxx_restart \
@@ -142,6 +145,9 @@ endif
 c_cxx_nr_SOURCES = c_cxx_nr.lll
 c_cxx_r_SOURCES = c_cxx_r.lll
 ccl_SOURCES = ccl.l
+c_comment_section1_option_SOURCES =	c-comment-section1-option.l
+comment_with_code_block_closing_tags1_SOURCES =	comment_with_code_block_closing_tags1.l
+comment_with_code_block_closing_tags2_SOURCES =	comment_with_code_block_closing_tags2.l
 cxx_basic_SOURCES = cxx_basic.ll
 cxx_restart_SOURCES = cxx_restart.ll
 cxx_multiple_scanners_SOURCES = cxx_multiple_scanners_main.cc cxx_multiple_scanners_1.ll cxx_multiple_scanners_2.ll
@@ -213,6 +219,9 @@ CLEANFILES = \
 	c_cxx_nr.cc \
 	c_cxx_r.cc \
 	ccl.c \
+	c-comment-section1-option.s \
+	comment_with_code_block_closing_tags1.c \
+	comment_with_code_block_closing_tags2.c \
 	cxx_basic.cc \
 	cxx_multiple_scanners_1.cc \
 	cxx_multiple_scanners_2.cc \
@@ -283,6 +292,7 @@ EXTRA_DIST = \
 	c_cxx_nr.txt \
 	c_cxx_r.txt \
 	ccl.txt \
+	c-comment-section1-option.txt \
 	cxx_basic.txt \
 	cxx_multiple_scanners.txt \
 	cxx_restart.txt \

--- a/tests/c-comment-section1-option.l
+++ b/tests/c-comment-section1-option.l
@@ -1,0 +1,7 @@
+%option noinput nounput main
+ /* <<< blank at BOL
+%option nomain
+ */
+%%
+.		yyterminate();
+%%

--- a/tests/c-comment-section1-option.txt
+++ b/tests/c-comment-section1-option.txt
@@ -1,0 +1,1 @@
+This is a test text.

--- a/tests/comment_with_code_block_closing_tags1.l
+++ b/tests/comment_with_code_block_closing_tags1.l
@@ -1,0 +1,30 @@
+%option noyywrap noinput nounput
+
+%{
+	/* This is a comment with closing tags
+	   of a code block, one at the beginning
+	   of the line, one within the line.
+
+	   Flex should not consider both of them
+	   as closing tag of this code block.
+
+	   %} ... closing tag within c-comment
+
+%} ... closing tag within c-comment at BOL
+	*/
+%}
+
+%%
+.
+
+%%
+
+/*
+	This test is about processing this input
+	file, not about compilation. So we add
+	a simple main function.
+*/
+int main(void)
+{
+	return 0;
+}

--- a/tests/comment_with_code_block_closing_tags2.l
+++ b/tests/comment_with_code_block_closing_tags2.l
@@ -1,0 +1,30 @@
+%option noyywrap noinput nounput
+
+%%
+
+%{
+	/* This is a comment with closing tags
+	   of a code block, one at the beginning
+	   of the line, one within the line.
+
+	   Flex should not consider both of them
+	   as closing tag of this code block.
+
+	   %} ... closing tag within c-comment
+
+%} ... closing tag within c-comment at BOL
+	*/
+%}
+.
+
+%%
+
+/*
+	This test is about processing this input
+	file, not about compilation. So we add
+	a simple main function.
+*/
+int main(void)
+{
+	return 0;
+}


### PR DESCRIPTION
c-comments within %{...%} code blocks are now copied
verbatim from the input file, the token `%}` as
part of the comment, in particular.

flex 2.6.4 fails to parse the following input file:
~~~c
  /* test input file test.l */
%{
  /*
%} ... a closing tag of a code block *within* a comment
  */
%}
%%
.
  /* EOF */
~~~

Test cases are added to the test suite.