### PR TITLE
Add a link to documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ interest:
 * INSTALL - basic installation information.
 * ABOUT-NLS - description of internationalization support in flex.
 * COPYING - flex's copyright and license.
-* doc/ - user documentation.
+* doc/ - user documentation (also available [online](https://westes.github.io/flex/manual/)).
 * examples/ - containing examples of some possible flex scanners and a
               few other things. See the file examples/README for more
               details.


### PR DESCRIPTION
The online documentation is not linked from the README and so it is a bit hard to find. This commit adds the link to make it easier to discover.