### PR TITLE
remove hard-wired bison lookup, check for "GNU Bison" in $YACC's version output instead

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -42,11 +42,18 @@ AC_SUBST(SHARED_VERSION_INFO)
 AM_GNU_GETTEXT([external])
 AM_GNU_GETTEXT_VERSION([0.19.7])
 AC_PROG_YACC
-AS_IF([test "$YACC" != 'bison -y'], [
-	YACC="\${top_srcdir}/build-aux/missing bison -y"
-	AC_MSG_NOTICE(no bison program found: only required for maintainers)
-	])
-AM_CONDITIONAL([HAVE_BISON], [test "$YACC" = 'bison -y'])
+  # Extract the first word of "$YACC", so it can be a program name with args.
+  set dummy $YACC; ac_word=$2
+  AC_MSG_CHECKING(whether $ac_word is GNU Bison)
+  AS_IF([test -n "$YACC" && $YACC --version 2>&1 | $GREP "GNU Bison" >/dev/null],
+    [AC_MSG_RESULT(yes)
+  	use_gnu_bison=1],
+    [AC_MSG_RESULT(no)
+  	AC_MSG_WARN($YACC does not appear to be GNU Bison; required for maintainers)
+  	use_gnu_bison=0
+  	YACC="\${top_srcdir}/build-aux/missing bison"
+    ])
+AM_CONDITIONAL([HAVE_BISON], [test $use_gnu_bison -eq 1])
 AM_PROG_LEX
 AC_PROG_CC
 AX_PROG_CC_FOR_BUILD
@@ -109,12 +116,17 @@ AC_CACHE_CHECK([for m4 that supports -P], [ac_cv_path_M4],
 AC_SUBST([M4], [$ac_cv_path_M4])
 AC_DEFINE_UNQUOTED([M4], ["$M4"], [Define to the m4 executable name.])
 
-AC_PATH_PROG([INDENT], indent, [\${top_srcdir}/build-aux/missing indent])
-  AC_MSG_CHECKING(if $INDENT is GNU indent)
-  AS_IF([$INDENT --version 2>/dev/null | head -n 1 | grep "GNU indent" >/dev/null],
-    [AC_MSG_RESULT(yes)],
-    [AC_MSG_RESULT(no)
-     AC_MSG_WARN($INDENT does not appear to be GNU indent; 'make indent' may not function properly)
+AC_PATH_PROG([INDENT], indent)
+  AS_IF([test -n "$INDENT"], [
+    # Extract the first word of "$INDENT", so it can be a program name with args.
+    set dummy $INDENT; ac_word=$2
+    AC_MSG_CHECKING(whether $ac_word is GNU indent)
+    AS_IF([$INDENT --version 2>/dev/null | $GREP "GNU indent" >/dev/null],
+      [AC_MSG_RESULT(yes)],
+      [AC_MSG_RESULT(no)
+       AC_MSG_WARN($INDENT does not appear to be GNU indent; 'make indent' may not function properly)
+       INDENT="\${top_srcdir}/build-aux/missing indent"
+      ])
     ])
 
 # checks for headers

--- a/configure.ac
+++ b/configure.ac
@@ -42,9 +42,7 @@ AC_SUBST(SHARED_VERSION_INFO)
 AM_GNU_GETTEXT([external])
 AM_GNU_GETTEXT_VERSION([0.19.7])
 AC_PROG_YACC
-  # Extract the first word of "$YACC", so it can be a program name with args.
-  set dummy $YACC; ac_word=$2
-  AC_MSG_CHECKING(whether $ac_word is GNU Bison)
+  AC_MSG_CHECKING(whether $YACC is GNU Bison)
   AS_IF([test -n "$YACC" && $YACC --version 2>&1 | $GREP "GNU Bison" >/dev/null],
     [AC_MSG_RESULT(yes)
   	use_gnu_bison=1],
@@ -118,9 +116,7 @@ AC_DEFINE_UNQUOTED([M4], ["$M4"], [Define to the m4 executable name.])
 
 AC_PATH_PROG([INDENT], indent)
   AS_IF([test -n "$INDENT"], [
-    # Extract the first word of "$INDENT", so it can be a program name with args.
-    set dummy $INDENT; ac_word=$2
-    AC_MSG_CHECKING(whether $ac_word is GNU indent)
+    AC_MSG_CHECKING(whether $INDENT is GNU indent)
     AS_IF([$INDENT --version 2>/dev/null | $GREP "GNU indent" >/dev/null],
       [AC_MSG_RESULT(yes)],
       [AC_MSG_RESULT(no)


### PR DESCRIPTION
… fixes #386 

additional:
* don't check for GNU indent if indent-check already found no indent
* use common wording to check "*whether* $BINARY is GNU stuff"

You may pass a full path and/or a different name for the Bison executable and/or additional options for the bison executable now.

Tested with Cygwin and Trisquel.
