### PR TITLE
scanner: Re-add 'bool' fallback definition.

### DIFF
--- a/src/flexdef.h
+++ b/src/flexdef.h
@@ -68,7 +68,19 @@
 #include <sys/stat.h>
 /* Required: wait() in <sys/wait.h> */
 #include <sys/wait.h>
+#ifdef HAVE_STDBOOL_H
 #include <stdbool.h>
+#else
+# ifndef __cplusplus
+#  ifdef HAVE__BOOL
+#   define bool _Bool
+#  else
+#   define bool int
+#  endif
+# endif
+# define false 0
+# define true 1
+#endif
 #include <stdarg.h>
 /* Required: regcomp(), regexec() and regerror() in <regex.h> */
 #include <regex.h>


### PR DESCRIPTION
(Split from PR #321)

The fallback definition of 'bool' was deleted in
3efb40df0ec5cddf0cb63a7900eb88258c478514, and it was a bad idea to
require C99 stdbool.h for builders.