### PR TITLE
bug fix: flex now honouring all %option 'no' flags

### DIFF
--- a/src/scan.l
+++ b/src/scan.l
@@ -201,7 +201,7 @@ M4QEND      "]""]"
 	^"%pointer".*{NL}	yytext_is_array = false; ++linenum;
 	^"%array".*{NL}		yytext_is_array = true; ++linenum;
 
-	^"%option"	BEGIN(OPTION); return TOK_OPTION;
+	^"%option"	BEGIN(OPTION); option_sense = true; return TOK_OPTION;
 
 	^"%"{LEXOPT}{OPTWS}[[:digit:]]*{OPTWS}{NL}	++linenum; /* ignore */
 	^"%"{LEXOPT}{WS}.*{NL}	++linenum;	/* ignore */

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -84,6 +84,7 @@ simple_tests = \
 	mem_r \
 	multiple_scanners_nr \
 	multiple_scanners_r \
+	option1 \
 	posix \
 	posixly_correct \
 	prefix_nr \
@@ -167,6 +168,7 @@ multiple_scanners_r_SOURCES = multiple_scanners_r_main.c multiple_scanners_r_1.l
 nodist_multiple_scanners_r_SOURCES = multiple_scanners_nr_1.h multiple_scanners_nr_2.h
 posix_SOURCES = posix.l
 posixly_correct_SOURCES = posixly_correct.l
+option1_SOURCES = option1.l
 prefix_nr_SOURCES = prefix_nr.l
 prefix_r_SOURCES = prefix_r.l
 pthread_pthread_SOURCES = pthread.l

--- a/tests/option1.l
+++ b/tests/option1.l
@@ -1,0 +1,49 @@
+ /*
+    This test checks if flex honours 'no' options flags,
+    in the following obscure %option section, in particular:
+
+    %option noyylineno <<< last option is negated
+    %optionnoyywrap    <<< first option is negated
+                            and *no* blank after
+                            token '%option' which
+                            makes flex 2.6.4 ignore
+                            the negation.
+
+    Return code of program is 1 if flex fails to allow for
+    'no' flag, 0 otherwise.
+
+    Compile with DEBUG=1 (e.g. 'gcc -DDEBUG') to have program
+    emit verbose information.
+ */
+%option prefix="test"
+%option noyylineno
+%optionnoyywrap
+
+%%
+    #ifdef testwrap
+        /* flex correctly parsed the option 'noyywrap' */
+        #define ADJ 0
+    #else
+        /* add definition of testwrap which flex forgot */
+        #define ADJ 1
+        #define testwrap() (1)
+    #endif
+.
+
+%%
+
+int main(int argc, char** argv)
+{
+#if DEBUG
+    if ( ADJ == 0 )
+        printf("OK - flex defined 'testwrap' as expected.\n");
+    else
+        printf("FAILED - flex %d.%d.%d forgot to define 'testwrap'.\n"
+            , YY_FLEX_MAJOR_VERSION
+            , YY_FLEX_MINOR_VERSION
+            , YY_FLEX_SUBMINOR_VERSION
+            );
+#endif
+
+    return ADJ;
+}


### PR DESCRIPTION
Bug fix to make flex allow for the negation in
~~~c
%optionnoyylineno
~~~

Test file (with more information re issue) added to test suite.

NB: A blank after `%option` is not documented as mandatory, so the patch simply makes flex behave correctly in this spurious situation.