### PR TITLE
Fix build on macOS by using GNU sed in mkskel.sh

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -55,6 +55,7 @@ AM_PROG_CC_C_O
 AC_PROG_LN_S
 AC_PROG_AWK
 AC_PROG_INSTALL
+AC_PROG_SED
 
 pkgconfigdir=${libdir}/pkgconfig
 AC_SUBST(pkgconfigdir)
@@ -116,6 +117,11 @@ AC_PATH_PROG([INDENT], indent, [\${top_srcdir}/build-aux/missing indent])
     [AC_MSG_RESULT(no)
      AC_MSG_WARN($INDENT does not appear to be GNU indent; 'make indent' may not function properly)
     ])
+AS_IF([$SED --version 2>/dev/null | head -n 1 | grep "GNU sed" >/dev/null],
+  [AC_MSG_RESULT(yes)],
+  [AC_MSG_RESULT(no)
+   AC_MSG_WARN($SED does not appear to be GNU sed; 'mkskel.sh' will not function properly)
+  ])
 
 # checks for headers
 

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -4,6 +4,7 @@ LIBS = @LIBS@
 pkgconfigdir = @pkgconfigdir@
 
 m4 = @M4@
+sed = @SED@
 
 bin_PROGRAMS = flex
 if ENABLE_BOOTSTRAP
@@ -97,7 +98,7 @@ CLEANFILES = stage1scan.c stage1flex$(EXEEXT)
 MAINTAINERCLEANFILES = skel.c
 
 skel.c: flex.skl mkskel.sh flexint_shared.h tables_shared.h tables_shared.c
-	$(SHELL) $(srcdir)/mkskel.sh $(srcdir) $(m4) $(VERSION) > $@.tmp
+	$(SHELL) $(srcdir)/mkskel.sh $(srcdir) $(m4) $(sed) $(VERSION) > $@.tmp
 	mv -f $@.tmp $@
 
 if ENABLE_BOOTSTRAP

--- a/src/mkskel.sh
+++ b/src/mkskel.sh
@@ -21,8 +21,8 @@
 #  WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
 #  PURPOSE.
 
-if test ! $# = 3; then
-   echo 'Usage: mkskel.sh srcdir m4 version' >&2
+if test ! $# = 4; then
+   echo 'Usage: mkskel.sh srcdir m4 sed version' >&2
    exit 1
 fi
 echo '/* File created from flex.skl via mkskel.sh */
@@ -32,19 +32,20 @@ echo '/* File created from flex.skl via mkskel.sh */
 const char *skel[] = {'
 srcdir=$1
 m4=$2
-VERSION=$3
+sed=$3
+VERSION=$4
 case $VERSION in
    *[!0-9.]*) echo 'Invalid version number' >&2; exit 1;;
 esac
 IFS=.
 set $VERSION
-sed 's/4_/a4_/g
+"$sed" 's/4_/a4_/g
 s/m4preproc_/m4_/g
 ' "$srcdir/flex.skl" |
 "$m4" -P -I "$srcdir" "-DFLEX_MAJOR_VERSION=$1" \
    "-DFLEX_MINOR_VERSION=$2" \
    "-DFLEX_SUBMINOR_VERSION=$3" |
-sed '/^%#/d
+"$sed" '/^%#/d
 s/m4_/m4preproc_/g
 s/a4_/4_/g
 s/[\\"]/\\&/g


### PR DESCRIPTION
The sed commandline used in mkskel.sh does not work correctly when using
the macos sed. Use the version of GNU sed found by configure instead to
generate a valid .c file.