### PR TITLE
Make documentation easyer to find

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,8 @@ flex is a tool for generating scanners: programs which recognize
 lexical patterns in text.
 
 The flex codebase is kept in
-[Git on GitHub.](https://github.com/westes/flex)
+[Git on GitHub](https://github.com/westes/flex) and documentation is
+published in [GitHub Pages](https://westes.github.io/flex/manual/).
 
 Use GitHub's [issues](https://github.com/westes/flex/issues) and
 [pull request](https://github.com/westes/flex) features to file bugs


### PR DESCRIPTION
Since there is no link to documentation published on [GitHub Pages](https://pages.github.com/), online documentation is hard to find.

In this pull request, i add the link inside the file `README.md` to make it appear on the repository first page.
I think that can permit to simply find documentation.