### PR TITLE
autogen.sh fixes

### DIFF
--- a/autogen.sh
+++ b/autogen.sh
@@ -34,8 +34,8 @@ if test "$?" -ne 0; then
    LIBTOOLIZE=glibtoolize
    $LIBTOOLIZE --version 2>/dev/null
    if test "$?" -ne 0; then
-      echo "error: libtoolize not working, re-run with LIBTOOLIZE=/path/to/libtoolize"
-      echo "       LIBTOOLIZE is currently \"$LIBTOOLIZE_ORIG\""
+      echo "error: libtoolize not working, re-run with LIBTOOLIZE=/path/to/libtoolize">&2
+      echo "       LIBTOOLIZE is currently \"$LIBTOOLIZE_ORIG\"">&2
       exit 1
    fi
 fi
@@ -47,5 +47,5 @@ fi
 if ! test -f ChangeLog; then
    touch ChangeLog
 fi
-"$LIBTOOLIZE" --install --force
+$LIBTOOLIZE --install --force
 autoreconf --install --force

--- a/autogen.sh
+++ b/autogen.sh
@@ -25,19 +25,20 @@
 # and procede with the "normal" build procedures.
 
 # use LIBTOOLIZE, if set
-LIBTOOLIZE_ORIG="$LIBTOOLIZE";
-if test "x$LIBTOOLIZE" = "x"; then LIBTOOLIZE=libtoolize; fi
+if test "x$LIBTOOLIZE" = "x"; then
+   for ac_prog in libtoolize glibtoolize; do
+      if $ac_prog --version >/dev/null 2>&1; then
+         LIBTOOLIZE=$ac_prog
+         break
+      fi
+   done
+fi
 
 # test libtoolize
-$LIBTOOLIZE --version 2>/dev/null
-if test "$?" -ne 0; then
-   LIBTOOLIZE=glibtoolize
-   $LIBTOOLIZE --version 2>/dev/null
-   if test "$?" -ne 0; then
-      echo "error: libtoolize not working, re-run with LIBTOOLIZE=/path/to/libtoolize">&2
-      echo "       LIBTOOLIZE is currently \"$LIBTOOLIZE_ORIG\"">&2
-      exit 1
-   fi
+if test "x$LIBTOOLIZE" = "x" || ! $LIBTOOLIZE --version >/dev/null; then
+   echo "error: libtoolize not working, re-run with LIBTOOLIZE=/path/to/libtoolize">&2
+   echo "       LIBTOOLIZE is currently \"$LIBTOOLIZE\"">&2
+   exit 1
 fi
 
 #if we pretend to have a ChangeLog, then automake is less


### PR DESCRIPTION
* Don't silence `libtoolize --version` error messages. Silence the `--version` output instead.
* Let `autogen.sh` error message go to stderr.
* Don't quote the variable $LIBTOOLIZE when invoking it. This would allow invocation when `LIBTOOLIZE='a-future-libtoolize --gnu-compat';`.