### PR TITLE
add line number to message in yy_fatal_error

### DIFF
--- a/src/flex.skl
+++ b/src/flex.skl
@@ -2478,7 +2478,13 @@ static void yynoreturn yy_fatal_error YYFARGS1(const char*, msg)
 {
 	M4_YY_DECL_GUTS_VAR();
 	M4_YY_NOOP_GUTS_VAR();
+m4_ifdef( [[M4_YY_USE_LINENO]],
+[[
+	fprintf( stderr, "fatal error in line %d: %s\n", yylineno, msg );
+]],
+[[
 	fprintf( stderr, "%s\n", msg );
+]])
 	exit( YY_EXIT_FAILURE );
 }
 %endif


### PR DESCRIPTION
As requested in #67. 
The fatal error message is enhanced by the line number derived from yylineno, but only if the scanner is generated with the option `yylineno` (for both reentrant and non-reentrant scanners).
CAVEAT: The line number info might be misleading if `yylineno` is incorrect.  