### PR TITLE
build: add __attribute__s for deprecating functions etc.

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -56,6 +56,24 @@ AC_PROG_LN_S
 AC_PROG_AWK
 AC_PROG_INSTALL
 
+#
+# check for func and var __attribute__(()) variations
+#
+AX_GCC_FUNC_ATTRIBUTE([alloc_size])
+AX_GCC_FUNC_ATTRIBUTE([always_inline])
+AX_GCC_FUNC_ATTRIBUTE([deprecated])
+AX_GCC_FUNC_ATTRIBUTE([format])
+AX_GCC_FUNC_ATTRIBUTE([format_arg])
+AX_GCC_FUNC_ATTRIBUTE([gnu_inline])
+AX_GCC_FUNC_ATTRIBUTE([malloc])
+AX_GCC_FUNC_ATTRIBUTE([nonnull])
+AX_GCC_FUNC_ATTRIBUTE([noreturn])
+AX_GCC_FUNC_ATTRIBUTE([unused])
+
+AX_GCC_VAR_ATTRIBUTE([deprecated])
+AX_GCC_VAR_ATTRIBUTE([unused])
+
+
 pkgconfigdir=${libdir}/pkgconfig
 AC_SUBST(pkgconfigdir)
 

--- a/configure.ac
+++ b/configure.ac
@@ -22,8 +22,15 @@
 # WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
 # PURPOSE.
 
+#
+# flex version read from '.prev-version' and format checked
+#
+m4_define( [FLEX_VERSION], [m4_esyscmd_s([cat .prev-version])])
+m4_define( [RX_FLEX_VERSION], [^\([0-9]+\)\.\([0-9]+\)\.\([0-9]+\)$])
+m4_bmatch( FLEX_VERSION, m4_defn([RX_FLEX_VERSION]), [],
+          [m4_fatal( [Illegal flex version read from file '.prev-version'.] , [2])])
+
 # autoconf requirements and initialization
-m4_define( [FLEX_VERSION], [2.6.4] )
 AC_INIT([the fast lexical analyser generator],[FLEX_VERSION],[flex-help@lists.sourceforge.net],[flex])
 AC_PREREQ([2.60])
 AC_CONFIG_SRCDIR([src/scan.l])
@@ -40,7 +47,6 @@ AC_SUBST(SHARED_VERSION_INFO)
 #
 # split package version string (major.minor.subminor) into components
 #
-m4_define([RX_FLEX_VERSION],[^\([0-9]+\)\.\([0-9]+\)\.\([0-9]+\)])
 AC_DEFINE_UNQUOTED( [FLEX_VERSION_MAJOR],
 	[m4_bregexp( FLEX_VERSION, m4_defn([RX_FLEX_VERSION]), [\1])],
 	[major of flex version] )

--- a/configure.ac
+++ b/configure.ac
@@ -23,6 +23,7 @@
 # PURPOSE.
 
 # autoconf requirements and initialization
+m4_define( [FLEX_VERSION], [2.6.4] )
 
 AC_INIT([the fast lexical analyser generator],[2.6.4],[flex-help@lists.sourceforge.net],[flex])
 AC_PREREQ([2.60])
@@ -36,6 +37,20 @@ AC_CONFIG_LIBOBJ_DIR([lib])
 AC_CONFIG_MACRO_DIR([m4])
 SHARED_VERSION_INFO="2:0:0"
 AC_SUBST(SHARED_VERSION_INFO)
+
+#
+# split package version string (major.minor.subminor) into components
+#
+m4_define([RX_FLEX_VERSION],[^\([0-9]+\)\.\([0-9]+\)\.\([0-9]+\)])
+AC_DEFINE_UNQUOTED( [FLEX_VERSION_MAJOR],
+	[m4_bregexp( FLEX_VERSION, m4_defn([RX_FLEX_VERSION]), [\1])],
+	[major of flex version] )
+AC_DEFINE_UNQUOTED( [FLEX_VERSION_MINOR],
+	[m4_bregexp( FLEX_VERSION, m4_defn([RX_FLEX_VERSION]), [\2])],
+	[minor of flex version] )
+AC_DEFINE_UNQUOTED( [FLEX_VERSION_SUBMINOR],
+	[m4_bregexp( FLEX_VERSION, m4_defn([RX_FLEX_VERSION]), [\3])],
+	[subminor of flex version] )
 
 # checks for programs
 

