### PR TITLE
Fix -Wundef warnings by using #ifdef instead of #if

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -172,6 +172,8 @@ AC_CHECK_FUNCS([dup2 memset regcomp strcasecmp strchr strdup strtol], [],
 # reallocarray - OpenBSD function. We have replacement if not available.
 AC_CHECK_FUNCS([pow setlocale reallocarr reallocarray])
 
+AC_CHECK_DECLS(__func__)
+
 AC_CONFIG_FILES(
 Makefile
 doc/Makefile

--- a/src/flexdef.h
+++ b/src/flexdef.h
@@ -822,7 +822,7 @@ extern void flexerror(const char *);
 extern void flexfatal(const char *);
 
 /* Report a fatal error with a pinpoint, and terminate */
-#if HAVE_DECL___FUNC__
+#ifdef HAVE_DECL___FUNC__
 #define flex_die(msg) \
     do{ \
         fprintf (stderr,\

--- a/src/misc.c
+++ b/src/misc.c
@@ -141,12 +141,12 @@ void add_action (const char *new_text)
 void   *allocate_array (int size, size_t element_size)
 {
 	void *new_array;
-#if HAVE_REALLOCARR
+#ifdef HAVE_REALLOCARR
 	new_array = NULL;
 	if (reallocarr(&new_array, (size_t) size, element_size))
 		flexfatal (_("memory allocation failed in allocate_array()"));
 #else
-# if HAVE_REALLOCARRAY
+# ifdef HAVE_REALLOCARRAY
 	new_array = reallocarray(NULL, (size_t) size, element_size);
 # else
 	/* Do manual overflow detection */
@@ -662,12 +662,12 @@ char   *readable_form (int c)
 void   *reallocate_array (void *array, int size, size_t element_size)
 {
 	void *new_array;
-#if HAVE_REALLOCARR
+#ifdef HAVE_REALLOCARR
 	new_array = array;
 	if (reallocarr(&new_array, (size_t) size, element_size))
 		flexfatal (_("attempt to increase array size failed"));
 #else
-# if HAVE_REALLOCARRAY
+# ifdef HAVE_REALLOCARRAY
 	new_array = reallocarray(array, (size_t) size, element_size);
 # else
 	/* Do manual overflow detection */


### PR DESCRIPTION
This also brings back the check for __func__ that was deleted in commit
9b41a091bcb2fb9bd2b6db79d06a0c976d1a5663