### PR TITLE
yyinput() didn't correctly store yy_hold_char

### DIFF
--- a/src/flex.skl
+++ b/src/flex.skl
@@ -1893,8 +1893,8 @@ m4_ifdef( [[M4_YY_USE_LINENO]],
 		}
 
 	c = *(unsigned char *) YY_G(yy_c_buf_p);	/* cast for 8-bit char's */
-	*YY_G(yy_c_buf_p) = '\0';	/* preserve yytext */
 	YY_G(yy_hold_char) = *++YY_G(yy_c_buf_p);
+	*YY_G(yy_c_buf_p) = '\0';	/* preserve yytext */
 
 %% [19.0] update BOL and yylineno
 


### PR DESCRIPTION
This fixes issue https://github.com/westes/flex/issues/395.