### PR TITLE
optimize yy_get_next_buffer by switching to memcpy

### DIFF
--- a/src/flex.skl
+++ b/src/flex.skl
@@ -1609,8 +1609,7 @@ int yyFlexLexer::yy_get_next_buffer()
 	/* First move last chars to start of buffer. */
 	number_to_move = (int) (YY_G(yy_c_buf_p) - YY_G(yytext_ptr) - 1);
 
-	for ( i = 0; i < number_to_move; ++i )
-		*(dest++) = *(source++);
+	memcpy(dest,source,number_to_move);
 
 	if ( YY_CURRENT_BUFFER_LVALUE->yy_buffer_status == YY_BUFFER_EOF_PENDING )
 		/* don't do the read, it's not guaranteed to return an EOF,


### PR DESCRIPTION
based on https://lists.defectivebydesign.org/archive/html/help-flex/2013-01/msg00000.html