### PR TITLE
flex: Fix typo in noline option check

### DIFF
--- a/src/buf.c
+++ b/src/buf.c
@@ -95,7 +95,7 @@ struct Buf *buf_linedir (struct Buf *buf, const char* filename, int lineno)
     const char *src;
     size_t tsz;
 
-    if (gen_line_dirs)
+    if (!gen_line_dirs)
 	return buf;
 
     tsz = strlen("#line \"\"\n")                +   /* constant parts */


### PR DESCRIPTION
If we set --noline we should not print line directives.
But setting --noline means gen_line_dirs is false.

Signed-off-by: Oleksiy Obitotskyy <oobitots@cisco.com>