### PR TITLE
build: Deterministic scan.c and bootstrap byte comparison check

### DIFF
--- a/src/.gitignore
+++ b/src/.gitignore
@@ -10,8 +10,10 @@ libfl.pc
 parse.c
 parse.h
 scan.c
-stage1scan.[cl]
+stage1scan.c
 stage1flex
+stage2compare
+stage2scan.c
 
 # for MSWindows
 

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -51,7 +51,11 @@ flex_SOURCES = \
 nodist_flex_SOURCES = \
 	$(SKELINCLUDES)
 
+if ENABLE_BOOTSTRAP
 nodist_flex_SOURCES += stage1scan.c
+else
+flex_SOURCES += scan.l
+endif
 
 flex_CFLAGS = $(AM_CFLAGS) $(WARNINGFLAGS)
 
@@ -126,18 +130,19 @@ go-flex.h: go-flex.skl mkskel.sh
 	$(SHELL) $(srcdir)/chkskel.sh $@.tmp
 	mv -f $@.tmp $@
 
-if ENABLE_BOOTSTRAP
+# The input and output file names are fixed for deterministic scanner
+# generation. If scan.l is not modified by builders, stage1scan.c should
+# be bit-identical to the scan.c pregenerated on release.
 stage1scan.c: scan.l stage1flex$(EXEEXT)
-	./stage1flex$(EXEEXT) $(AM_LFLAGS) $(LFLAGS) -o $@ $(srcdir)/scan.l
-else
-stage1scan.c: scan.c
-	sed 's|^\(#line .*\)"'`printf %s $< | sed 's|[][\\\\.*]|\\\\&|g'`'"|\1"$@"|g' $< > $@
-endif
+	( cd $(srcdir) && $(abs_builddir)/stage1flex$(EXEEXT) \
+	  $(AM_LFLAGS) $(LFLAGS) -o scan.c -t scan.l ) >$@ || \
+	{ s=$$?; rm -f $@; exit $$s; }
 
 dist-hook: scan.l flex$(EXEEXT)
 	chmod u+w $(distdir) && \
 	chmod u+w $(distdir)/scan.c && \
-	./flex$(EXEEXT) -o scan.c $< && \
+	( cd $(srcdir) && $(abs_builddir)/flex$(EXEEXT) \
+	  -o scan.c -t scan.l ) >scan.c && \
 	mv -f scan.c $(distdir)
 
 # make needs to be told to make inclusions so that parallelized runs will
@@ -154,6 +159,7 @@ flex-yylex.$(OBJEXT): parse.h
 
 stage1flex-scan.$(OBJEXT): parse.h
 flex-stage1scan.$(OBJEXT): parse.h
+flex-scan.$(OBJEXT): parse.h
 
 # Run GNU indent on sources. Don't run this unless all the sources compile cleanly.
 #

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -8,6 +8,9 @@ m4 = @M4@
 bin_PROGRAMS = flex
 if ENABLE_BOOTSTRAP
 noinst_PROGRAMS = stage1flex
+if !CROSS
+noinst_DATA = stage2compare
+endif
 endif
 
 if ENABLE_LIBFL
@@ -106,7 +109,9 @@ EXTRA_DIST = \
 
 MOSTLYCLEANFILES = \
 	$(SKELINCLUDES) \
-	stage1scan.c
+	stage1scan.c \
+	stage2scan.c \
+	stage2compare
 
 CLEANFILES = stage1flex$(EXEEXT)
 
@@ -137,6 +142,24 @@ stage1scan.c: scan.l stage1flex$(EXEEXT)
 	( cd $(srcdir) && $(abs_builddir)/stage1flex$(EXEEXT) \
 	  $(AM_LFLAGS) $(LFLAGS) -o scan.c -t scan.l ) >$@ || \
 	{ s=$$?; rm -f $@; exit $$s; }
+
+# Unlike stage1scan.c, we leave stage2scan.c intact when the generation
+# fails. This allow users to examine generation errors.
+stage2scan.c: scan.l flex$(EXEEXT) stage1scan.c
+	( cd $(srcdir) && $(abs_builddir)/flex$(EXEEXT) \
+	  $(AM_LFLAGS) $(LFLAGS) -o scan.c -t scan.l ) >$@
+
+stage2compare: stage1scan.c
+	@rm -f stage2scan.c; \
+	$(MAKE) $(AM_MAKEFLAGS) stage2scan.c; \
+	echo Comparing stage1scan.c and stage2scan.c; \
+	cmp stage1scan.c stage2scan.c || { \
+	  s=$$?; \
+	  echo "Bootstrap comparison failure!"; \
+	  exit $$s; \
+	}; \
+	echo Comparison successful.; \
+	echo success >$@
 
 dist-hook: scan.l flex$(EXEEXT)
 	chmod u+w $(distdir) && \


### PR DESCRIPTION
(Split from PR #321)

Change the generating rules of scan.c (in dist-hook) and stage1scan.c
so that the source and output file names in #line directives are fixed.
This would allow the scanner results be comparable to each other.

Also in --disable-bootstrap build, the flex binary will now be built
with scan.c directly - no more sedding.