### PR TITLE
Constify local 'slash'

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -342,7 +342,7 @@ void check_options (void)
     /* Setup the filter chain. */
     output_chain = filter_create_int(NULL, filter_tee_header, headerfilename);
     if ( !(m4 = getenv("M4"))) {
-	    char *slash;
+	    const char *slash;
 		m4 = M4;
 		if ((slash = strrchr(M4, '/')) != NULL) {
 			m4 = slash+1;


### PR DESCRIPTION
slash is used for the return value of `strrchr` on M4, which is by default
a macro expanding to a string literal.

While `strrchr` returns a non-const `char *` on contract, we should not be
modifying the return value of it based on M4. Some versions of GCC will
in-fact warn about this, even though the return value isn't being mutated
right now.

This has the side-effect of making it clear that *slash should not be
mutated, whether it is currently or not.