--- a/configure.ac
+++ b/configure.ac
@@ -24,8 +24,7 @@
 
 # autoconf requirements and initialization
 m4_define( [FLEX_VERSION], [2.6.4] )
-
-AC_INIT([the fast lexical analyser generator],[2.6.4],[flex-help@lists.sourceforge.net],[flex])
+AC_INIT([the fast lexical analyser generator],[FLEX_VERSION],[flex-help@lists.sourceforge.net],[flex])
 AC_PREREQ([2.60])
 AC_CONFIG_SRCDIR([src/scan.l])
 AC_CONFIG_AUX_DIR([build-aux])

--- a/m4/ax_gcc_func_attribute.m4
+++ b/m4/ax_gcc_func_attribute.m4
@@ -1,0 +1,238 @@
+# ===========================================================================
+#  https://www.gnu.org/software/autoconf-archive/ax_gcc_func_attribute.html
+# ===========================================================================
+#
+# SYNOPSIS
+#
+#   AX_GCC_FUNC_ATTRIBUTE(ATTRIBUTE)
+#
+# DESCRIPTION
+#
+#   This macro checks if the compiler supports one of GCC's function
+#   attributes; many other compilers also provide function attributes with
+#   the same syntax. Compiler warnings are used to detect supported
+#   attributes as unsupported ones are ignored by default so quieting
+#   warnings when using this macro will yield false positives.
+#
+#   The ATTRIBUTE parameter holds the name of the attribute to be checked.
+#
+#   If ATTRIBUTE is supported define HAVE_FUNC_ATTRIBUTE_<ATTRIBUTE>.
+#
+#   The macro caches its result in the ax_cv_have_func_attribute_<attribute>
+#   variable.
+#
+#   The macro currently supports the following function attributes:
+#
+#    alias
+#    aligned
+#    alloc_size
+#    always_inline
+#    artificial
+#    cold
+#    const
+#    constructor
+#    constructor_priority for constructor attribute with priority
+#    deprecated
+#    destructor
+#    dllexport
+#    dllimport
+#    error
+#    externally_visible
+#    fallthrough
+#    flatten
+#    format
+#    format_arg
+#    gnu_inline
+#    hot
+#    ifunc
+#    leaf
+#    malloc
+#    noclone
+#    noinline
+#    nonnull
+#    noreturn
+#    nothrow
+#    optimize
+#    pure
+#    sentinel
+#    sentinel_position
+#    unused
+#    used
+#    visibility
+#    warning
+#    warn_unused_result
+#    weak
+#    weakref
+#
+#   Unsupported function attributes will be tested with a prototype
+#   returning an int and not accepting any arguments and the result of the
+#   check might be wrong or meaningless so use with care.
+#
+# LICENSE
+#
+#   Copyright (c) 2013 Gabriele Svelto <gabriele.svelto@gmail.com>
+#
+#   Copying and distribution of this file, with or without modification, are
+#   permitted in any medium without royalty provided the copyright notice
+#   and this notice are preserved.  This file is offered as-is, without any
+#   warranty.
+
+#serial 9
+
+AC_DEFUN([AX_GCC_FUNC_ATTRIBUTE], [
+    AS_VAR_PUSHDEF([ac_var], [ax_cv_have_func_attribute_$1])
+
+    AC_CACHE_CHECK([for __attribute__(($1))], [ac_var], [
+        AC_LINK_IFELSE([AC_LANG_PROGRAM([
+            m4_case([$1],
+                [alias], [
+                    int foo( void ) { return 0; }
+                    int bar( void ) __attribute__(($1("foo")));
+                ],
+                [aligned], [
+                    int foo( void ) __attribute__(($1(32)));
+                ],
+                [alloc_size], [
+                    void *foo(int a) __attribute__(($1(1)));
+                ],
+                [always_inline], [
+                    inline __attribute__(($1)) int foo( void ) { return 0; }
+                ],
+                [artificial], [
+                    inline __attribute__(($1)) int foo( void ) { return 0; }
+                ],
+                [cold], [
+                    int foo( void ) __attribute__(($1));
+                ],
+                [const], [
+                    int foo( void ) __attribute__(($1));
+                ],
+                [constructor_priority], [
+                    int foo( void ) __attribute__((__constructor__(65535/2)));
+                ],
+                [constructor], [
+                    int foo( void ) __attribute__(($1));
+                ],
+                [deprecated], [
+                    int foo( void ) __attribute__(($1("")));
+                ],
+                [destructor], [
+                    int foo( void ) __attribute__(($1));
+                ],
+                [dllexport], [
+                    __attribute__(($1)) int foo( void ) { return 0; }
+                ],
+                [dllimport], [
+                    int foo( void ) __attribute__(($1));
+                ],
+                [error], [
+                    int foo( void ) __attribute__(($1("")));
+                ],
+                [externally_visible], [
+                    int foo( void ) __attribute__(($1));
+                ],
+                [fallthrough], [
+                    int foo( void ) {switch (0) { case 1: __attribute__(($1)); case 2: break ; }};
+                ],
+                [flatten], [
+                    int foo( void ) __attribute__(($1));
+                ],
+                [format], [
+                    int foo(const char *p, ...) __attribute__(($1(printf, 1, 2)));
+                ],
+                [format_arg], [
+                    char *foo(const char *p) __attribute__(($1(1)));
+                ],
+                [gnu_inline], [
+                    inline __attribute__(($1)) int foo( void ) { return 0; }
+                ],
+                [hot], [
+                    int foo( void ) __attribute__(($1));
+                ],
+                [ifunc], [
+                    int my_foo( void ) { return 0; }
+                    static int (*resolve_foo(void))(void) { return my_foo; }
+                    int foo( void ) __attribute__(($1("resolve_foo")));
+                ],
+                [leaf], [
+                    __attribute__(($1)) int foo( void ) { return 0; }
+                ],
+                [malloc], [
+                    void *foo( void ) __attribute__(($1));
+                ],
+                [noclone], [
+                    int foo( void ) __attribute__(($1));
+                ],
+                [noinline], [
+                    __attribute__(($1)) int foo( void ) { return 0; }
+                ],
+                [nonnull], [
+                    int foo(char *p) __attribute__(($1(1)));
+                ],
+                [noreturn], [
+                    void foo( void ) __attribute__(($1));
+                ],
+                [nothrow], [
+                    int foo( void ) __attribute__(($1));
+                ],
+                [optimize], [
+                    __attribute__(($1(3))) int foo( void ) { return 0; }
+                ],
+                [pure], [
+                    int foo( void ) __attribute__(($1));
+                ],
+                [sentinel], [
+                    int foo(void *p, ...) __attribute__(($1));
+                ],
+                [sentinel_position], [
+                    int foo(void *p, ...) __attribute__(($1(1)));
+                ],
+                [returns_nonnull], [
+                    void *foo( void ) __attribute__(($1));
+                ],
+                [unused], [
+                    int foo( void ) __attribute__(($1));
+                ],
+                [used], [
+                    int foo( void ) __attribute__(($1));
+                ],
+                [visibility], [
+                    int foo_def( void ) __attribute__(($1("default")));
+                    int foo_hid( void ) __attribute__(($1("hidden")));
+                    int foo_int( void ) __attribute__(($1("internal")));
+                    int foo_pro( void ) __attribute__(($1("protected")));
+                ],
+                [warning], [
+                    int foo( void ) __attribute__(($1("")));
+                ],
+                [warn_unused_result], [
+                    int foo( void ) __attribute__(($1));
+                ],
+                [weak], [
+                    int foo( void ) __attribute__(($1));
+                ],
+                [weakref], [
+                    static int foo( void ) { return 0; }
+                    static int bar( void ) __attribute__(($1("foo")));
+                ],
+                [
+                 m4_warn([syntax], [Unsupported attribute $1, the test may fail])
+                 int foo( void ) __attribute__(($1));
+                ]
+            )], [])
+            ],
+            dnl GCC doesn't exit with an error if an unknown attribute is
+            dnl provided but only outputs a warning, so accept the attribute
+            dnl only if no warning were issued.
+            [AS_IF([test -s conftest.err],
+                [AS_VAR_SET([ac_var], [no])],
+                [AS_VAR_SET([ac_var], [yes])])],
+            [AS_VAR_SET([ac_var], [no])])
+    ])
+
+    AS_IF([test yes = AS_VAR_GET([ac_var])],
+        [AC_DEFINE_UNQUOTED(AS_TR_CPP(HAVE_FUNC_ATTRIBUTE_$1), 1,
+            [Define to 1 if the system has the `$1' function attribute])], [])
+
+    AS_VAR_POPDEF([ac_var])
+])

--- a/m4/ax_gcc_var_attribute.m4
+++ b/m4/ax_gcc_var_attribute.m4
@@ -1,0 +1,141 @@
+# ===========================================================================
+#   https://www.gnu.org/software/autoconf-archive/ax_gcc_var_attribute.html
+# ===========================================================================
+#
+# SYNOPSIS
+#
+#   AX_GCC_VAR_ATTRIBUTE(ATTRIBUTE)
+#
+# DESCRIPTION
+#
+#   This macro checks if the compiler supports one of GCC's variable
+#   attributes; many other compilers also provide variable attributes with
+#   the same syntax. Compiler warnings are used to detect supported
+#   attributes as unsupported ones are ignored by default so quieting
+#   warnings when using this macro will yield false positives.
+#
+#   The ATTRIBUTE parameter holds the name of the attribute to be checked.
+#
+#   If ATTRIBUTE is supported define HAVE_VAR_ATTRIBUTE_<ATTRIBUTE>.
+#
+#   The macro caches its result in the ax_cv_have_var_attribute_<attribute>
+#   variable.
+#
+#   The macro currently supports the following variable attributes:
+#
+#    aligned
+#    cleanup
+#    common
+#    nocommon
+#    deprecated
+#    mode
+#    packed
+#    tls_model
+#    unused
+#    used
+#    vector_size
+#    weak
+#    dllimport
+#    dllexport
+#    init_priority
+#
+#   Unsupported variable attributes will be tested against a global integer
+#   variable and without any arguments given to the attribute itself; the
+#   result of this check might be wrong or meaningless so use with care.
+#
+# LICENSE
+#
+#   Copyright (c) 2013 Gabriele Svelto <gabriele.svelto@gmail.com>
+#
+#   Copying and distribution of this file, with or without modification, are
+#   permitted in any medium without royalty provided the copyright notice
+#   and this notice are preserved.  This file is offered as-is, without any
+#   warranty.
+
+#serial 5
+
+AC_DEFUN([AX_GCC_VAR_ATTRIBUTE], [
+    AS_VAR_PUSHDEF([ac_var], [ax_cv_have_var_attribute_$1])
+
+    AC_CACHE_CHECK([for __attribute__(($1))], [ac_var], [
+        AC_LINK_IFELSE([AC_LANG_PROGRAM([
+            m4_case([$1],
+                [aligned], [
+                    int foo __attribute__(($1(32)));
+                ],
+                [cleanup], [
+                    int bar(int *t) { return *t; };
+                ],
+                [common], [
+                    int foo __attribute__(($1));
+                ],
+                [nocommon], [
+                    int foo __attribute__(($1));
+                ],
+                [deprecated], [
+                    int foo __attribute__(($1)) = 0;
+                ],
+                [mode], [
+                    long foo __attribute__(($1(word)));
+                ],
+                [packed], [
+                    struct bar {
+                        int baz __attribute__(($1));
+                    };
+                ],
+                [tls_model], [
+                    __thread int bar1 __attribute__(($1("global-dynamic")));
+                    __thread int bar2 __attribute__(($1("local-dynamic")));
+                    __thread int bar3 __attribute__(($1("initial-exec")));
+                    __thread int bar4 __attribute__(($1("local-exec")));
+                ],
+                [unused], [
+                    int foo __attribute__(($1));
+                ],
+                [used], [
+                    int foo __attribute__(($1));
+                ],
+                [vector_size], [
+                    int foo __attribute__(($1(16)));
+                ],
+                [weak], [
+                    int foo __attribute__(($1));
+                ],
+                [dllimport], [
+                    int foo __attribute__(($1));
+                ],
+                [dllexport], [
+                    int foo __attribute__(($1));
+                ],
+                [init_priority], [
+                    struct bar { bar() {} ~bar() {} };
+                    bar b __attribute__(($1(65535/2)));
+                ],
+                [
+                 m4_warn([syntax], [Unsupported attribute $1, the test may fail])
+                 int foo __attribute__(($1));
+                ]
+            )], [
+            m4_case([$1],
+                [cleanup], [
+                    int foo __attribute__(($1(bar))) = 0;
+                    foo = foo + 1;
+                ],
+                []
+            )])
+            ],
+            dnl GCC doesn't exit with an error if an unknown attribute is
+            dnl provided but only outputs a warning, so accept the attribute
+            dnl only if no warning were issued.
+            [AS_IF([test -s conftest.err],
+                [AS_VAR_SET([ac_var], [no])],
+                [AS_VAR_SET([ac_var], [yes])])],
+            [AS_VAR_SET([ac_var], [no])])
+    ])
+
+    AS_IF([test yes = AS_VAR_GET([ac_var])],
+        [AC_DEFINE_UNQUOTED(AS_TR_CPP(HAVE_VAR_ATTRIBUTE_$1), 1,
+            [Define to 1 if the system has the `$1' variable attribute])], [])
+
+    AS_VAR_POPDEF([ac_var])
+])

--- a/src/flexdef.h
+++ b/src/flexdef.h
@@ -97,6 +97,111 @@
 #define DEFAULT_CSIZE 128
 #endif
 
+/*
+    GCC attribute related macros
+*/
+
+ /* function attributes */
+
+#ifndef FLEX_ATTRIBUTE_FUNC_ALLOC_SIZE
+#ifdef HAVE_FUNC_ATTRIBUTE_ALLOC_SIZE
+#define FLEX_ATTRIBUTE_FUNC_ALLOC_SIZE(i_arg)    __attribute__((alloc_size(i_arg)))
+#else
+#define FLEX_ATTRIBUTE_FUNC_ALLOC_SIZE(i_arg)
+#endif
+#endif
+
+#ifndef FLEX_ATTRIBUTE_FUNC_ALWAYS_INLINE
+#ifdef HAVE_FUNC_ATTRIBUTE_ALWAYS_INLINE
+#define FLEX_ATTRIBUTE_FUNC_ALWAYS_INLINE       __attribute__((always_inline))
+#else
+#define FLEX_ATTRIBUTE_FUNC_ALWAYS_INLINE
+#endif
+#endif
+
+#ifndef FLEX_ATTRIBUTE_FUNC_DEPRECATED
+#ifdef HAVE_FUNC_ATTRIBUTE_DEPRECATED
+#define FLEX_ATTRIBUTE_FUNC_DEPRECATED(msg)     __attribute__((deprecated((msg))))
+#else
+#define FLEX_ATTRIBUTE_FUNC_DEPRECATED(msg)
+#endif
+#endif
+
+#ifndef FLEX_ATTRIBUTE_FUNC_FORMAT_PRINTF
+#ifdef HAVE_FUNC_ATTRIBUTE_FORMAT
+#define FLEX_ATTRIBUTE_FUNC_FORMAT_PRINTF(i_fmt,i_dots)    \
+                    __attribute__((format(printf, i_fmt, i_dots)))
+#else
+#define FLEX_ATTRIBUTE_FUNC_FORMAT_PRINTF(i_fmt,i_dots)
+#endif
+#endif
+
+#ifndef FLEX_ATTRIBUTE_FUNC_FORMAT_ARG
+#ifdef HAVE_FUNC_ATTRIBUTE_FORMAT_ARG
+#define FLEX_ATTRIBUTE_FUNC_FORMAT_ARG(i_fmt)      __attribute__((format_arg(i_fmt)))
+#else
+#define FLEX_ATTRIBUTE_FUNC_FORMAT_ARG(i_fmt)
+#endif
+#endif
+
+#ifndef FLEX_ATTRIBUTE_FUNC_GNU_INLINE
+#ifdef HAVE_FUNC_ATTRIBUTE_GNU_INLINE
+#define FLEX_ATTRIBUTE_FUNC_GNU_INLINE      __attribute__((gnu_inline))
+#else
+#define FLEX_ATTRIBUTE_FUNC_GNU_INLINE
+#endif
+#endif
+
+#ifndef FLEX_ATTRIBUTE_FUNC_MALLOC
+#ifdef HAVE_FUNC_ATTRIBUTE_MALLOC
+#define FLEX_ATTRIBUTE_FUNC_MALLOC          __attribute__((malloc))
+#else
+#define FLEX_ATTRIBUTE_FUNC_MALLOC
+#endif
+#endif
+
+#ifndef FLEX_ATTRIBUTE_FUNC_NONNULL
+#ifdef HAVE_FUNC_ATTRIBUTE_NONNULL
+#define FLEX_ATTRIBUTE_FUNC_NONNULL(i_arg) __attribute__((nonnull(i_arg)))
+#else
+#define FLEX_ATTRIBUTE_FUNC_NONNULL(i_arg)
+#endif
+#endif
+
+#ifndef FLEX_ATTRIBUTE_FUNC_NORETURN
+#ifdef HAVE_FUNC_ATTRIBUTE_NORETURN
+#define FLEX_ATTRIBUTE_FUNC_NORETURN        __attribute__((noreturn))
+#else
+#define FLEX_ATTRIBUTE_FUNC_NORETURN
+#endif
+#endif
+
+#ifndef FLEX_ATTRIBUTE_FUNC_UNUSED
+#ifdef HAVE_FUNC_ATTRIBUTE_UNUSED
+#define FLEX_ATTRIBUTE_FUNC_UNUSED          __attribute__((unused))
+#else
+#define FLEX_ATTRIBUTE_FUNC_UNUSED
+#endif
+#endif
+
+ /* variable attributes */
+#ifndef FLEX_ATTRIBUTE_VAR_DEPRECATED
+#ifdef HAVE_VAR_ATTRIBUTE_DEPRECATED
+#define FLEX_ATTRIBUTE_VAR_DEPRECATED       __attribute__((deprecated))
+#else
+#define FLEX_ATTRIBUTE_VAR_DEPRECATED
+#endif
+#endif
+
+#ifndef FLEX_ATTRIBUTE_VAR_UNUSED
+#ifdef HAVE_VAR_ATTRIBUTE_UNUSED
+#define FLEX_ATTRIBUTE_VAR_UNUSED           __attribute__((unused))
+#else
+#define FLEX_ATTRIBUTE_VAR_UNUSED
+#endif
+#endif
+
+
 /* Maximum line length we'll have to deal with. */
 #define MAXLINE 2048
 

--- a/src/flexdef.h
+++ b/src/flexdef.h
@@ -1008,8 +1008,11 @@ extern void skelout(void);
 extern void transition_struct_out(int, int);
 
 /* Only needed when using certain broken versions of bison to build parse.c. */
-extern void *yy_flex_xmalloc(int);
-
+extern void *yy_flex_xmalloc(int)
+FLEX_ATTRIBUTE_FUNC_MALLOC
+FLEX_ATTRIBUTE_FUNC_ALLOC_SIZE(1)
+FLEX_ATTRIBUTE_FUNC_DEPRECATED("Deprecated since flex 2.6.4. To be obsoleted in flex 3.0.0")
+;
 
 /* from file nfa.c */
 

--- a/src/flexdef.h
+++ b/src/flexdef.h
@@ -948,18 +948,10 @@ extern void flexfatal(const char *);
 #endif /* ! HAVE_DECL___func__ */
 
 /* Report an error message formatted  */
-extern void lerr(const char *, ...)
-#if defined(__GNUC__) && __GNUC__ >= 3
-    __attribute__((__format__(__printf__, 1, 2)))
-#endif
-;
+extern void lerr(const char *, ...) FLEX_ATTRIBUTE_FUNC_FORMAT_PRINTF(1,2);
 
 /* Like lerr, but also exit after displaying message. */
-extern void lerr_fatal(const char *, ...)
-#if defined(__GNUC__) && __GNUC__ >= 3
-    __attribute__((__format__(__printf__, 1, 2)))
-#endif
-;
+extern void lerr_fatal(const char *, ...) FLEX_ATTRIBUTE_FUNC_FORMAT_PRINTF(1,2);
 
 /* Spit out a "#line" statement. */
 extern void line_directive_out(FILE *, int);

--- a/src/flexdef.h
+++ b/src/flexdef.h
@@ -737,8 +737,16 @@ extern int sectnum, nummt, hshcol, dfaeql, numeps, eps2, num_reallocs;
 extern int tmpuses, totnst, peakpairs, numuniq, numdup, hshsave;
 extern int num_backing_up, bol_needed;
 
-void   *allocate_array(int, size_t);
-void   *reallocate_array(void *, int, size_t);
+void   *allocate_array(int, size_t)
+FLEX_ATTRIBUTE_FUNC_MALLOC
+FLEX_ATTRIBUTE_FUNC_ALLOC_SIZE(1)
+FLEX_ATTRIBUTE_FUNC_ALLOC_SIZE(2);
+
+void   *reallocate_array(void *, int, size_t)
+FLEX_ATTRIBUTE_FUNC_MALLOC
+FLEX_ATTRIBUTE_FUNC_NONNULL(1)
+FLEX_ATTRIBUTE_FUNC_ALLOC_SIZE(2)
+FLEX_ATTRIBUTE_FUNC_ALLOC_SIZE(3);
 
 #define allocate_integer_array(size) \
 	allocate_array(size, sizeof(int))

--- a/src/flexdef.h
+++ b/src/flexdef.h
@@ -914,7 +914,7 @@ extern int intcmp(const void *, const void *);
 extern void check_char(int c);
 
 /* Replace upper-case letter to lower-case. */
-extern unsigned char clower(int);
+extern unsigned char clower(int) FLEX_ATTRIBUTE_FUNC_UNUSED;
 
 /* strdup() that fails fatally on allocation failures. */
 extern char *xstrdup(const char *);
@@ -989,7 +989,8 @@ extern void out_dec(const char *, int);
 extern void out_dec2(const char *, int, int);
 extern void out_hex(const char *, unsigned int);
 extern void out_str(const char *, const char *);
-extern void out_str3(const char *, const char *, const char *, const char *);
+extern void out_str3(const char *, const char *, const char *, const char *)
+    FLEX_ATTRIBUTE_FUNC_UNUSED;
 extern void out_str_dec(const char *, const char *, int);
 extern void outc(int);
 extern void outn(const char *);

--- a/src/flexdef.h
+++ b/src/flexdef.h
@@ -1020,11 +1020,15 @@ extern void skelout(void);
 /* Output a yy_trans_info structure. */
 extern void transition_struct_out(int, int);
 
+#if FLEX_CHECK_VERSION(3,0,0)
+#warning Remove function 'yy_flex_xmalloc' obsoleted from version 3.0.0 onwards.
+#else
 /* Only needed when using certain broken versions of bison to build parse.c. */
 extern void *yy_flex_xmalloc(int)
 FLEX_ATTRIBUTE_FUNC_MALLOC
 FLEX_ATTRIBUTE_FUNC_ALLOC_SIZE(1)
-FLEX_ATTRIBUTE_FUNC_DEPRECATED("Deprecated since flex 2.6.4. To be obsoleted in flex 3.0.0")
+FLEX_ATTRIBUTE_FUNC_DEPRECATED("Deprecated since flex 2.6.4. To be obsoleted in flex 3.0.0.")
+#endif
 ;
 
 /* from file nfa.c */

--- a/src/flexdef.h
+++ b/src/flexdef.h
@@ -39,6 +39,19 @@
 #include <config.h>
 #endif
 
+
+/*  check if the current version is greater than or equal to major.minor.subminor */
+#if defined FLEX_VERSION_MAJOR && \
+	defined FLEX_VERSION_MINOR && \
+	defined FLEX_VERSION_SUBMINOR
+#define FLEX_CHECK_VERSION(major,minor,subminor) \
+	(FLEX_VERSION_MAJOR > (major) || \
+	(FLEX_VERSION_MAJOR == (major) && FLEX_VERSION_MINOR > (minor)) || \
+	(FLEX_VERSION_MAJOR == (major) && FLEX_VERSION_MINOR == (minor) && FLEX_VERSION_SUBMINOR >= (subminor)))
+#else
+#error Define FLEX_VERSION_MAJOR, FLEX_VERSION_MINOR and FLEX_VERSION_SUBMINOR (usually in config.h)
+#endif
+
 #include <stdio.h>
 #include <stdlib.h>
 #include <stdarg.h>

--- a/src/misc.c
+++ b/src/misc.c
@@ -840,7 +840,9 @@ void transition_struct_out (int element_v, int element_n)
 	}
 }
 
-
+#if FLEX_CHECK_VERSION(3,0,0)
+#warning Remove function 'yy_flex_xmalloc' obsoleted from version 3.0.0 onwards.
+#else
 /* The following is only needed when building flex's parser using certain
  * broken versions of bison.
  *
@@ -857,7 +859,7 @@ void   *yy_flex_xmalloc (int size)
 
 	return result;
 }
-
+#endif
 
 /* Remove all '\n' and '\r' characters, if any, from the end of str.
  * str can be any null-terminated string, or NULL.

--- a/src/scanopt.h
+++ b/src/scanopt.h
@@ -97,7 +97,8 @@ extern  "C" {
  *   usage    - Text to be prepended to option list. May be NULL.
  * Return:  Always returns 0 (zero).
  */
-	int scanopt_usage (scanopt_t * scanner, FILE * fp, const char *usage);
+	int scanopt_usage (scanopt_t * scanner, FILE * fp, const char *usage)
+	FLEX_ATTRIBUTE_FUNC_UNUSED;
 #endif
 
 /* Scans command-line options in argv[].


### PR DESCRIPTION
As promised here a package providing features for deprecating and obsoleting functions (plus more). It effectively relies on `__attribute__`s for functions (and variables).

1. add m4 macro templates (from the autoconf-archive) for checking function and variable `__attribute__`s and have `autotools` process them
2. add macro definitions `FLEX_ATTRIBUTE_FUNCTION_...` and `FLEX_ATTRIBUTE_VAR_...` to `flexdef.h`
3. sample application to label functions
4. example of how to deprecate a function (here: `yy_flex_xmalloc`). Suggested messages and flex version number can certainly be adjusted.

With this it is easy to add new attributes to the system.