### PR TITLE
scanner: consistently +2 to realloc size for EOB

### DIFF
--- a/src/c99-flex.skl
+++ b/src/c99-flex.skl
@@ -1153,7 +1153,7 @@ m4_ifdef( [[M4_MODE_USES_REJECT]],
 	}
 	if ((yyscanner->yy_n_chars + number_to_move) > yyscanner->yy_buffer_stack[yyscanner->yy_buffer_stack_top]->yy_buf_size) {
 		/* Extend the array by 50%, plus the number we really need. */
-		int new_size = yyscanner->yy_n_chars + number_to_move + (yyscanner->yy_n_chars >> 1);
+		int new_size = yyscanner->yy_n_chars + number_to_move + (yyscanner->yy_n_chars >> 1) + 2;
 		yyscanner->yy_buffer_stack[yyscanner->yy_buffer_stack_top]->yy_ch_buf = (char *) yyrealloc(
 			(void *) yyscanner->yy_buffer_stack[yyscanner->yy_buffer_stack_top]->yy_ch_buf, (size_t) new_size, yyscanner );
 		if ( yyscanner->yy_buffer_stack[yyscanner->yy_buffer_stack_top]->yy_ch_buf == NULL ) {

--- a/src/cpp-flex.skl
+++ b/src/cpp-flex.skl
@@ -2534,7 +2534,7 @@ m4_ifdef( [[M4_MODE_USES_REJECT]],
 	}
 	if ((YY_G(yy_n_chars) + number_to_move) > YY_CURRENT_BUFFER_LVALUE->yy_buf_size) {
 		/* Extend the array by 50%, plus the number we really need. */
-		int new_size = YY_G(yy_n_chars) + number_to_move + (YY_G(yy_n_chars) >> 1);
+		int new_size = YY_G(yy_n_chars) + number_to_move + (YY_G(yy_n_chars) >> 1) + 2;
 		YY_CURRENT_BUFFER_LVALUE->yy_ch_buf = (char *) yyrealloc(
 			(void *) YY_CURRENT_BUFFER_LVALUE->yy_ch_buf, (yy_size_t) new_size M4_YY_CALL_LAST_ARG );
 		if ( ! YY_CURRENT_BUFFER_LVALUE->yy_ch_buf ) {

--- a/src/go-flex.skl
+++ b/src/go-flex.skl
@@ -1060,7 +1060,7 @@ m4_ifdef([[M4_MODE_USES_REJECT]],
 	}
 	if ((yyscanner->yyNChars + numberToMove) > yyscanner->yyBufferStack[yyscanner->yyBufferStackTop]->yyInputBufSize) {
 		/* Extend the array by 50%, plus the number we really need. */
-		int newSize = yyscanner->yyNChars + numberToMove + (yyscanner->yyNChars >> 1);
+		int newSize = yyscanner->yyNChars + numberToMove + (yyscanner->yyNChars >> 1) + 2;
 		yyscanner->yyBufferStack[yyscanner->yyBufferStackTop]->yyChBuf = (char *) yyrealloc(
 			(void *) yyscanner->yyBufferStack[yyscanner->yyBufferStackTop]->yyChBuf, (size_t) newSize, yyscanner);
 		if (yyscanner->yyBufferStack[yyscanner->yyBufferStackTop]->yyChBuf == NULL) {


### PR DESCRIPTION
We expect to have room for 2 EOB chars, but in this particular realloc
path this only works because yy_n_chars tends to be large enough for
1.5x its value to have room for our 2 EOB chars.

That said, clang-6's static analyzer does produce a warning about this
("Use of zero-allocated memory", meaning realloc with size=0) because it
goes by the assumption that yy_n_chars and number_to_move could be 0.

While this is somewhat bogus, it does make sense to just put the "+ 2"
here and be done with it.  AFAICS, this is the correct thing to do here
after all.

Signed-off-by: David Lamparter <equinox@diac24.net>