### PR TITLE
src/gen.c: Remove dead code from do_indent()

### DIFF
--- a/src/gen.c
+++ b/src/gen.c
@@ -89,11 +89,6 @@ void do_indent (void)
 		outc ('\t');
 		i -= 8;
 	}
-
-	while (i > 0) {
-		outc (' ');
-		--i;
-	}
 }
 
 


### PR DESCRIPTION
In `do_indent()`, since `i` is a multiple of 8 and is decremented by 8 `while (i >= 8)`, `while (i > 0)` is never true.