### PR TITLE
Remove manual m4 search code. No more stat() dependency.

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -119,7 +119,7 @@ AC_PATH_PROG([INDENT], indent, [\${top_srcdir}/build-aux/missing indent])
 
 # checks for headers
 
-AC_CHECK_HEADERS([regex.h strings.h sys/stat.h sys/wait.h unistd.h], [],
+AC_CHECK_HEADERS([regex.h strings.h sys/wait.h unistd.h], [],
   [AC_MSG_ERROR(required header not found on your system)])
 
 AC_CHECK_HEADERS([inttypes.h libintl.h limits.h locale.h malloc.h netinet/in.h])

--- a/src/flexdef.h
+++ b/src/flexdef.h
@@ -64,8 +64,6 @@
 #ifdef HAVE_SYS_PARAMS_H
 #include <sys/params.h>
 #endif
-/* Required: stat() in <sys/stat.h> */
-#include <sys/stat.h>
 /* Required: wait() in <sys/wait.h> */
 #include <sys/wait.h>
 #include <stdbool.h>

--- a/src/main.c
+++ b/src/main.c
@@ -293,43 +293,7 @@ void initialize_output_filters(void)
 
 	output_chain = filter_create_int(NULL, filter_tee_header, env.headerfilename);
 	if ( !(m4 = getenv("M4"))) {
-		char *slash;
 		m4 = M4;
-		if ((slash = strrchr(M4, '/')) != NULL) {
-			m4 = slash+1;
-			/* break up $PATH */
-			const char *path = getenv("PATH");
-			if (!path) {
-				m4 = M4;
-			} else {
-				int m4_length = strlen(m4);
-				do {
-					size_t length = strlen(path);
-					struct stat sbuf;
-
-					const char *endOfDir = strchr(path, ':');
-					if (!endOfDir)
-						endOfDir = path+length;
-
-					{
-						char *m4_path = calloc(endOfDir-path + 1 + m4_length + 1, 1);
-
-						memcpy(m4_path, path, endOfDir-path);
-						m4_path[endOfDir-path] = '/';
-						memcpy(m4_path + (endOfDir-path) + 1, m4, m4_length + 1);
-						if (stat(m4_path, &sbuf) == 0 &&
-						    (S_ISREG(sbuf.st_mode)) && sbuf.st_mode & S_IXUSR) {
-							m4 = m4_path;
-							break;
-						}
-						free(m4_path);
-					}
-					path = endOfDir+1;
-				} while (path[0]);
-				if (!path[0])
-					m4 = M4;
-			}
-		}
 	}
 	filter_create_ext(output_chain, m4, "-P", 0);
 	filter_create_int(output_chain, filter_fix_linedirs, NULL);


### PR DESCRIPTION
This reverts commit c34590c4bf067d4e749e5298a8ce9f90072d6332
and all search code patches that followed it.

The execvp() would do the $PATH searching of m4 for flex. There's no
need to duplicate the effort.

Another reason for the removal is to remove dependency on stat()
system call, which would cause a problem in a 32-bit OS accessing a
filesystem with 64-bit inode number (see #413).
