### PR TITLE
build: use AC_SYS_LARGEFILE in configure.ac

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -29,6 +29,7 @@ AC_PREREQ([2.60])
 AC_CONFIG_SRCDIR([src/scan.l])
 AC_CONFIG_AUX_DIR([build-aux])
 AC_USE_SYSTEM_EXTENSIONS
+AC_SYS_LARGEFILE
 LT_INIT
 AM_INIT_AUTOMAKE([1.15 -Wno-portability foreign std-options dist-lzip parallel-tests subdir-objects])
 AC_CONFIG_HEADER([src/config.h])


### PR DESCRIPTION
This enables LFS on those of 32-bit systems that do not enable it
by default.

As result, stat() call in src/main.c:check_options() will not fail
on filesystems with 64-bit inode numbers.