### PR TITLE
Reset yy_at_bol in yyless() if yyleng is non-zero.

### DIFF
--- a/src/flex.skl
+++ b/src/flex.skl
@@ -471,6 +471,9 @@ m4_ifdef( [[M4_YY_NOT_IN_HEADER]],
 		YY_RESTORE_YY_MORE_OFFSET \
 		YY_G(yy_c_buf_p) = yy_cp = yy_bp + yyless_macro_arg - YY_MORE_ADJ; \
 		YY_DO_BEFORE_ACTION; /* set up yytext again */ \
+		if ( yyleng > 0 ) \
+			YY_CURRENT_BUFFER_LVALUE->yy_at_bol = \
+			    (yytext[yyleng - 1] == '\n'); \
 		} \
 	while ( 0 )
 #define unput(c) yyunput( c, YY_G(yytext_ptr) M4_YY_CALL_LAST_ARG )


### PR DESCRIPTION
Fixes a bug where calling yyless() to unput all the chars before a newline would not reset the beginning of line marker.  Otherwise, flex won't match rules that start with a caret (^) after calling yyless() in thise case.  AT&T lex behaves correctly.