### PR TITLE
build: let "make mostlyclean" delete stage1scan.c.

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -92,7 +92,9 @@ EXTRA_DIST = \
 	mkskel.sh \
 	gettext.h
 
-CLEANFILES = stage1scan.c stage1flex$(EXEEXT)
+MOSTLYCLEANFILES = stage1scan.c
+
+CLEANFILES = stage1flex$(EXEEXT)
 
 MAINTAINERCLEANFILES = skel.c
 


### PR DESCRIPTION
(Split from PR #321)

The argument is that it's easy to regenerate stage1scan.c comparing to
the stage 1 flex program, which takes time to rebuild.