### PR TITLE
scanner: Fix compiler confusion in yy_init_buffer()

### DIFF
--- a/src/c99-flex.skl
+++ b/src/c99-flex.skl
@@ -854,7 +854,7 @@ void yyrestart(FILE * input_file, yyscan_t yyscanner)
 			yy_create_buffer( yyscanner->yyin_r, YY_BUF_SIZE, yyscanner);
 	}
 
-	yy_init_buffer( yy_current_buffer(yyscanner), input_file, yyscanner);
+	yy_init_buffer( yyscanner->yy_buffer_stack[yyscanner->yy_buffer_stack_top], input_file, yyscanner);
 	yy_load_buffer_state( yyscanner );
 }
 

--- a/src/cpp-flex.skl
+++ b/src/cpp-flex.skl
@@ -2831,7 +2831,7 @@ void yyFlexLexer::yyrestart( std::istream& input_file )
 	        	yy_create_buffer( yyin, YY_BUF_SIZE M4_YY_CALL_LAST_ARG);
 	}
 
-	yy_init_buffer( yy_current_buffer(), input_file M4_YY_CALL_LAST_ARG);
+	yy_init_buffer( YY_CURRENT_BUFFER_LVALUE, input_file M4_YY_CALL_LAST_ARG);
 	yy_load_buffer_state( M4_YY_CALL_ONLY_ARG );
 }
 

--- a/src/go-flex.skl
+++ b/src/go-flex.skl
@@ -763,7 +763,7 @@ void yyrestart(FILE * input_file, FlexLexer *yyscanner)
 			yy_create_buffer(yyscanner->yyin, flexInputBufferSize, yyscanner);
 	}
 
-	yy_init_buffer(yy_current_buffer(yyscanner), input_file, yyscanner);
+	yy_init_buffer(yyscanner->yyBufferStack[yyscanner->yyBufferStackTop], input_file, yyscanner);
 	yy_load_buffer_state(yyscanner);
 }
 


### PR DESCRIPTION
When complied with 'gcc -O3', the yy_init_buffer call can confuse gcc,
thinking the 'b' pointer may be NULL. (gcc would warn that if
'-Wnull-dereference' is used). Fix the confusion by never pass a NULL
constant to the function.

Fixes: #377