### PR TITLE
Emit code from the skeleton or skeleton macros.

### DIFF
--- a/src/buf.c
+++ b/src/buf.c
@@ -71,13 +71,41 @@ struct Buf *buf_print_strings(struct Buf * buf, FILE* out)
 struct Buf *buf_prints (struct Buf *buf, const char *fmt, const char *s)
 {
 	char   *t;
-        size_t tsz;
+    size_t tsz;
 
 	tsz = strlen(fmt) + strlen(s) + 1;
 	t = malloc(tsz);
 	if (!t)
 	    flexfatal (_("Allocation of buffer to print string failed"));
 	snprintf (t, tsz, fmt, s);
+	buf = buf_strappend (buf, t);
+	free(t);
+	return buf;
+}
+
+/* Append a "%s %s ..." formatted string to a string buffer */
+struct Buf *buf_printns (struct Buf *buf, const char *fmt, const int count, ...)
+{
+	char   *t;
+    size_t tsz;
+	va_list ap;
+	const char* s;
+	
+	va_start(ap, count);
+	tsz = strlen(fmt);
+	for(int i=0; i<count; ++i) {
+	    s = va_arg(ap, const char*);
+		tsz += strlen(s);
+	}
+	va_end(ap);
+	tsz += 1;
+	t = malloc(tsz);
+	if (!t)
+	    flexfatal (_("Allocation of buffer to print string failed"));
+	
+	va_start(ap, count);
+	vsnprintf (t, tsz, fmt, ap);
+	va_end(ap);
 	buf = buf_strappend (buf, t);
 	free(t);
 	return buf;

--- a/src/dfa.c
+++ b/src/dfa.c
@@ -517,27 +517,32 @@ void ntod (void)
 					    sizeof (flex_int32_t));
 		yynxt_curr = 0;
 
-		buf_prints (&yydmap_buf,
-			    "\t{YYTD_ID_NXT, (void**)&yy_nxt, sizeof(%s)},\n",
-			    long_align ? "flex_int32_t" : "flex_int16_t");
+		buf_printns (&yydmap_buf, "YYDMAP_ENTRY( %s, %s )", 2, 
+		        "YYTD_ID_NXT", "yy_nxt");
 
 		/* Unless -Ca, declare it "short" because it's a real
 		 * long-shot that that won't be large enough.
 		 */
 		if (gentables)
-			out_str_dec
-				("static const %s yy_nxt[][%d] =\n    {\n",
+		/*	out_str_dec
+				("static yyconst %s yy_nxt[][%d] =\n    {\n",
 				 long_align ? "flex_int32_t" : "flex_int16_t",
 				 num_full_table_rows);
+        */
+            out_str_dec("DEFINE_TABLE_2D(%s, %d)", "yy_nxt", num_full_table_rows);
 		else {
-			out_dec ("#undef YY_NXT_LOLEN\n#define YY_NXT_LOLEN (%d)\n", num_full_table_rows);
-			out_str ("static const %s *yy_nxt =0;\n",
+		/*	out_dec ("#undef YY_NXT_LOLEN\n#define YY_NXT_LOLEN (%d)\n", num_full_table_rows); */
+            out_dec ("RESET_NXT_LOLEN(%d)", num_full_table_rows);
+		/*	out_str ("static const %s *yy_nxt =0;\n",
 				 long_align ? "flex_int32_t" : "flex_int16_t");
+        */
+            out_str("DEFINE_TABLE_EMPTY( %s )", "yy_nxt");
 		}
 
 
 		if (gentables)
-			outn ("    {");
+		/*	outn ("    {"); */
+            outn ("INDENT BEGIN_ROW");
 
 		/* Generate 0 entries for state #0. */
 		for (i = 0; i < num_full_table_rows; ++i) {
@@ -547,7 +552,7 @@ void ntod (void)
 
 		dataflush ();
 		if (gentables)
-			outn ("    },\n");
+			outn ("INDENT END_ROW");
 	}
 
 	/* Create the first states. */
@@ -703,7 +708,7 @@ void ntod (void)
 
 
 			if (gentables)
-				outn ("    {");
+				outn ("INDENT BEGIN_ROW");
 
 			/* Supply array's 0-element. */
 			if (ds == end_of_buffer_state) {
@@ -728,7 +733,7 @@ void ntod (void)
 
 			dataflush ();
 			if (gentables)
-				outn ("    },\n");
+				outn ("INDENT END_ROW");
 		}
 
 		else if (fullspd)

--- a/src/flex.skl
+++ b/src/flex.skl
@@ -56,6 +56,232 @@ m4_changequote([[, ]])
 %#   edit the skeleton.
 %#
 
+%#
+%#   Macros that customize this skeleton to a specific target language.
+%#
+
+%#   Define language-specific macros controlling emission.
+%#   Skeleton authors must alter these to conform to their target language.
+
+%#   Define target language features.
+m4_define( [[M4_YY_COMMENT]], [[/* $1 */]] )
+m4_define( [[M4_YY_ALIAS]], [[#define $1 $2]] )
+m4_define( [[M4_YY_LINE_DIRECTIVE]], [[#line $1 "$2"]] )
+
+%#   Define the standard input and output files, with and without initialization.
+m4_define( [[M4_YY_STDFILES]], [[extern FILE *yyin, *yyout;]] )
+m4_define( [[M4_YY_STDINIT]], [[FILE *yyin=stdin, *yyout=stdout;]] )
+m4_define( [[M4_YY_NO_STDINIT]], [[FILE *yyin=NULL, *yyout=NULL;]] )
+
+%#   Defines type macros emitted by flex.
+m4_define( [[M4_YY_TRANS_INFO_TYPE]], [[struct yy_trans_info]] )
+m4_define( [[M4_YY_TRANS_INFO_P_TYPE]], [[struct yy_trans_info*]] )
+m4_define( [[M4_YY_TRANS_INFO_PP_TYPE]], [[struct yy_trans_info**]] )
+
+%#   Defines a table with a parameterized name and dimension.
+%#      /param1 - name of the table
+%#      /param2 - number of rows
+m4_define( [[DEFINE_TABLE_2D]], [[static const YY_INT_ALIGNED $1 [][$2] =
+{
+]] )
+
+%#   Defines an array with a parameterized name and dimension.
+%#      /param1 - name of the table
+%#      /param2 - number of cells
+m4_define( [[DEFINE_ARRAY]], [[static const YY_INT_ALIGNED $1 [$2] =
+{ 0,
+]] )
+m4_define( [[DEFINE_LONG_ARRAY]], [[static const flex_int32_t $1 [$2] =
+{ 0,
+]] )
+m4_define( [[DEFINE_STATE_ARRAY]], [[static const yy_state_type $1 [$2] =
+{ 0,
+]] )
+m4_define( [[DEFINE_CHAR_ARRAY]], [[static const YY_CHAR $1 [$2] =
+{ 0,
+]] )
+%# One-off typed arrays. Usually structs.
+%# Zero-indexed, unlike all the other arrays.
+m4_define( [[DEFINE_TYPE_ARRAY]], [[static const $1 $2 [$3] =
+{
+]] )
+
+%#   Like DEFINE_TABLE, but for strictly empty tables
+%#      /param1 - name of the table
+m4_define( [[DEFINE_TABLE_EMPTY]], [[static const YY_INT_ALIGNED * $1 = 0;
+]] )
+m4_define( [[DEFINE_LONG_TABLE_EMPTY]], [[static const flex_int32_t * $1 = 0;
+]] )
+m4_define( [[DEFINE_STATE_TABLE_EMPTY]], [[static const yy_state_type * $1 = 0;
+]] )
+m4_define( [[DEFINE_CHAR_TABLE_EMPTY]], [[static const YY_CHAR * $1 = 0;
+]] )
+m4_define( [[DEFINE_TYPE_TABLE_EMPTY]], [[static const $1 $2 = 0;
+]] )
+
+
+%#   Defines the end-of-table syntax
+m4_define( [[END_TABLE]], [[}]] )
+
+%#   Defines the row separator syntax
+m4_define( [[BEGIN_ROW]], [[{]] )
+m4_define( [[END_ROW]], [[},
+]] )
+m4_define( [[LAST_ROW]], [[} ;
+]] )
+
+%# Define structure & slot syntax
+m4_define( [[BEGIN_STRUCT]], [[{]] )
+m4_define( [[NEXT_STRUCT]], [[},]] )
+m4_define( [[LAST_STRUCT]], [[}]] )
+m4_define( [[NEXT_SLOT]], [[,]] )
+m4_define( [[LAST_SLOT]], [[]] )
+
+%#   Defines the column separator syntax
+m4_define( [[COLUMN_SEPARATOR]], [[,]] )
+
+%#   Defines the table entry syntax
+%#      /param1 - the table entry
+m4_define( [[TABLE_DATA]], [[$1]] )
+
+%#   Defines spacing for pretty-printing tables
+m4_define( [[INDENT]], [[    ]] )
+m4_define( [[TABLE_BLOCK]], [[
+]] )
+
+%#   Defines lookup syntax for a table entry
+m4_define( [[LOOKUP_TABLE_ENTRY]], [[$1[$2]]] )
+m4_define( [[REFERENCE_TABLE_ENTRY]], [[&$1[$2]]] )
+
+%#   Defines an entry in the table map emitted by the %tables-yydmap command
+%#      /param1 - A table ID constant
+%#      /param2 - A handle for a table, usually a symbol/name/etc
+m4_define( [[YYDMAP_ENTRY]], [[ {$1, (void**)&$2, sizeof(YY_INT_ALIGNED)},
+]] )
+m4_define( [[YYDMAP_ENTRY_LONG]], [[ {$1, (void**)&$2, sizeof(flex_int32_t)},
+]] )
+m4_define( [[YYDMAP_ENTRY_TYPE]], [[ {$1, (void**)&$2, sizeof($3)},
+]] )
+
+%#   Defines the syntax for matching EOF rules in yylex.
+m4_define( [[EOF_RULE]], [[case YY_STATE_EOF($1):
+]] )
+
+%#   Redefines the YY_NXT_LOLEN constant used to index tables in the C/C++ scanner
+%#      /param1 - the new (integer) value of YY_NXT_LOLEN
+m4_define( [[RESET_NXT_LOLEN]], [[#undef YY_NXT_LOLEN
+#define YY_NXT_LOLEN ($1)
+]] )
+
+
+%#   The skeleton uses the following macros to implement CLI switch-controlled emissions.
+%#   They are either emitted directly from main.c in flexinit() and readin() or by M4_YY_USERDEF.  
+%#   They are listed here for documentation's sake.  They are wrapped in m4_undefs to ensure they 
+%#   don't break anything if they're uncommented and unused.  This way you can uncomment them in a
+%#   new skeleton to indicate that they are ignored in your code.
+
+%# m4_undef( [[M4_YY_MORE_USED]] )
+%# m4_undef( [[M4_YY_USES_REJECT]] )
+%# m4_undef( [[M4_YY_SKIP_YYWRAP]] )
+%# m4_undef( [[M4_FLEX_DEBUG]] )
+%# m4_undef( [[M4_YY_REENTRANT]] )
+%# m4_undef( [[M4_YYTEXT_PTR]] )
+%# m4_undef( [[M4_YY_INTERACTIVE]] )
+%# m4_undef( [[M4_DO_STDINIT]] )
+%# m4_undef( [[M4_YY_FULLSPD]] )
+%# m4_undef( [[M4_LEX_COMPAT]] )
+%# m4_undef( [[M4_YYCLASS]] )
+%# m4_undef( [[M4_YY_TEXT_IS_ARRAY]] )
+%# m4_undef( [[M4_YY_MAIN]] )
+%# m4_undef( [[M4_YY_NO_UNISTD_H]] )
+%# m4_undef( [[M4_YY_ALWAYS_INTERACTIVE]] )
+%# m4_undef( [[M4_YY_NEVER_INTERACTIVE]] )
+%# m4_undef( [[M4_YY_STACK_USED]] )
+%# m4_undef( [[M4_YYCLASS]] )
+%# m4_undef( [[M4_YY_NO_PUSH_STATE]] )
+%# m4_undef( [[M4_YY_NO_POP_STATE]] )
+%# m4_undef( [[M4_YY_NO_TOP_STATE]] )
+%# m4_undef( [[M4_YY_NO_UNPUT]] )
+%# m4_undef( [[M4_YY_NO_SCAN_BUFFER]] )
+%# m4_undef( [[M4_YY_NO_SCAN_BYTES]] )
+%# m4_undef( [[M4_YY_NO_SCAN_STRING]] )
+%# m4_undef( [[M4_YY_NO_GET_EXTRA]] )
+%# m4_undef( [[M4_YY_NO_SET_EXTRA]] )
+%# m4_undef( [[M4_YY_NO_GET_LENG]] )
+%# m4_undef( [[M4_YY_NO_GET_TEXT]] )
+%# m4_undef( [[M4_YY_NO_GET_LINENO]] )
+%# m4_undef( [[M4_YY_NO_SET_LINENO]] )
+%# m4_undef( [[M4_YY_NO_GET_IN]] )
+%# m4_undef( [[M4_YY_NO_SET_IN]] )
+%# m4_undef( [[M4_YY_NO_GET_OUT]] )
+%# m4_undef( [[M4_YY_NO_SET_OUT]] )
+%# m4_undef( [[M4_YY_NO_GET_LVAL]] )
+%# m4_undef( [[M4_YY_NO_SET_LVAL]] )
+%# m4_undef( [[M4_YY_NO_GET_LLOC]] )
+%# m4_undef( [[M4_YY_NO_SET_LLOC]] )
+%# m4_undef( [[M4_VARIABLE_TRAILING_CONTEXT_RULES]] )
+%# m4_undef( [[M4_YY_USE_READ]] )
+%# m4_undef( [[M4_YY_BOL_NEEDED]] )
+%# m4_undef( [[M4_YY_USE_ECS]] )
+%# m4_undef( [[M4_YY_NUM_RULES]] )
+%# m4_undef( [[M4_YY_END_OF_BUFFER]] )
+%# m4_undef( [[M4_YY_NEEDS_BACKING_UP]] )
+
+%# The skeleton uses the following macros during state table generation.
+%# Skeleton authors must determine how to translate these values into
+%# their target language.  That will depend heavily upon how you plan
+%# to walk the tables.  The C/C++ skeletons will provide some guidance.
+%# The macros are listed here without m4 decoration for documentation only.
+
+%# M4_YY_NUM_RULES
+%# M4_YY_END_OF_BUFFER
+%# M4_YY_TRANS_OFFSET_TYPE
+%# M4_YY_TRAILING_MASK
+%# M4_YY_TRAILING_HEAD_MASK
+
+%#
+%#   Begin actual emission of code
+%#
+
+%% [1.0] Pause to allow Flex to set options from the command line, etc.
+
+%#   Defines table alignment macro.  
+%#   The test macro is defined when the -Ca command line argument is specified.
+%#   Possibly only useful in skeletons for C/C++ and kin.
+m4_ifdef([[M4_YY_LONG_ALIGNED]], [[
+#define YY_INT_ALIGNED flex_int32_t]], [[
+#define YY_INT_ALIGNED flex_int16_t
+]] )
+
+%#   Emit the user-defined top block from the input.
+m4_ifdef( [[M4_YY_TOP_BLOCK]], M4_YY_TOP_BLOCK )
+
+%#   Emit any user-defined constants from the input or command line.
+m4_ifdef( [[M4_YY_MAIN]], [[#define YY_MAIN 1]], [[#define YY_MAIN 0]] )
+m4_ifdef( [[M4_YY_USERDEF]], M4_YY_USERDEF )
+
+%#   Emit the right definitions for yywrap
+%if-c-only
+m4_ifdef( [[M4_YY_SKIP_YYWRAP]], [[
+  m4_ifdef( [[M4_YY_REENTRANT]], [[
+    #define M4_YY_PREFIX[[wrap(yyscanner)]] (/*CONSTCOND*/1)
+  ]], [[
+    #define M4_YY_PREFIX[[wrap()]] (/*CONSTCOND*/1)
+  ]] )
+]] )
+%endif
+
+%#   Enable debugging, or not
+m4_ifdef( [[M4_FLEX_DEBUG]], [[#define FLEX_DEBUG (/*CONSTCOND*/1)]], [[
+  m4_define( [[M4_YY_NO_GET_DEBUG]], 0 )
+  m4_define( [[M4_YY_NO_SET_DEBUG]], 0 )
+]] )
+
+
+%#   Define handling for the --lex-compat flag
+m4_ifdef( [[M4_LEX_COMPAT]], [[#define YY_FLEX_LEX_COMPAT]] )
+
+
 %not-for-header
 %if-c-only
 %if-not-reentrant
@@ -98,19 +324,19 @@ m4_ifelse(M4_YY_PREFIX,yy,,
 #endif
 
 %# Some negated symbols
-m4_ifdef( [[M4_YY_IN_HEADER]], , [[m4_define([[M4_YY_NOT_IN_HEADER]], [[]])]])
-m4_ifdef( [[M4_YY_REENTRANT]], , [[m4_define([[M4_YY_NOT_REENTRANT]], [[]])]])
+m4_ifdef( [[M4_YY_IN_HEADER]], , [[m4_define( [[M4_YY_NOT_IN_HEADER]], [[]] )]] )
+m4_ifdef( [[M4_YY_REENTRANT]], , [[m4_define( [[M4_YY_NOT_REENTRANT]], [[]] )]] )
 
 %# This is the m4 way to say "(stack_used || is_reentrant)
-m4_ifdef( [[M4_YY_STACK_USED]], [[m4_define([[M4_YY_HAS_START_STACK_VARS]])]])
-m4_ifdef( [[M4_YY_REENTRANT]],  [[m4_define([[M4_YY_HAS_START_STACK_VARS]])]])
+m4_ifdef( [[M4_YY_STACK_USED]], [[m4_define( [[M4_YY_HAS_START_STACK_VARS]], [[]] ) ]] )
+m4_ifdef( [[M4_YY_REENTRANT]],  [[m4_define( [[M4_YY_HAS_START_STACK_VARS]], [[]] ) ]] )
 
 %# Prefixes.
 %# The complexity here is necessary so that m4 preserves
 %# the argument lists to each C function.
 
 
-m4_ifdef( [[M4_YY_PREFIX]],, [[m4_define([[M4_YY_PREFIX]], [[yy]])]])
+m4_ifdef( [[M4_YY_PREFIX]],, [[m4_define( [[M4_YY_PREFIX]], [[yy]] )]] )
 
 m4preproc_define(`M4_GEN_PREFIX',``
 [[#ifdef yy$1
@@ -168,7 +394,7 @@ m4_ifelse(M4_YY_PREFIX,yy,,
     [[
         M4_GEN_PREFIX(`get_column')
         M4_GEN_PREFIX(`set_column')
-    ]])
+    ]] )
     M4_GEN_PREFIX(`wrap')
 )
 %endif
@@ -177,13 +403,13 @@ m4_ifdef( [[M4_YY_BISON_LVAL]],
 [[
     M4_GEN_PREFIX(`get_lval')
     M4_GEN_PREFIX(`set_lval')
-]])
+]] )
 
 m4_ifdef( [[<M4_YY_BISON_LLOC>]],
 [[
     M4_GEN_PREFIX(`get_lloc')
     M4_GEN_PREFIX(`set_lloc')
-]])
+]] )
 
 
 m4_ifelse(M4_YY_PREFIX,yy,,
@@ -212,7 +438,7 @@ m4_ifdef( [[M4_YY_TABLES_EXTERNAL]],
     M4_GEN_PREFIX(`tables_fload')
     M4_GEN_PREFIX(`tables_destroy')
     M4_GEN_PREFIX(`TABLES_NAME')
-]])
+]] )
 
 /* First, we deal with  platform-specific or compiler-specific issues. */
 
@@ -259,11 +485,102 @@ m4_ifdef( [[M4_YY_ALWAYS_INTERACTIVE]], ,
 %endif
 
 %if-c-or-c++
+m4preproc_include(`flexint.h')
 m4preproc_include(`flexint_shared.h')
 %endif
 
-/* TODO: this is always defined, so inline it */
+%if-c-or-c++
+#ifndef yyconst
 #define yyconst const
+#endif
+%endif
+
+%#   Define the flex_uint8_t type
+m4_ifdef( [[M4_YY_IN_HEADER]], , [[typedef flex_uint8_t YY_CHAR;]] )
+
+%if-c++-only
+%#   Define the yytext_ptr macro, if needed
+m4_ifdef( [[M4_YYTEXT_PTR]], [[#define yytext_ptr yytext]] )
+%endif
+
+%#   Declare the standard yyin and yyout files
+m4_ifdef( [[M4_YY_IN_HEADER]], [[M4_YY_STDFILES]], [[
+  m4_ifdef( [[M4_DO_STDINIT]], [[
+    m4_ifdef( [[M4_YY_REENTRANT]], [[
+#ifdef VMS
+  #ifdef __VMS_POSIX
+    #define YY_STDINIT
+  #endif
+#else
+  #define YY_STDINIT
+#endif
+    ]])
+  ]])
+]])
+
+%#  Define what to emit for the -F CLI swtich
+m4_ifdef( [[M4_YY_IN_HEADER]], ,  [[
+  m4_ifdef( [[M4_YY_FULLSPD]], 
+            [[typedef const struct yy_trans_info *yy_state_type;]] )
+]] )
+%if-c-only
+m4_ifdef( [[M4_YY_IN_HEADER]], ,  [[
+  m4_ifdef( [[M4_YY_FULLSPD]], , [[typedef int yy_state_type;]] )
+]] )
+%endif
+
+%#   Define yylineno for C
+%if-c-only
+m4_ifdef( [[M4_YY_REENTRANT]], , [[
+    extern int yylineno;
+  m4_ifdef( [[M4_YY_IN_HEADER]], , [[
+	int yylineno = 1;
+    ]] )
+]] )
+%endif
+
+%#   Define C++ specifics
+%if-c++-only
+#include <FlexLexer.h>
+
+m4_ifdef( [[M4_YY_SKIP_YYWRAP]], [[
+int yyFlexLexer::yywrap() { return 1; }
+]] )
+
+m4_ifdef( [[M4_YYCLASS]], [[
+int yyFlexLexer::yylex()
+{
+    LexerError( "yyFlexLexer::yylex invoked but %option yyclass used" );
+    return 0;
+}
+
+#define YY_DECL int M4_YYCLASS::yylex()
+]] )
+%endif
+
+%#   Define yytext_ptr in C 
+%if-c-only
+m4_ifdef( [[M4_YY_TEXT_IS_ARRAY]], [[
+  m4_ifdef( [[M4_YY_REENTRANT]], [[
+#ifdef yytext_ptr
+#undef yytext_ptr
+#endif
+  ]], [[
+extern char yytext[];
+  ]] ) 
+]], [[
+  m4_ifdef( [[M4_YY_REENTRANT]], [[
+#define yytext_ptr yytext_r
+  ]], [[
+extern char *yytext;
+
+#ifdef yytext_ptr
+#undef yytext_ptr
+#endif
+#define yytext_ptr yytext
+  ]] )
+]] )
+%endif
 
 #if defined(__GNUC__) && __GNUC__ >= 3
 #define yynoreturn __attribute__((__noreturn__))
@@ -423,9 +740,13 @@ extern int yyleng;
 
 %if-c-only
 %if-not-reentrant
-extern FILE *yyin, *yyout;
+m4_ifdef( [[M4_YY_NOT_IN_HEADER]], [[
+M4_YY_NO_STDINIT
+]] )
 %endif
 %endif
+
+
 
 m4_ifdef( [[M4_YY_NOT_IN_HEADER]],
 [[
@@ -650,11 +971,22 @@ m4_ifdef( [[M4_YY_NOT_IN_HEADER]],
 #define YY_AT_BOL() (YY_CURRENT_BUFFER_LVALUE->yy_at_bol)
 ]])
 
-%% [1.0] yytext/yyin/yyout/yy_state_type/yylineno etc. def's & init go here
+m4_ifdef(  [[M4_YY_FULLSPD]], , [[
+/* This struct is not used in this scanner */
+/* but its presence is necessary. */]]
+)
+#ifndef YY_STRUCT_YY_TRANS_INFO
+#define YY_STRUCT_YY_TRANS_INFO
+struct yy_trans_info
+{
+    flex_int[[]]M4_YY_TRANS_OFFSET_TYPE[[]]_t yy_verify;
+    flex_int[[]]M4_YY_TRANS_OFFSET_TYPE[[]]_t yy_nxt;
+};
+#endif /* YY_STRUCT_YY_TRANS_INFO */
 
 m4_ifdef( [[M4_YY_NOT_IN_HEADER]],
 [[
-%% [1.5] DFA
+%% [2.0] DFA
 ]])
 
 %if-c-only Standard (non-C++) definition
@@ -671,17 +1003,190 @@ static void yynoreturn yy_fatal_error ( const char* msg M4_YY_PROTO_LAST_ARG );
 
 m4_ifdef( [[M4_YY_NOT_IN_HEADER]],
 [[
+/* Report a fatal error. */
+#ifndef YY_FATAL_ERROR
+%if-c-only
+#define YY_FATAL_ERROR(msg) yy_fatal_error( msg M4_YY_CALL_LAST_ARG)
+%endif
+%if-c++-only
+#define YY_FATAL_ERROR(msg) LexerError( msg )
+%endif
+#endif
+]])
+
+m4_ifdef( [[M4_YY_NOT_IN_HEADER]],
+[[
 /* Done after the current pattern has been matched and before the
  * corresponding action - sets up yytext.
  */
 #define YY_DO_BEFORE_ACTION \
 	YY_G(yytext_ptr) = yy_bp; \
-%% [2.0] code to fiddle yytext and yyleng for yymore() goes here \
+m4_ifdef( [[M4_YY_MORE_USED]], [[ \
+  m4_ifdef( [[M4_YY_TEXT_IS_ARRAY]], [[ \
+	yyleng = (int) (yy_cp - yy_bp); \
+  ]], [[ \
+	YY_G(yytext_ptr) -= YY_G(yy_more_len); \
+	yyleng = (int) (yy_cp - YY_G(yytext_ptr)); \
+  ]] ) \
+]], [[ \
+	yyleng = (int) (yy_cp - yy_bp); \
+]] ) \
 	YY_G(yy_hold_char) = *yy_cp; \
 	*yy_cp = '\0'; \
-%% [3.0] code to copy yytext_ptr to yytext[] goes here, if %array \
-	YY_G(yy_c_buf_p) = yy_cp;
-%% [4.0] data tables for the DFA and the user's section 1 definitions go here
+m4_ifdef( [[M4_YY_TEXT_IS_ARRAY]], [[ \
+    m4_ifdef( [[M4_YY_MORE_USED]], [[ \
+	if ( yyleng + YY_G(yy_more_offset) >= YYLMAX ) \
+    ]], [[ \
+	if ( yyleng >= YYLMAX ) \
+    ]] ) \
+	YY_FATAL_ERROR( "token too large, exceeds YYLMAX" ); \
+    m4_ifdef( [[M4_YY_MORE_USED]], [[ \
+	yy_flex_strncpy( &yytext[YY_G(yy_more_offset)], YY_G(yytext_ptr), yyleng + 1 M4_YY_CALL_LAST_ARG); \
+	yyleng += YY_G(yy_more_offset); \
+	YY_G(yy_prev_more_offset) = YY_G(yy_more_offset); \
+	YY_G(yy_more_offset) = 0; \
+    ]], [[ \
+	yy_flex_strncpy( yytext, YY_G(yytext_ptr), yyleng + 1 M4_YY_CALL_LAST_ARG); \
+    ]] ) \
+]] ) \
+    YY_G(yy_c_buf_p) = yy_cp;
+
+#define YY_NUM_RULES M4_YY_NUM_RULES
+#define YY_END_OF_BUFFER M4_YY_END_OF_BUFFER
+
+
+
+%# TODO: The tables have to be output here, but the code to do it is a mess of spaghetti.
+%#       It looks like it'll work best to create commands like %tables-yydmap that dump
+%#       the individual tables.  The gen.c functions will write the tables into buffers
+%#       the same way we do the table map.
+%#
+%#       In the meantime, we need to ensure that defines for the various table options get
+%#       propogated into the output stream so we can test them here in the skeleton.
+%#
+%#       In other words, gen.c:1611-1742, 1750-1757 goes here
+
+
+%if-c-only
+m4_ifdef( [[M4_YY_REENTRANT]], , [[
+    extern int yy_flex_debug;
+m4_ifdef( [[M4_FLEX_DEBUG]],
+          [[int yy_flex_debug = 1;]],
+          [[int yy_flex_debug = 0;]] )
+]])
+%endif
+
+m4_ifdef( [[M4_YY_USES_REJECT]],
+[[
+		/* Declare state buffer variables. */
+%if-c-only
+m4_ifdef( [[M4_YY_REENTRANT]], , [[
+			static yy_state_type *yy_state_buf=0, *yy_state_ptr=0;
+			static char *yy_full_match;
+			static int yy_lp;
+]] )
+%endif
+
+m4_ifdef( [[M4_VARIABLE_TRAILING_CONTEXT_RULES]],
+[[
+%if-c-only
+			static int yy_looking_for_trail_begin = 0;
+			static int yy_full_lp;
+			static int *yy_full_state;
+%endif
+]] )
+			#define YY_TRAILING_MASK M4_YY_TRAILING_MASK
+			#define YY_TRAILING_HEAD_MASK M4_YY_TRAILING_HEAD_MASK
+
+		#define REJECT \
+		{ \
+		*yy_cp = YY_G(yy_hold_char); /* undo effects of setting up yytext */ \
+		yy_cp = YY_G(yy_full_match); /* restore poss. backed-over text */ \
+m4_ifdef( [[M4_VARIABLE_TRAILING_CONTEXT_RULES]], [[ \
+			YY_G(yy_lp) = YY_G(yy_full_lp); /* restore orig. accepting pos. */ \
+			YY_G(yy_state_ptr) = YY_G(yy_full_state); /* restore orig. state */ \
+			yy_current_state = *YY_G(yy_state_ptr); /* restore curr. state */ \
+]] ) \
+		++YY_G(yy_lp); \
+		goto find_rule; \
+		}
+]],
+[[
+		/* The intent behind this definition is that it'll catch
+		 * any uses of REJECT which flex missed.
+		 */
+		#define REJECT reject_used_but_not_detected
+]] )
+
+m4_ifdef( [[M4_YY_MORE_USED]], [[
+%if-c-only
+m4_ifdef( [[M4_YY_TEXT_IS_ARRAY]], [[
+    m4_ifdef( [[M4_YY_REENTRANT]], [[]], [[
+    		static int yy_more_offset = 0;
+            static int yy_prev_more_offset = 0;
+    ]] )
+]],
+[[
+m4_ifdef( [[M4_YY_REENTRANT]], [[]], [[
+			static int yy_more_flag = 0;
+			static int yy_more_len = 0;
+]] )
+]] )
+%endif
+
+m4_ifdef( [[M4_YY_TEXT_IS_ARRAY]], [[
+			#define yymore() (YY_G(yy_more_offset) = yy_flex_strlen( yytext M4_YY_CALL_LAST_ARG))
+			#define YY_NEED_STRLEN
+			#define YY_MORE_ADJ 0
+			#define YY_RESTORE_YY_MORE_OFFSET \
+			{ \
+                YY_G(yy_more_offset) = YY_G(yy_prev_more_offset); \
+                yyleng -= YY_G(yy_more_offset); \
+			}
+]],
+[[
+			#define yymore() (YY_G(yy_more_flag) = 1)
+			#define YY_MORE_ADJ YY_G(yy_more_len)
+			#define YY_RESTORE_YY_MORE_OFFSET
+]] )
+]],
+[[
+		#define yymore() yymore_used_but_not_detected
+		#define YY_MORE_ADJ 0
+		#define YY_RESTORE_YY_MORE_OFFSET
+]] )
+
+%if-c-only
+m4_ifdef( [[M4_YY_TEXT_IS_ARRAY]], [[
+			#ifndef YYLMAX
+			#define YYLMAX 8192
+			#endif
+m4_ifdef( [[M4_YY_REENTRANT]], [[]], [[
+            char yytext[YYLMAX];
+            char *yytext_ptr;
+]] )
+]],
+[[
+m4_ifdef( [[M4_YY_REENTRANT]], [[]], [[char *yytext;]] )
+]] )
+%endif
+
+%if-c-only
+%# Definitions for backing up.  We don't need them if REJECT
+%# is being used because then we use an alternative backin-up
+%# technique instead.
+m4_ifdef( [[M4_YY_NEEDS_BACKING_UP]], [[
+  m4_ifdef( [[M4_YY_USES_REJECT]], , [[
+    m4_ifdef( [[M4_YY_REENTRANT]], , [[
+static yy_state_type yy_last_accepting_state;
+static char *yy_last_accepting_cpos;
+    ]] )
+  ]] )
+]] )
+%endif
+
+%# TODO: Insert at this point the equivalents of gen.c:1879-1884.
+%% [3.0] the user's section 1 definitions go here
 ]])
 
 m4_ifdef( [[M4_YY_IN_HEADER]], [[#ifdef YY_HEADER_EXPORT_START_CONDITIONS]])
@@ -931,13 +1436,13 @@ m4_ifdef( [[<M4_YY_BISON_LLOC>]],
  * section 1.
  */
 
-#ifndef YY_SKIP_YYWRAP
+m4_ifdef( [[M4_YY_SKIP_YYWRAP]], , [[
 #ifdef __cplusplus
 extern "C" int yywrap ( M4_YY_PROTO_ONLY_ARG );
 #else
 extern int yywrap ( M4_YY_PROTO_ONLY_ARG );
 #endif
-#endif
+]] )
 
 %not-for-header
 #ifndef YY_NO_UNPUT
@@ -1042,12 +1547,54 @@ m4_ifdef( [[M4_YY_NOT_IN_HEADER]],
  */
 #ifndef YY_INPUT
 #define YY_INPUT(buf,result,max_size) \
-%% [5.0] fread()/read() definition of YY_INPUT goes here unless we're doing C++ \
+%if-c-only \
+m4_ifdef( [[M4_YY_USE_READ]], [[ \
+	errno=0; \
+	while ( (result = (int) read( fileno(yyin), buf, (yy_size_t) max_size )) < 0 ) \
+	{ \
+		if( errno != EINTR) \
+		{ \
+			YY_FATAL_ERROR( "input in flex scanner failed" ); \
+			break; \
+		} \
+		errno=0; \
+		clearerr(yyin); \
+	} \
+]], [[ \
+    if ( YY_CURRENT_BUFFER_LVALUE->yy_is_interactive ) \
+	{ \
+		int c = '*'; \
+		int n; \
+		for ( n = 0; n < max_size && \
+			(c = getc( yyin )) != EOF && c != '\n'; ++n ) \
+			buf[n] = (char) c; \
+			if ( c == '\n' ) \
+                buf[n++] = (char) c; \
+			if ( c == EOF && ferror( yyin ) ) \
+                YY_FATAL_ERROR( "input in flex scanner failed" ); \
+			result = n; \
+	} \
+	else \
+	{ \
+        errno=0; \
+		while ( (result = (int) fread(buf, 1, (yy_size_t) max_size, yyin)) == 0 && ferror(yyin)) \
+		{ \
+			if( errno != EINTR) \
+			{ \
+                YY_FATAL_ERROR( "input in flex scanner failed" ); \
+                break; \
+			} \
+            errno=0; \
+            clearerr(yyin); \
+        } \
+	} \
+]] ) \
+%endif \
 \
 %if-c++-only C++ definition \
 	if ( (int)(result = LexerInput( (char *) buf, max_size )) < 0 ) \
-		YY_FATAL_ERROR( "input in flex scanner failed" );
-%endif
+		YY_FATAL_ERROR( "input in flex scanner failed" ); \
+%endif \
 
 #endif
 ]])
@@ -1068,18 +1615,7 @@ m4_ifdef( [[M4_YY_NOT_IN_HEADER]],
 #define YY_START_STACK_INCR 25
 #endif
 
-m4_ifdef( [[M4_YY_NOT_IN_HEADER]],
-[[
-/* Report a fatal error. */
-#ifndef YY_FATAL_ERROR
-%if-c-only
-#define YY_FATAL_ERROR(msg) yy_fatal_error( msg M4_YY_CALL_LAST_ARG)
-%endif
-%if-c++-only
-#define YY_FATAL_ERROR(msg) LexerError( msg )
-%endif
-#endif
-]])
+
 
 %if-tables-serialization structures and prototypes
 m4preproc_include(`tables_shared.h')
@@ -1180,8 +1716,88 @@ m4_ifdef( [[M4_YY_NOT_IN_HEADER]],
 
 m4_ifdef( [[M4_YY_NOT_IN_HEADER]],
 [[
-%% [6.0] YY_RULE_SETUP definition goes here
+#define YY_RULE_SETUP \
+m4_ifdef( [[M4_YY_BOL_NEEDED]], [[ \
+	if ( yyleng > 0 ) \
+        YY_CURRENT_BUFFER_LVALUE->yy_at_bol = (yytext[yyleng - 1] == '\n'); \
+]], [[]] ) \
+	YY_USER_ACTION
 ]])
+
+m4_ifdef( [[M4_YY_NOT_IN_HEADER]],
+[[
+m4_define( [[M4_YY_BACKING_UP]], [[
+m4_ifdef( [[M4_YY_NEEDS_BACKING_UP]], [[
+  m4_ifdef( [[M4_YY_USES_REJECT]], , [[
+    m4_ifdef( [[M4_YY_FULLSPD]], [[
+	if ( yy_current_state[-1].yy_nxt ) {
+    ]], [[
+	if ( yy_accept[yy_current_state] ) {
+    ]] )
+		YY_G(yy_last_accepting_state) = yy_current_state;
+		YY_G(yy_last_accepting_cpos) = yy_cp;
+	}
+    ]] )
+  ]] )
+]] )
+
+m4_define( [[M4_YY_NEXT_COMPRESSED_STATE]], [[
+	YY_CHAR yy_c = $1[[]];
+
+	 /* Save the backing-up info \before/ computing the next state
+	 * because we always compute one more state than needed - we
+	 * always proceed until we reach a jam state
+	 */
+	M4_YY_BACKING_UP()
+
+	while ( yy_chk[yy_base[yy_current_state] + yy_c] != yy_current_state )
+	{
+		yy_current_state = (int) yy_def[yy_current_state];
+
+  m4_ifdef( [[M4_YY_USE_MECS]], [[
+		/* We've arranged it so that templates are never chained
+		 * to one another.  This means we can afford to make a
+		 * very simple test to see if we need to convert to
+		 * yy_c's meta-equivalence class without worrying
+		 * about erroneously looking up the meta-equivalence
+		 * class twice
+		 */
+
+		/* [[M4_YY_LASTDFA]] (magic number M4_YY_LASTDFA[[]]) + 2 is the beginning of the templates */
+		if ( yy_current_state >= ( M4_YY_LASTDFA + 2) )
+			yy_c = yy_meta[yy_c];
+  ]] )
+	}
+	
+	yy_current_state = yy_nxt[yy_base[yy_current_state] + yy_c];
+]] )
+
+m4_define( [[M4_YY_GEN_START_STATE]], [[
+m4_ifdef( [[M4_YY_FULLSPD]], [[
+  m4_ifdef( [[M4_YY_BOL_NEEDED]], [[
+		yy_current_state = yy_start_state_list[YY_G(yy_start) + YY_AT_BOL()];
+  ]], [[
+		yy_current_state = yy_start_state_list[YY_G(yy_start)];
+  ]] )
+]],[[
+		yy_current_state = YY_G(yy_start);
+
+  m4_ifdef( [[M4_YY_BOL_NEEDED]], [[
+		yy_current_state += YY_AT_BOL();
+  ]] )
+
+  m4_ifdef( [[M4_YY_USES_REJECT]], [[
+		/* Set up for storing up states. */
+		YY_G(yy_state_ptr) = YY_G(yy_state_buf);
+		*YY_G(yy_state_ptr)++ = yy_current_state;
+  ]] )
+]] )
+]] )
+
+]] )
+
+
+
 
 %not-for-header
 /** The main scanner function which does all the work.
@@ -1191,7 +1807,7 @@ YY_DECL
 	yy_state_type yy_current_state;
 	char *yy_cp, *yy_bp;
 	int yy_act;
-    M4_YY_DECL_GUTS_VAR();
+	M4_YY_DECL_GUTS_VAR();
 
 m4_ifdef( [[M4_YY_NOT_REENTRANT]],
 [[
@@ -1230,7 +1846,7 @@ m4_ifdef( [[M4_YY_USES_REJECT]],
 			YY_G(yy_state_buf) = (yy_state_type *)yyalloc(YY_STATE_BUF_SIZE  M4_YY_CALL_LAST_ARG);
 		if ( ! YY_G(yy_state_buf) )
 			YY_FATAL_ERROR( "out of dynamic memory in yylex()" );
-]])
+]] )
 
 		if ( ! YY_G(yy_start) )
 			YY_G(yy_start) = 1;	/* first start state */
@@ -1261,11 +1877,20 @@ m4_ifdef( [[M4_YY_USES_REJECT]],
 		}
 
 	{
-%% [7.0] user's declarations go here
-
+%# This one might be needed because of the action_array output
+%% [4.0] user's declarations go here
 	while ( /*CONSTCOND*/1 )		/* loops until end-of-file is reached */
+	{
+m4_ifdef( [[M4_YY_MORE_USED]], [[ 
+  m4_ifdef( [[M4_YY_TEXT_IS_ARRAY]], , [[
+		YY_G(yy_more_len) = 0;
+		if ( YY_G(yy_more_flag) )
 		{
-%% [8.0] yymore()-related code goes here
+			YY_G(yy_more_len) = (int) (YY_G(yy_c_buf_p) - YY_G(yytext_ptr));
+			YY_G(yy_more_flag) = 0;
+		}
+  ]] )
+]] )
 		yy_cp = YY_G(yy_c_buf_p);
 
 		/* Support of yytext. */
@@ -1276,25 +1901,300 @@ m4_ifdef( [[M4_YY_USES_REJECT]],
 		 */
 		yy_bp = yy_cp;
 
-%% [9.0] code to set up and find next match goes here
+		M4_YY_GEN_START_STATE()
+
+yy_match:
+m4_ifdef( [[M4_YY_USE_ECS]], [[
+  m4_define( [[M4_YY_ECS_CHAR_MAP]], [[ yy_ec[YY_SC_TO_UI(*yy_cp)] ]] )
+  m4_define( [[M4_YY_ECS_CHAR_MAP_2]], [[ yy_ec[YY_SC_TO_UI(*++yy_cp)] ]] )
+]], [[
+  m4_define( [[M4_YY_ECS_CHAR_MAP]], [[ YY_SC_TO_UI(*yy_cp) ]] )
+  m4_define( [[M4_YY_ECS_CHAR_MAP_2]], [[ YY_SC_TO_UI(*++yy_cp) ]] )
+]] )
+
+m4_ifdef( [[M4_YY_FULLTBL]], [[
+  m4_ifdef( [[M4_YY_GENTABLES]], [[
+		while ( (yy_current_state = yy_nxt[yy_current_state][ M4_YY_ECS_CHAR_MAP ]) > 0 )
+  ]], [[
+		while ( (yy_current_state = yy_nxt[yy_current_state*YY_NXT_LOLEN +  M4_YY_ECS_CHAR_MAP ]) > 0 )
+  ]] )
+  m4_ifdef( [[M4_YY_NEEDS_BACKING_UP]], [[
+		{
+		M4_YY_BACKING_UP
+  ]] )
+		++yy_cp;
+  m4_ifdef( [[M4_YY_NEEDS_BACKING_UP]], [[
+		}
+  ]] )
+		yy_current_state = -yy_current_state;
+]], [[
+  m4_ifdef( [[M4_YY_FULLSPD]], [[
+		{
+			const struct yy_trans_info *yy_trans_info;
+			YY_CHAR yy_c;
+			for ( yy_c = M4_YY_ECS_CHAR_MAP;
+			      (yy_trans_info = &yy_current_state[yy_c])->yy_verify == yy_c;
+			       yy_c = M4_YY_ECS_CHAR_MAP_2 )
+    m4_ifdef( [[M4_YY_NEEDS_BACKING_UP]], [[
+			{
+    ]] )
+			yy_current_state += yy_trans_info->yy_nxt;
+    m4_ifdef( [[M4_YY_NEEDS_BACKING_UP]], [[
+  
+			M4_YY_BACKING_UP
+			}
+    ]] )
+		}
+  ]], [[
+		do
+		{
+
+%# /* Expansion/translation of gen_next_state(false); defined in gen.c */
+      m4_ifdef( [[M4_YY_FULLTBL]], [[
+        m4_ifdef( [[M4_YY_GENTABLES]], [[
+                          yy_current_state = yy_nxt[yy_current_state][ M4_YY_ECS_CHAR_MAP ];
+        ]], [[
+                          yy_current_state = yy_nxt[yy_current_state*YY_NXT_LOLEN + M4_YY_ECS_CHAR_MAP ];
+        ]] )
+      ]], [[
+        m4_ifdef( [[M4_YY_FULLSPD]], [[
+                  yy_current_state += yy_current_state[ M4_YY_ECS_CHAR_MAP ].yy_nxt;
+        ]], [[
+                  /* gen_next_compressed_state (char_map); */
+                  M4_YY_NEXT_COMPRESSED_STATE(M4_YY_ECS_CHAR_MAP)
+                  
+        ]] )
+      ]] )
+
+      m4_ifdef( [[M4_YY_FULLSPD]], [[
+                  M4_YY_BACKING_UP
+      ]], [[
+        m4_ifdef( [[M4__YY_FULLTBL]], [[
+                  M4_YY_BACKING_UP
+        ]] )
+      ]] )
+
+      m4_ifdef( [[M4_YY_USES_REJECT]], [[
+                  *YY_G(yy_state_ptr)++ = yy_current_state;
+      ]] )
+%# End of gen_next_state(false)
+    
+		++yy_cp;
+		}
+    m4_ifdef( [[M4_YY_INTERACTIVE]], [[
+		while ( yy_base[yy_current_state] != M4_YY_JAMBASE );
+    ]], [[
+		while ( yy_current_state != M4_YY_JAMSTATE );
+    ]] )
+    m4_ifdef( [[M4_YY_USES_REJECT]], , [[
+      m4_ifdef( [[M4_YY_INTERACTIVE]], , [[
+		/* Do the guaranteed-needed backing up to figure out
+		 * the match.
+		 */
+		yy_cp = YY_G(yy_last_accepting_cpos);
+		yy_current_state = YY_G(yy_last_accepting_state);
+      ]] )
+    ]] )
+  ]] )
+]] )
+%# END TODO: gen.c:1996 Translate gen_next_match here.
 
 yy_find_action:
-%% [10.0] code to find the action number goes here
+m4_ifdef( [[M4_YY_FULLSPD]], [[
+		yy_act = yy_current_state[-1].yy_nxt;
+]], [[
+  m4_ifdef( [[M4_YY_FULLTBL]], [[
+		yy_act = yy_accept[yy_current_state];
+  ]], [[
+    m4_ifdef( [[M4_YY_USES_REJECT]], [[
+		yy_current_state = *--YY_G(yy_state_ptr);
+		YY_G(yy_lp) = yy_accept[yy_current_state];
 
+find_rule: /* we branch to this label when backing up */
+
+		for ( ; ; ) /* until we find what rule we matched */
+		{                
+			if ( YY_G(yy_lp) && YY_G(yy_lp) < yy_accept[yy_current_state + 1] )
+			{
+				yy_act = yy_acclist[YY_G(yy_lp)];
+
+        m4_ifdef( [[M4_VARIABLE_TRAILING_CONTEXT_RULES]], [[
+				if ( yy_act & YY_TRAILING_HEAD_MASK ||
+					YY_G(yy_looking_for_trail_begin) )
+				{
+
+					if ( yy_act == YY_G(yy_looking_for_trail_begin) )
+			
+					{
+						YY_G(yy_looking_for_trail_begin) = 0;
+						yy_act &= ~YY_TRAILING_HEAD_MASK;
+						break;
+					}
+
+				}
+				else if ( yy_act & YY_TRAILING_MASK )
+				{
+					YY_G(yy_looking_for_trail_begin) = yy_act & ~YY_TRAILING_MASK;
+					YY_G(yy_looking_for_trail_begin) |= YY_TRAILING_HEAD_MASK;
+
+					/* Remember matched text in case we back up
+					 * due to REJECT.
+					 */
+					YY_G(yy_full_match) = yy_cp;
+					YY_G(yy_full_state) = YY_G(yy_state_ptr);
+					YY_G(yy_full_lp) = YY_G(yy_lp);
+				}
+				else
+				{
+					YY_G(yy_full_match) = yy_cp;
+					YY_G(yy_full_state) = YY_G(yy_state_ptr);
+					YY_G(yy_full_lp) = YY_G(yy_lp);
+					break;
+				}
+                        
+				++YY_G(yy_lp);
+				goto find_rule;
+        ]], [[
+			/* Remember matched text in case we back up due to
+			 * trailing context plus REJECT.
+			 */
+			{
+				YY_G(yy_full_match) = yy_cp;
+				break;
+			}
+        ]] )
+
+			}
+
+		--yy_cp;
+
+		/* We could consolidate the following two lines with those at
+		 * the beginning, but at the cost of complaints that we're
+		 * branching inside a loop.
+		 */
+		yy_current_state = *--YY_G(yy_state_ptr);
+		YY_G(yy_lp) = yy_accept[yy_current_state];
+
+		}
+
+	
+    ]], [[
+		/* compressed */
+		yy_act = yy_accept[yy_current_state];
+      m4_ifdef( [[M4_YY_INTERACTIVE]], [[
+        m4_ifdef( [[M4_YY_USES_REJECT]], , [[
+		/* Do the guaranteed-needed backing up to figure out
+		 * the match.
+		 */
+		if ( yy_act == 0 )
+		{ /* have to back up */
+			yy_cp = YY_G(yy_last_accepting_cpos);
+			yy_current_state = YY_G(yy_last_accepting_state);
+			yy_act = yy_accept[yy_current_state];
+		}
+        ]] )
+      ]] )
+    ]] )
+  ]] )
+]] )
 		YY_DO_BEFORE_ACTION;
 
-%% [11.0] code for yylineno update goes here
+m4_ifdef( [[M4_YY_USE_LINENO]],[[
+		if ( yy_act != YY_END_OF_BUFFER && yy_rule_can_match_eol[yy_act] )
+		{
+			int yyl;
+    m4_ifdef( [[M4_YYMORE_USED]], [[
+      m4_ifdef( [[M4_YY_TEXT_IS_ARRAY]], [[
+			for ( yyl = YY_G(yy_prev_more_offset); yyl < yyleng; ++yyl )
+      ]], [[
+			for ( yyl = YY_G(yy_more_len); yyl < yyleng; ++yyl )
+      ]] )
+    ]], [[
+			for ( yyl = 0; yyl < yyleng; ++yyl )
+    ]] )
+				if ( yytext[yyl] == '\n' )
+					M4_YY_INCR_LINENO();
+		}
+]] )
 
 do_action:	/* This label is used only to access EOF actions. */
 
-%% [12.0] debug code goes here
+m4_ifdef( [[M4_FLEX_DEBUG]], [[
+		if ( yy_flex_debug )
+		{
+			if ( yy_act == 0 )
+%if-c++-only
+				std::cerr << "--scanner backing up\n";
+%endif
+%if-c-only
+				fprintf( stderr, "--scanner backing up\n" );
+%endif
+			else if ( yy_act < M4_YY_NUM_RULES )
+%if-c++-only
+				std::cerr << "--accepting rule at line " << yy_rule_linenum[yy_act] <<
+						"(\"" << yytext << "\")\n";
+%endif
+%if-c-only
+				fprintf( stderr, "--accepting rule at line %ld (\"%s\")\n",
+					(long)yy_rule_linenum[yy_act], yytext );
+%endif
+			else if ( yy_act == M4_YY_NUM_RULES )
+%if-c++-only
+				std::cerr << "--accepting default rule (\"" << yytext << "\")\n";
+%endif
+%if-c-only
+				fprintf( stderr, "--accepting default rule (\"%s\")\n", yytext );
+%endif
+			else if ( yy_act == (M4_YY_NUM_RULES + 1) )
+%if-c++-only
+				std::cerr << "--(end of buffer or a NUL)\n";
+%endif
+%if-c-only
+				fprintf( stderr, "--(end of buffer or a NUL)\n" );
+%endif
+			else
+%if-c++-only
+				std::cerr << "--EOF (start condition " << YY_START << ")\n";
+%endif
+%if-c-only
+				fprintf( stderr, "--EOF (start condition %d)\n", YY_START );
+%endif
+		}
+]] )
 
 		switch ( yy_act )
 	{ /* beginning of action switch */
-%% [13.0] actions go here
+m4_ifdef( [[M4_YY_USES_REJECT]], , [[
+  m4_ifdef( [[M4_YY_NEEDS_BACKING_UP]], [[
+	case 0: /* must back up */
+		/* undo the effects of YY_DO_BEFORE_ACTION */
+		*yy_cp = YY_G(yy_hold_char);
+
+    m4_ifdef( [[M4_YY_FULLSPD]], [[
+		yy_cp = YY_G(yy_last_accepting_cpos) + 1;
+    ]], [[
+      m4_ifdef( [[M4_YY_FULLTBL]], [[
+		yy_cp = YY_G(yy_last_accepting_cpos) + 1;
+      ]], [[
+		/* Backing-up info for compressed tables is taken \after/
+		 * yy_cp has been incremented for the next state.
+		 */
+		yy_cp = YY_G(yy_last_accepting_cpos);
+      ]] )
+    ]] )
+		yy_current_state = YY_G(yy_last_accepting_state);
+		goto yy_find_action;
+  ]] )
+]] )
+
+%% [5.0] actions go here
+
+m4_ifdef( [[M4_YY_DID_EOF_RULE]], [[
+		yyterminate();
+]] )
 
 	case YY_END_OF_BUFFER:
-		{
+	{
 		/* Amount of text matched not including the EOB char. */
 		int yy_amount_of_matched_text = (int) (yy_cp - YY_G(yytext_ptr)) - 1;
 
@@ -1303,7 +2203,7 @@ do_action:	/* This label is used only to access EOF actions. */
 		YY_RESTORE_YY_MORE_OFFSET
 
 		if ( YY_CURRENT_BUFFER_LVALUE->yy_buffer_status == YY_BUFFER_NEW )
-			{
+		{
 			/* We're scanning a new file or input source.  It's
 			 * possible that this happened because the user
 			 * just pointed yyin at a new source and called
@@ -1321,7 +2221,7 @@ do_action:	/* This label is used only to access EOF actions. */
 			YY_CURRENT_BUFFER_LVALUE->yy_input_file = yyin.rdbuf();
 %endif
 			YY_CURRENT_BUFFER_LVALUE->yy_buffer_status = YY_BUFFER_NORMAL;
-			}
+		}
 
 		/* Note that here we test for yy_c_buf_p "<=" to the position
 		 * of the first EOB in the buffer, since yy_c_buf_p will
@@ -1331,7 +2231,7 @@ do_action:	/* This label is used only to access EOF actions. */
 		 * in input().
 		 */
 		if ( YY_G(yy_c_buf_p) <= &YY_CURRENT_BUFFER_LVALUE->yy_ch_buf[YY_G(yy_n_chars)] )
-			{ /* This was really a NUL. */
+		{ 	/* This was really a NUL. */
 			yy_state_type yy_next_state;
 
 			YY_G(yy_c_buf_p) = YY_G(yytext_ptr) + yy_amount_of_matched_text;
@@ -1352,28 +2252,57 @@ do_action:	/* This label is used only to access EOF actions. */
 			yy_bp = YY_G(yytext_ptr) + YY_MORE_ADJ;
 
 			if ( yy_next_state )
-				{
+			{
 				/* Consume the NUL. */
 				yy_cp = ++YY_G(yy_c_buf_p);
 				yy_current_state = yy_next_state;
 				goto yy_match;
-				}
-
-			else
-				{
-%% [14.0] code to do back-up for compressed tables and set up yy_cp goes here
-				goto yy_find_action;
-				}
 			}
 
-		else switch ( yy_get_next_buffer( M4_YY_CALL_ONLY_ARG ) )
+			else
 			{
+m4_ifdef( [[M4_YY_FULLSPD]], [[
+				yy_cp = YY_G(yy_c_buf_p);
+]], [[
+  m4_ifdef( [[M4_YY_FULLTBL]], [[
+				yy_cp = YY_G(yy_c_buf_p);
+  ]], [[
+				/* compressed table */
+    m4_ifdef( [[M4_YY_USES_REJECT]], [[
+				/* Still need to initialize yy_cp, though
+				* yy_current_state was set up by
+				* yy_get_previous_state().
+				*/
+				yy_cp = YY_G(yy_c_buf_p);
+    ]], [[
+      m4_ifdef( [[M4_YY_INTERACTIVE]], [[
+				/* Still need to initialize yy_cp, though
+				* yy_current_state was set up by
+				* yy_get_previous_state().
+				*/
+				yy_cp = YY_G(yy_c_buf_p);
+      ]], [[
+				/* Do the guaranteed-needed backing up to figure
+				 * out the match.
+				 */
+				yy_cp = YY_G(yy_last_accepting_cpos);
+				yy_current_state = YY_G(yy_last_accepting_state);
+      ]] )
+    ]] )
+  ]] )
+]] )
+				goto yy_find_action;
+			}
+		}
+
+		else switch ( yy_get_next_buffer( M4_YY_CALL_ONLY_ARG ) )
+		{
 			case EOB_ACT_END_OF_FILE:
-				{
+			{
 				YY_G(yy_did_buffer_switch_on_eof) = 0;
 
-				if ( yywrap( M4_YY_CALL_ONLY_ARG ) )
-					{
+				if ( yywrap(M4_YY_CALL_ONLY_ARG) )
+				{
 					/* Note: because we've taken care in
 					 * yy_get_next_buffer() to have set up
 					 * yytext, we can now set up
@@ -1387,15 +2316,15 @@ do_action:	/* This label is used only to access EOF actions. */
 
 					yy_act = YY_STATE_EOF(YY_START);
 					goto do_action;
-					}
+				}
 
 				else
-					{
+				{
 					if ( ! YY_G(yy_did_buffer_switch_on_eof) )
 						YY_NEW_FILE;
-					}
-				break;
 				}
+				break;
+			}
 
 			case EOB_ACT_CONTINUE_SCAN:
 				YY_G(yy_c_buf_p) =
@@ -1416,9 +2345,9 @@ do_action:	/* This label is used only to access EOF actions. */
 				yy_cp = YY_G(yy_c_buf_p);
 				yy_bp = YY_G(yytext_ptr) + YY_MORE_ADJ;
 				goto yy_find_action;
-			}
-		break;
 		}
+		break;
+	}
 
 	default:
 		YY_FATAL_ERROR(
@@ -1730,12 +2659,70 @@ m4_ifdef( [[M4_YY_USES_REJECT]],
 	char *yy_cp;
     M4_YY_DECL_GUTS_VAR();
 
-%% [15.0] code to get the start state into yy_current_state goes here
+    M4_YY_GEN_START_STATE()
 
 	for ( yy_cp = YY_G(yytext_ptr) + YY_MORE_ADJ; yy_cp < YY_G(yy_c_buf_p); ++yy_cp )
-		{
-%% [16.0] code to find the next state goes here
-		}
+	{
+%# Expansion/translation of gen_next_state (true); defined in gen.c */
+m4_ifdef( [[M4_YY_NULTRANS]], [[
+  m4_ifdef( [[M4_YY_USE_ECS]], [[
+    m4_define( [[M4_YY_ECS_CHAR_MAP_3]], [[yy_ec[YY_SC_TO_UI(*yy_cp)] ]] )
+  ]], [[
+    m4_define( [[M4_YY_ECS_CHAR_MAP_3]], [[YY_SC_TO_UI(*yy_cp)]] )
+  ]] )
+]], [[
+  m4_ifdef( [[M4_YY_USE_ECS]], [[
+    m4_define( [[M4_YY_ECS_CHAR_MAP_3]], [[(*yy_cp ? yy_ec[YY_SC_TO_UI(*yy_cp)] : M4_YY_NUL_EC)]] )
+  ]], [[
+    m4_define( [[M4_YY_ECS_CHAR_MAP_3]], [[(*yy_cp ? YY_SC_TO_UI(*yy_cp) : M4_YY_NUL_EC)]] )
+  ]] )
+]] )
+
+m4_ifdef( [[M4_YY_NULTRANS]], [[
+  m4_ifdef( [[M4_YY_FULLTBL]], , [[
+    m4_ifdef( [[M4_YY_FULLSPD]], , [[
+	/* Compressed tables back up *before* they match. */
+	M4_YY_BACKING_UP
+    ]] )
+  ]] )
+	if ( *yy_cp )
+	{
+]] )
+
+m4_ifdef( [[M4_YY_FULLTBL]], [[
+  m4_ifdef( [[M4_YY_GENTABLES]], [[
+		yy_current_state = yy_nxt[yy_current_state][ M4_YY_ECS_CHAR_MAP_3 ];
+  ]], [[
+		yy_current_state = yy_nxt[yy_current_state*YY_NXT_LOLEN + M4_YY_ECS_CHAR_MAP_3 ];
+  ]] )
+]], [[
+  m4_ifdef( [[M4_YY_FULLSPD]], [[
+		yy_current_state += yy_current_state[ M4_YY_ECS_CHAR_MAP_3 ].yy_nxt;
+  ]], [[
+		/* gen_next_compressed_state (char_map); */
+		M4_YY_NEXT_COMPRESSED_STATE(M4_YY_ECS_CHAR_MAP_3)
+  ]] )
+]] )
+
+m4_ifdef( [[M4_YY_NULTRANS]], [[
+	}
+	else
+		yy_current_state = yy_NUL_trans[yy_current_state];
+]] )
+
+m4_ifdef( [[M4_YY_FULLSPD]], [[
+	M4_YY_BACKING_UP
+]], [[
+  m4_ifdef( [[M4_YY_FULLTBL]], [[
+	M4_YY_BACKING_UP
+  ]] )
+]] )
+
+m4_ifdef( [[M4_YY_USES_REJECT]], [[
+	*YY_G(yy_state_ptr)++ = yy_current_state;
+]] )
+%# End of gen_next_state(true)
+	}
 
 	return yy_current_state;
 }
@@ -1754,8 +2741,65 @@ m4_ifdef( [[M4_YY_USES_REJECT]],
 %endif
 {
 	int yy_is_jam;
-    M4_YY_DECL_GUTS_VAR(); /* This var may be unused depending upon options. */
-%% [17.0] code to find the next state, and perhaps do backing up, goes here
+	M4_YY_DECL_GUTS_VAR(); /* This var may be unused depending upon options. */
+        char *yy_cp = YY_G(yy_c_buf_p);
+        
+%# /* Translation of gen_NUL_trans(); defined in gen.c */
+
+m4_ifdef( [[M4_YY_NULTRANS]], [[
+	yy_current_state = yy_NUL_trans[yy_current_state];
+	yy_is_jam = (yy_current_state == 0);
+]], [[
+  m4_ifdef( [[M4_YY_FULLTBL]], [[
+    m4_ifdef( [[M4_YY_GENTABLES]], [[
+	yy_current_state = yy_nxt[yy_current_state][M4_YY_NUL_EC[[]]];
+    ]], [[
+	yy_current_state = yy_nxt[yy_current_state*YY_NXT_LOLEN + M4_YY_NUL_EC[[]]];
+    ]] )
+	yy_is_jam = (yy_current_state <= 0);
+  ]], [[
+    m4_ifdef( [[M4_YY_FULLSPD]], [[
+	int yy_c = M4_YY_NUL_EC[[]];
+	const struct yy_trans_info *yy_trans_info;
+	yy_trans_info = &yy_current_state[(unsigned int) yy_c];
+	yy_current_state += yy_trans_info->yy_nxt;
+	yy_is_jam = (yy_trans_info->yy_verify != yy_c);
+    ]], [[
+%# /*		gen_next_compressed_state ([[M4_YY_NUL_EC]]); */
+	M4_YY_NEXT_COMPRESSED_STATE(M4_YY_NUL_EC)
+		
+	yy_is_jam = (yy_current_state == M4_YY_JAMSTATE[[]]);
+
+      m4_ifdef( [[M4_YY_USES_REJECT]], [[
+	/* Only stack this state if it's a transition we
+	 * actually make.  If we stack it on a jam, then
+	 * the state stack and yy_c_buf_p get out of sync.
+	 */
+	if ( ! yy_is_jam )
+		*YY_G(yy_state_ptr)++ = yy_current_state;
+      ]] )
+    ]] )
+  ]] )
+]] )
+
+m4_ifdef( [[M4_YY_NEEDS_BACKING_UP]], [[
+  m4_ifdef( [[M4_YY_REJECT]], , [[
+    m4_ifdef( [[M4_YY_FULLSPD]], [[
+	if ( ! yy_is_jam )
+	{
+		M4_YY_BACKING_UP
+	}
+    ]], [[
+      m4_ifdef( [[M4_YY_FULLTBL]], [[
+	if ( ! yy_is_jam )
+	{
+		M4_YY_BACKING_UP
+	}
+      ]])
+    ]] )
+  ]] )
+]] )
+
 
 	M4_YY_NOOP_GUTS_VAR();
 return yy_is_jam ? 0 : yy_current_state;
@@ -1773,15 +2817,15 @@ m4_ifdef( [[M4_YY_NO_UNPUT]],,
 %endif
 {
 	char *yy_cp;
-    M4_YY_DECL_GUTS_VAR();
+	M4_YY_DECL_GUTS_VAR();
 
-    yy_cp = YY_G(yy_c_buf_p);
+	yy_cp = YY_G(yy_c_buf_p);
 
 	/* undo effects of setting up yytext */
 	*yy_cp = YY_G(yy_hold_char);
 
 	if ( yy_cp < YY_CURRENT_BUFFER_LVALUE->yy_ch_buf + 2 )
-		{ /* need to shift things up to make room */
+	{ 	/* need to shift things up to make room */
 		/* +2 for EOB chars. */
 		int number_to_move = YY_G(yy_n_chars) + 2;
 		char *dest = &YY_CURRENT_BUFFER_LVALUE->yy_ch_buf[
@@ -1799,16 +2843,15 @@ m4_ifdef( [[M4_YY_NO_UNPUT]],,
 
 		if ( yy_cp < YY_CURRENT_BUFFER_LVALUE->yy_ch_buf + 2 )
 			YY_FATAL_ERROR( "flex scanner push-back overflow" );
-		}
+	}
 
 	*--yy_cp = (char) c;
 
-%% [18.0] update yylineno here
 m4_ifdef( [[M4_YY_USE_LINENO]],
 [[
-    if ( c == '\n' ){
-        --yylineno;
-    }
+	if ( c == '\n' ){
+		--yylineno;
+	}
 ]])
 
 	YY_G(yytext_ptr) = yy_bp;
@@ -1896,8 +2939,22 @@ m4_ifdef( [[M4_YY_USE_LINENO]],
 	*YY_G(yy_c_buf_p) = '\0';	/* preserve yytext */
 	YY_G(yy_hold_char) = *++YY_G(yy_c_buf_p);
 
-%% [19.0] update BOL and yylineno
-
+m4_ifdef( [[M4_YY_BOL_NEEDED]], [[
+	YY_CURRENT_BUFFER_LVALUE->yy_at_bol = (c == '\n');
+  m4_ifdef( [[M4_YY_LINENO]], [[
+	if ( YY_CURRENT_BUFFER_LVALUE->yy_at_bol )
+	{
+		M4_YY_INCR_LINENO();
+	}
+  ]] )
+]], [[
+  m4_ifdef( [[M4_YY_LINENO]], [[
+	if ( c == '\n' )
+	{
+		M4_YY_INCR_LINENO();
+	}
+  ]] )
+]] )
 	return c;
 }
 %if-c-only

--- a/src/flexdef.h
+++ b/src/flexdef.h
@@ -399,6 +399,7 @@ extern int trace_hex;
  * action_offset - index where the non-prolog starts in action_array
  * action_index - index where the next action should go, with respect
  * 	to "action_array"
+ * always_interactive - if true, generate an interactive scanner
  */
 
 extern int datapos, dataline, linenum;
@@ -730,45 +731,13 @@ extern void mkechar(int, int[], int[]);
 
 /* from file gen.c */
 
-extern void do_indent(void);	/* indent to the current level */
-
-/* Generate the code to keep backing-up information. */
-extern void gen_backing_up(void);
-
-/* Generate the code to perform the backing up. */
-extern void gen_bu_action(void);
-
 /* Generate full speed compressed transition table. */
 extern void genctbl(void);
 
-/* Generate the code to find the action number. */
-extern void gen_find_action(void);
-
 extern void genftbl(void);	/* generate full transition table */
-
-/* Generate the code to find the next compressed-table state. */
-extern void gen_next_compressed_state(char *);
-
-/* Generate the code to find the next match. */
-extern void gen_next_match(void);
-
-/* Generate the code to find the next state. */
-extern void gen_next_state(int);
-
-/* Generate the code to make a NUL transition. */
-extern void gen_NUL_trans(void);
-
-/* Generate the code to find the start state. */
-extern void gen_start_state(void);
 
 /* Generate data statements for the transition tables. */
 extern void gentabs(void);
-
-/* Write out a formatted string at the current indentation level. */
-extern void indent_put2s(const char *, const char *);
-
-/* Write out a string + newline at the current indentation level. */
-extern void indent_puts(const char *);
 
 extern void make_tables(void);	/* generate transition tables */
 
@@ -884,11 +853,15 @@ extern void out_dec(const char *, int);
 extern void out_dec2(const char *, int, int);
 extern void out_hex(const char *, unsigned int);
 extern void out_str(const char *, const char *);
+extern void out_str2(const char *, const char *, const char *);
 extern void out_str3(const char *, const char *, const char *, const char *);
 extern void out_str_dec(const char *, const char *, int);
+extern void out_str2_dec (const char *, const char *, const char *, int);
 extern void outc(int);
 extern void outn(const char *);
 extern void out_m4_define(const char* def, const char* val);
+extern void out_m4_define_dec(const char* def, const int val);
+extern void out_m4_define_hex(const char* def, const unsigned int val);
 
 /* Return a printable version of the given character, which might be
  * 8-bit.
@@ -1048,6 +1021,7 @@ extern struct Buf *buf_strappend(struct Buf *, const char *str);
 extern struct Buf *buf_strnappend(struct Buf *, const char *str, int nchars);
 extern struct Buf *buf_strdefine(struct Buf * buf, const char *str, const char *def);
 extern struct Buf *buf_prints(struct Buf *buf, const char *fmt, const char* s);
+extern struct Buf *buf_printns(struct Buf *buf, const char *fmt, const int count, ...);
 extern struct Buf *buf_m4_define(struct Buf *buf, const char* def, const char* val);
 extern struct Buf *buf_m4_undefine(struct Buf *buf, const char* def);
 extern struct Buf *buf_print_strings(struct Buf * buf, FILE* out);

--- a/src/gen.c
+++ b/src/gen.c
@@ -39,63 +39,46 @@
 
 void	genecs(void);
 
-
-static int indent_level = 0;	/* each level is 8 spaces */
-
-#define set_indent(indent_val) indent_level = indent_val
-
 /* Almost everything is done in terms of arrays starting at 1, so provide
  * a null entry for the zero element of all C arrays.  (The exception
  * to this is that the fast table representation generally uses the
  * 0 elements of its arrays, too.)
  */
 
-static const char *get_int16_decl (void)
+static const char *get_int_decl (void)
 {
 	return (gentables)
-		? "static const flex_int16_t %s[%d] =\n    {   0,\n"
-		: "static const flex_int16_t * %s = 0;\n";
+		? "DEFINE_ARRAY( %s, %d )"
+		: "DEFINE_TABLE_EMPTY( %s )";
 }
-
 
 static const char *get_int32_decl (void)
 {
 	return (gentables)
-		? "static const flex_int32_t %s[%d] =\n    {   0,\n"
-		: "static const flex_int32_t * %s = 0;\n";
+               ? "DEFINE_LONG_ARRAY( %s, %d )"
+               : "DEFINE_LONG_TABLE_EMPTY( %s )";
 }
 
 static const char *get_state_decl (void)
 {
 	return (gentables)
-		? "static const yy_state_type %s[%d] =\n    {   0,\n"
-		: "static const yy_state_type * %s = 0;\n";
+               ? "DEFINE_STATE_ARRAY( %s, %d )"
+               : "DEFINE_STATE_TABLE_EMPTY( %s )";
+}
+
+static const char *get_typed_decl (void)
+{
+	return (gentables)
+	       ? "DEFINE_TYPE_ARRAY( %s, %s, %d )"
+	       : "DEFINE_TYPE_TABLE_EMPTY( %s, %s )";
 }
 
 static const char *get_yy_char_decl (void)
 {
 	return (gentables)
-		? "static const YY_CHAR %s[%d] =\n    {   0,\n"
-		: "static const YY_CHAR * %s = 0;\n";
+               ? "DEFINE_CHAR_ARRAY( %s, %d )"
+               : "DEFINE_CHAR_TABLE_EMPTY( %s )";
 }
-
-/* Indent to the current level. */
-
-void do_indent (void)
-{
-	int i = indent_level * 8;
-
-	while (i >= 8) {
-		outc ('\t');
-		i -= 8;
-	}
-
-	while (i > 0) {
-		outc (' ');
-		--i;
-	}
-}
-
 
 /** Make the table for possible eol matches.
  *  @return the newly allocated rule_can_match_eol table
@@ -116,9 +99,7 @@ static struct yytbl_data *mkeoltbl (void)
 	for (i = 1; i <= num_rules; i++)
 		tdata[i] = rule_has_nl[i] ? 1 : 0;
 
-	buf_prints (&yydmap_buf,
-		    "\t{YYTD_ID_RULE_CAN_MATCH_EOL, (void**)&yy_rule_can_match_eol, sizeof(%s)},\n",
-		    "flex_int32_t");
+	buf_strappend (&yydmap_buf, "INDENT[[]]YYDMAP_ENTRY_LONG(YYTD_ID_RULE_CAN_MATCH_EOL, yy_rule_can_match_eol)");
 	return tbl;
 }
 
@@ -134,65 +115,17 @@ static void geneoltbl (void)
 
 	if (gentables) {
 		for (i = 1; i <= num_rules; i++) {
-			out_dec ("%d, ", rule_has_nl[i] ? 1 : 0);
+			out_dec ("TABLE_DATA(%5d)[[]]COLUMN_SEPARATOR[[]]", rule_has_nl[i] ? 1 : 0);
 			/* format nicely, 20 numbers per line. */
 			if ((i % 20) == 19)
-				out ("\n    ");
+				out ("TABLE_BLOCK[[]]INDENT[[]]");
 		}
-		out ("    };\n");
+		dataend();
 	}
 	outn ("]])");
 }
 
 
-/* Generate the code to keep backing-up information. */
-
-void gen_backing_up (void)
-{
-	if (reject || num_backing_up == 0)
-		return;
-
-	if (fullspd)
-		indent_puts ("if ( yy_current_state[-1].yy_nxt )");
-	else
-		indent_puts ("if ( yy_accept[yy_current_state] )");
-
-	++indent_level;
-	indent_puts ("{");
-	indent_puts ("YY_G(yy_last_accepting_state) = yy_current_state;");
-	indent_puts ("YY_G(yy_last_accepting_cpos) = yy_cp;");
-	indent_puts ("}");
-	--indent_level;
-}
-
-
-/* Generate the code to perform the backing up. */
-
-void gen_bu_action (void)
-{
-	if (reject || num_backing_up == 0)
-		return;
-
-	set_indent (3);
-
-	indent_puts ("case 0: /* must back up */");
-	indent_puts ("/* undo the effects of YY_DO_BEFORE_ACTION */");
-	indent_puts ("*yy_cp = YY_G(yy_hold_char);");
-
-	if (fullspd || fulltbl)
-		indent_puts ("yy_cp = YY_G(yy_last_accepting_cpos) + 1;");
-	else
-		/* Backing-up info for compressed tables is taken \after/
-		 * yy_cp has been incremented for the next state.
-		 */
-		indent_puts ("yy_cp = YY_G(yy_last_accepting_cpos);");
-
-	indent_puts ("yy_current_state = YY_G(yy_last_accepting_state);");
-	indent_puts ("goto yy_find_action;");
-	outc ('\n');
-
-	set_indent (0);
-}
 
 /** mkctbl - make full speed compressed transition table
  * This is an array of structs; each struct a pair of integers.
@@ -208,10 +141,12 @@ static struct yytbl_data *mkctbl (void)
 	flex_int32_t *tdata = 0, curr = 0;
 	int     end_of_buffer_action = num_rules + 1;
 
-	buf_prints (&yydmap_buf,
-		    "\t{YYTD_ID_TRANSITION, (void**)&yy_transition, sizeof(%s)},\n",
-		    ((tblend + numecs + 1) >= INT16_MAX
-		     || long_align) ? "flex_int32_t" : "flex_int16_t");
+        if( (tblend + numecs + 1) >= INT16_MAX ) {
+		buf_strappend (&yydmap_buf, "INDENT[[]]YYDMAP_ENTRY_LONG(YYTD_ID_TRANSITION, yy_transition)");
+        }
+        else {
+		buf_strappend (&yydmap_buf, "INDENT[[]]YYDMAP_ENTRY(YYTD_ID_TRANSITION, yy_transition)");
+        }
 
 	tbl = calloc(1, sizeof (struct yytbl_data));
 	yytbl_data_init (tbl, YYTD_ID_TRANSITION);
@@ -321,9 +256,9 @@ static struct yytbl_data *mkssltbl (void)
 	for (i = 0; i <= lastsc * 2; ++i)
 		tdata[i] = base[i];
 
-	buf_prints (&yydmap_buf,
-		    "\t{YYTD_ID_START_STATE_LIST, (void**)&yy_start_state_list, sizeof(%s)},\n",
-		    "struct yy_trans_info*");
+	buf_strappend (&yydmap_buf, "INDENT[[]]" \
+                       "YYDMAP_ENTRY_TYPE(YYTD_ID_START_STATE_LIST," \
+                       "yy_start_state_list, M4_YY_TRANS_INFO_P_TYPE)");
 
 	return tbl;
 }
@@ -339,9 +274,10 @@ void genctbl (void)
 
 	/* Table of verify for transition and offset to next state. */
 	if (gentables)
-		out_dec ("static const struct yy_trans_info yy_transition[%d] =\n    {\n", tblend + numecs + 1);
+		out_str2_dec (get_typed_decl(), "M4_YY_TRANS_INFO_TYPE", "yy_transition", tblend + numecs + 1);
+              
 	else
-		outn ("static const struct yy_trans_info *yy_transition = 0;");
+		out_str2 (get_typed_decl(), "M4_YY_TRANS_INFO_P_TYPE", "yy_transition");
 
 	/* We want the transition to be represented as the offset to the
 	 * next state, not the actual state number, which is what it currently
@@ -408,20 +344,19 @@ void genctbl (void)
 	transition_struct_out (chk[tblend + 1], nxt[tblend + 1]);
 	transition_struct_out (chk[tblend + 2], nxt[tblend + 2]);
 
-	if (gentables)
-		outn ("    };\n");
+	dataend();
 
 	/* Table of pointers to start states. */
 	if (gentables)
-		out_dec ("static const struct yy_trans_info *yy_start_state_list[%d] =\n", lastsc * 2 + 1);
+		out_str2_dec (get_typed_decl(), "M4_YY_TRANS_INFO_P_TYPE", "yy_start_state_list", lastsc * 2 + 1);
 	else
-		outn ("static const struct yy_trans_info **yy_start_state_list =0;");
+		out_str2 (get_typed_decl(), "M4_YY_TRANS_INFO_PP_TYPE", "yy_start_state_list");
 
 	if (gentables) {
-		outn ("    {");
+		
 
 		for (i = 0; i <= lastsc * 2; ++i)
-			out_dec ("    &yy_transition[%d],\n", base[i]);
+			out_dec ("REFERENCE_TABLE_ENTRY(yy_transition, %d)[[]]COLUMN_SEPARATOR[[]]TABLE_BLOCK[[]]", base[i]);
 
 		dataend ();
 	}
@@ -453,9 +388,7 @@ static struct yytbl_data *mkecstbl (void)
 		tdata[i] = ecgroup[i];
 	}
 
-	buf_prints (&yydmap_buf,
-		    "\t{YYTD_ID_EC, (void**)&yy_ec, sizeof(%s)},\n",
-		    "YY_CHAR");
+	buf_strappend (&yydmap_buf, "INDENT[[]]YYDMAP_ENTRY_TYPE(YYTD_ID_EC, yy_ec, YY_CHAR)");
 
 	return tbl;
 }
@@ -496,149 +429,6 @@ void genecs (void)
 }
 
 
-/* Generate the code to find the action number. */
-
-void gen_find_action (void)
-{
-	if (fullspd)
-		indent_puts ("yy_act = yy_current_state[-1].yy_nxt;");
-
-	else if (fulltbl)
-		indent_puts ("yy_act = yy_accept[yy_current_state];");
-
-	else if (reject) {
-		indent_puts ("yy_current_state = *--YY_G(yy_state_ptr);");
-		indent_puts ("YY_G(yy_lp) = yy_accept[yy_current_state];");
-
-		if (!variable_trailing_context_rules)
-			outn ("m4_ifdef( [[M4_YY_USES_REJECT]],\n[[");
-		if(reject_really_used)
-			outn ("find_rule: /* we branch to this label when backing up */");
-		if (!variable_trailing_context_rules)
-			outn ("]])\n");
-
-		indent_puts
-			("for ( ; ; ) /* until we find what rule we matched */");
-
-		++indent_level;
-
-		indent_puts ("{");
-
-		indent_puts
-			("if ( YY_G(yy_lp) && YY_G(yy_lp) < yy_accept[yy_current_state + 1] )");
-		++indent_level;
-		indent_puts ("{");
-		indent_puts ("yy_act = yy_acclist[YY_G(yy_lp)];");
-
-		if (variable_trailing_context_rules) {
-			indent_puts
-				("if ( yy_act & YY_TRAILING_HEAD_MASK ||");
-			indent_puts ("     YY_G(yy_looking_for_trail_begin) )");
-			++indent_level;
-			indent_puts ("{");
-
-			indent_puts
-				("if ( yy_act == YY_G(yy_looking_for_trail_begin) )");
-			++indent_level;
-			indent_puts ("{");
-			indent_puts ("YY_G(yy_looking_for_trail_begin) = 0;");
-			indent_puts ("yy_act &= ~YY_TRAILING_HEAD_MASK;");
-			indent_puts ("break;");
-			indent_puts ("}");
-			--indent_level;
-
-			indent_puts ("}");
-			--indent_level;
-
-			indent_puts
-				("else if ( yy_act & YY_TRAILING_MASK )");
-			++indent_level;
-			indent_puts ("{");
-			indent_puts
-				("YY_G(yy_looking_for_trail_begin) = yy_act & ~YY_TRAILING_MASK;");
-			indent_puts
-				("YY_G(yy_looking_for_trail_begin) |= YY_TRAILING_HEAD_MASK;");
-
-			if (real_reject) {
-				/* Remember matched text in case we back up
-				 * due to REJECT.
-				 */
-				indent_puts
-					("YY_G(yy_full_match) = yy_cp;");
-				indent_puts
-					("YY_G(yy_full_state) = YY_G(yy_state_ptr);");
-				indent_puts ("YY_G(yy_full_lp) = YY_G(yy_lp);");
-			}
-
-			indent_puts ("}");
-			--indent_level;
-
-			indent_puts ("else");
-			++indent_level;
-			indent_puts ("{");
-			indent_puts ("YY_G(yy_full_match) = yy_cp;");
-			indent_puts
-				("YY_G(yy_full_state) = YY_G(yy_state_ptr);");
-			indent_puts ("YY_G(yy_full_lp) = YY_G(yy_lp);");
-			indent_puts ("break;");
-			indent_puts ("}");
-			--indent_level;
-
-			indent_puts ("++YY_G(yy_lp);");
-			indent_puts ("goto find_rule;");
-		}
-
-		else {
-			/* Remember matched text in case we back up due to
-			 * trailing context plus REJECT.
-			 */
-			++indent_level;
-			indent_puts ("{");
-			indent_puts ("YY_G(yy_full_match) = yy_cp;");
-			indent_puts ("break;");
-			indent_puts ("}");
-			--indent_level;
-		}
-
-		indent_puts ("}");
-		--indent_level;
-
-		indent_puts ("--yy_cp;");
-
-		/* We could consolidate the following two lines with those at
-		 * the beginning, but at the cost of complaints that we're
-		 * branching inside a loop.
-		 */
-		indent_puts ("yy_current_state = *--YY_G(yy_state_ptr);");
-		indent_puts ("YY_G(yy_lp) = yy_accept[yy_current_state];");
-
-		indent_puts ("}");
-
-		--indent_level;
-	}
-
-	else {			/* compressed */
-		indent_puts ("yy_act = yy_accept[yy_current_state];");
-
-		if (interactive && !reject) {
-			/* Do the guaranteed-needed backing up to figure out
-			 * the match.
-			 */
-			indent_puts ("if ( yy_act == 0 )");
-			++indent_level;
-			indent_puts ("{ /* have to back up */");
-			indent_puts
-				("yy_cp = YY_G(yy_last_accepting_cpos);");
-			indent_puts
-				("yy_current_state = YY_G(yy_last_accepting_state);");
-			indent_puts
-				("yy_act = yy_accept[yy_current_state];");
-			indent_puts ("}");
-			--indent_level;
-		}
-	}
-}
-
 /* mkftbl - make the full table and return the struct .
  * you should call mkecstbl() after this.
  */
@@ -671,9 +461,8 @@ struct yytbl_data *mkftbl (void)
 				 i, anum);
 	}
 
-	buf_prints (&yydmap_buf,
-		    "\t{YYTD_ID_ACCEPT, (void**)&yy_accept, sizeof(%s)},\n",
-		    long_align ? "flex_int32_t" : "flex_int16_t");
+	buf_strappend (&yydmap_buf, "INDENT[[]]YYDMAP_ENTRY(YYTD_ID_ACCEPT, yy_accept)");
+
 	return tbl;
 }
 
@@ -685,8 +474,7 @@ void genftbl (void)
 	int i;
 	int     end_of_buffer_action = num_rules + 1;
 
-	out_str_dec (long_align ? get_int32_decl () : get_int16_decl (),
-		     "yy_accept", lastdfa + 1);
+	out_str_dec (get_int_decl (), "yy_accept", lastdfa + 1);
 
 	dfaacc[end_of_buffer_state].dfaacc_state = end_of_buffer_action;
 
@@ -709,345 +497,6 @@ void genftbl (void)
 	 * created on-the-fly.
 	 */
 }
-
-
-/* Generate the code to find the next compressed-table state. */
-
-void gen_next_compressed_state (char *char_map)
-{
-	indent_put2s ("YY_CHAR yy_c = %s;", char_map);
-
-	/* Save the backing-up info \before/ computing the next state
-	 * because we always compute one more state than needed - we
-	 * always proceed until we reach a jam state
-	 */
-	gen_backing_up ();
-
-	indent_puts
-		("while ( yy_chk[yy_base[yy_current_state] + yy_c] != yy_current_state )");
-	++indent_level;
-	indent_puts ("{");
-	indent_puts ("yy_current_state = (int) yy_def[yy_current_state];");
-
-	if (usemecs) {
-		/* We've arrange it so that templates are never chained
-		 * to one another.  This means we can afford to make a
-		 * very simple test to see if we need to convert to
-		 * yy_c's meta-equivalence class without worrying
-		 * about erroneously looking up the meta-equivalence
-		 * class twice
-		 */
-		do_indent ();
-
-		/* lastdfa + 2 is the beginning of the templates */
-		out_dec ("if ( yy_current_state >= %d )\n", lastdfa + 2);
-
-		++indent_level;
-		indent_puts ("yy_c = yy_meta[yy_c];");
-		--indent_level;
-	}
-
-	indent_puts ("}");
-	--indent_level;
-
-	indent_puts
-		("yy_current_state = yy_nxt[yy_base[yy_current_state] + yy_c];");
-}
-
-
-/* Generate the code to find the next match. */
-
-void gen_next_match (void)
-{
-	/* NOTE - changes in here should be reflected in gen_next_state() and
-	 * gen_NUL_trans().
-	 */
-	char   *char_map = useecs ?
-		"yy_ec[YY_SC_TO_UI(*yy_cp)] " : "YY_SC_TO_UI(*yy_cp)";
-
-	char   *char_map_2 = useecs ?
-		"yy_ec[YY_SC_TO_UI(*++yy_cp)] " : "YY_SC_TO_UI(*++yy_cp)";
-
-	if (fulltbl) {
-		if (gentables)
-			indent_put2s
-				("while ( (yy_current_state = yy_nxt[yy_current_state][ %s ]) > 0 )",
-				 char_map);
-		else
-			indent_put2s
-				("while ( (yy_current_state = yy_nxt[yy_current_state*YY_NXT_LOLEN +  %s ]) > 0 )",
-				 char_map);
-
-		++indent_level;
-
-		if (num_backing_up > 0) {
-			indent_puts ("{");
-			gen_backing_up ();
-			outc ('\n');
-		}
-
-		indent_puts ("++yy_cp;");
-
-		if (num_backing_up > 0)
-
-			indent_puts ("}");
-
-		--indent_level;
-
-		outc ('\n');
-		indent_puts ("yy_current_state = -yy_current_state;");
-	}
-
-	else if (fullspd) {
-		indent_puts ("{");
-		indent_puts
-			("const struct yy_trans_info *yy_trans_info;\n");
-		indent_puts ("YY_CHAR yy_c;\n");
-		indent_put2s ("for ( yy_c = %s;", char_map);
-		indent_puts
-			("      (yy_trans_info = &yy_current_state[yy_c])->");
-		indent_puts ("yy_verify == yy_c;");
-		indent_put2s ("      yy_c = %s )", char_map_2);
-
-		++indent_level;
-
-		if (num_backing_up > 0)
-			indent_puts ("{");
-
-		indent_puts ("yy_current_state += yy_trans_info->yy_nxt;");
-
-		if (num_backing_up > 0) {
-			outc ('\n');
-			gen_backing_up ();
-			indent_puts ("}");
-		}
-
-		--indent_level;
-		indent_puts ("}");
-	}
-
-	else {			/* compressed */
-		indent_puts ("do");
-
-		++indent_level;
-		indent_puts ("{");
-
-		gen_next_state (false);
-
-		indent_puts ("++yy_cp;");
-
-
-		indent_puts ("}");
-		--indent_level;
-
-		do_indent ();
-
-		if (interactive)
-			out_dec ("while ( yy_base[yy_current_state] != %d );\n", jambase);
-		else
-			out_dec ("while ( yy_current_state != %d );\n",
-				 jamstate);
-
-		if (!reject && !interactive) {
-			/* Do the guaranteed-needed backing up to figure out
-			 * the match.
-			 */
-			indent_puts
-				("yy_cp = YY_G(yy_last_accepting_cpos);");
-			indent_puts
-				("yy_current_state = YY_G(yy_last_accepting_state);");
-		}
-	}
-}
-
-
-/* Generate the code to find the next state. */
-
-void gen_next_state (int worry_about_NULs)
-{				/* NOTE - changes in here should be reflected in gen_next_match() */
-	char    char_map[256];
-
-	if (worry_about_NULs && !nultrans) {
-		if (useecs)
-			snprintf (char_map, sizeof(char_map),
-					"(*yy_cp ? yy_ec[YY_SC_TO_UI(*yy_cp)] : %d)",
-					NUL_ec);
-		else
-            snprintf (char_map, sizeof(char_map),
-					"(*yy_cp ? YY_SC_TO_UI(*yy_cp) : %d)",
-					NUL_ec);
-	}
-
-	else
-		strcpy (char_map, useecs ?
-			"yy_ec[YY_SC_TO_UI(*yy_cp)] " :
-			"YY_SC_TO_UI(*yy_cp)");
-
-	if (worry_about_NULs && nultrans) {
-		if (!fulltbl && !fullspd)
-			/* Compressed tables back up *before* they match. */
-			gen_backing_up ();
-
-		indent_puts ("if ( *yy_cp )");
-		++indent_level;
-		indent_puts ("{");
-	}
-
-	if (fulltbl) {
-		if (gentables)
-			indent_put2s
-				("yy_current_state = yy_nxt[yy_current_state][%s];",
-				 char_map);
-		else
-			indent_put2s
-				("yy_current_state = yy_nxt[yy_current_state*YY_NXT_LOLEN + %s];",
-				 char_map);
-	}
-
-	else if (fullspd)
-		indent_put2s
-			("yy_current_state += yy_current_state[%s].yy_nxt;",
-			 char_map);
-
-	else
-		gen_next_compressed_state (char_map);
-
-	if (worry_about_NULs && nultrans) {
-
-		indent_puts ("}");
-		--indent_level;
-		indent_puts ("else");
-		++indent_level;
-		indent_puts
-			("yy_current_state = yy_NUL_trans[yy_current_state];");
-		--indent_level;
-	}
-
-	if (fullspd || fulltbl)
-		gen_backing_up ();
-
-	if (reject)
-		indent_puts ("*YY_G(yy_state_ptr)++ = yy_current_state;");
-}
-
-
-/* Generate the code to make a NUL transition. */
-
-void gen_NUL_trans (void)
-{				/* NOTE - changes in here should be reflected in gen_next_match() */
-	/* Only generate a definition for "yy_cp" if we'll generate code
-	 * that uses it.  Otherwise lint and the like complain.
-	 */
-	int     need_backing_up = (num_backing_up > 0 && !reject);
-
-	if (need_backing_up && (!nultrans || fullspd || fulltbl))
-		/* We're going to need yy_cp lying around for the call
-		 * below to gen_backing_up().
-		 */
-		indent_puts ("char *yy_cp = YY_G(yy_c_buf_p);");
-
-	outc ('\n');
-
-	if (nultrans) {
-		indent_puts
-			("yy_current_state = yy_NUL_trans[yy_current_state];");
-		indent_puts ("yy_is_jam = (yy_current_state == 0);");
-	}
-
-	else if (fulltbl) {
-		do_indent ();
-		if (gentables)
-			out_dec ("yy_current_state = yy_nxt[yy_current_state][%d];\n", NUL_ec);
-		else
-			out_dec ("yy_current_state = yy_nxt[yy_current_state*YY_NXT_LOLEN + %d];\n", NUL_ec);
-		indent_puts ("yy_is_jam = (yy_current_state <= 0);");
-	}
-
-	else if (fullspd) {
-		do_indent ();
-		out_dec ("int yy_c = %d;\n", NUL_ec);
-
-		indent_puts
-			("const struct yy_trans_info *yy_trans_info;\n");
-		indent_puts
-			("yy_trans_info = &yy_current_state[(unsigned int) yy_c];");
-		indent_puts ("yy_current_state += yy_trans_info->yy_nxt;");
-
-		indent_puts
-			("yy_is_jam = (yy_trans_info->yy_verify != yy_c);");
-	}
-
-	else {
-		char    NUL_ec_str[20];
-
-		snprintf (NUL_ec_str, sizeof(NUL_ec_str), "%d", NUL_ec);
-		gen_next_compressed_state (NUL_ec_str);
-
-		do_indent ();
-		out_dec ("yy_is_jam = (yy_current_state == %d);\n",
-			 jamstate);
-
-		if (reject) {
-			/* Only stack this state if it's a transition we
-			 * actually make.  If we stack it on a jam, then
-			 * the state stack and yy_c_buf_p get out of sync.
-			 */
-			indent_puts ("if ( ! yy_is_jam )");
-			++indent_level;
-			indent_puts
-				("*YY_G(yy_state_ptr)++ = yy_current_state;");
-			--indent_level;
-		}
-	}
-
-	/* If we've entered an accepting state, back up; note that
-	 * compressed tables have *already* done such backing up, so
-	 * we needn't bother with it again.
-	 */
-	if (need_backing_up && (fullspd || fulltbl)) {
-		outc ('\n');
-		indent_puts ("if ( ! yy_is_jam )");
-		++indent_level;
-		indent_puts ("{");
-		gen_backing_up ();
-		indent_puts ("}");
-		--indent_level;
-	}
-}
-
-
-/* Generate the code to find the start state. */
-
-void gen_start_state (void)
-{
-	if (fullspd) {
-		if (bol_needed) {
-			indent_puts
-				("yy_current_state = yy_start_state_list[YY_G(yy_start) + YY_AT_BOL()];");
-		}
-		else
-			indent_puts
-				("yy_current_state = yy_start_state_list[YY_G(yy_start)];");
-	}
-
-	else {
-		indent_puts ("yy_current_state = YY_G(yy_start);");
-
-		if (bol_needed)
-			indent_puts ("yy_current_state += YY_AT_BOL();");
-
-		if (reject) {
-			/* Set up for storing up states. */
-			outn ("m4_ifdef( [[M4_YY_USES_REJECT]],\n[[");
-			indent_puts
-				("YY_G(yy_state_ptr) = YY_G(yy_state_buf);");
-			indent_puts
-				("*YY_G(yy_state_ptr)++ = yy_current_state;");
-			outn ("]])");
-		}
-	}
-}
-
 
 /* gentabs - generate data statements for the transition tables */
 
@@ -1087,13 +536,9 @@ void gentabs (void)
 		dfaacc[end_of_buffer_state].dfaacc_set =
 			EOB_accepting_list;
 
-		out_str_dec (long_align ? get_int32_decl () :
-			     get_int16_decl (), "yy_acclist", MAX (numas,
-								   1) + 1);
+		out_str_dec (get_int_decl(), "yy_acclist", MAX (numas, 1) + 1);
         
-        buf_prints (&yydmap_buf,
-                "\t{YYTD_ID_ACCLIST, (void**)&yy_acclist, sizeof(%s)},\n",
-                long_align ? "flex_int32_t" : "flex_int16_t");
+        buf_strappend (&yydmap_buf, "INDENT[[]]YYDMAP_ENTRY(YYTD_ID_ACCLIST, yy_acclist)");
 
         yyacclist_tbl = calloc(1,sizeof(struct yytbl_data));
         yytbl_data_init (yyacclist_tbl, YYTD_ID_ACCLIST);
@@ -1197,12 +642,9 @@ void gentabs (void)
 		 */
 		++k;
 
-	out_str_dec (long_align ? get_int32_decl () : get_int16_decl (),
-		     "yy_accept", k);
+	out_str_dec (get_int_decl (), "yy_accept", k);
 
-	buf_prints (&yydmap_buf,
-		    "\t{YYTD_ID_ACCEPT, (void**)&yy_accept, sizeof(%s)},\n",
-		    long_align ? "flex_int32_t" : "flex_int16_t");
+	buf_strappend (&yydmap_buf, "INDENT[[]]YYDMAP_ENTRY(YYTD_ID_ACCEPT, yy_accept)");
 
 	yyacc_tbl = calloc(1, sizeof (struct yytbl_data));
 	yytbl_data_init (yyacc_tbl, YYTD_ID_ACCEPT);
@@ -1273,9 +715,7 @@ void gentabs (void)
 			       stderr);
 
 		out_str_dec (get_yy_char_decl (), "yy_meta", numecs + 1);
-		buf_prints (&yydmap_buf,
-			    "\t{YYTD_ID_META, (void**)&yy_meta, sizeof(%s)},\n",
-			    "YY_CHAR");
+		buf_strappend (&yydmap_buf,"INDENT[[]]YYDMAP_ENTRY_TYPE(YYTD_ID_META, yy_meta, YY_CHAR)");
 
 		for (i = 1; i <= numecs; ++i) {
 			if (trace)
@@ -1301,13 +741,15 @@ void gentabs (void)
 
 	/* Begin generating yy_base */
 	out_str_dec ((tblend >= INT16_MAX || long_align) ?
-		     get_int32_decl () : get_int16_decl (),
+		     get_int32_decl () : get_int_decl (),
 		     "yy_base", total_states + 1);
 
-	buf_prints (&yydmap_buf,
-		    "\t{YYTD_ID_BASE, (void**)&yy_base, sizeof(%s)},\n",
-		    (tblend >= INT16_MAX
-		     || long_align) ? "flex_int32_t" : "flex_int16_t");
+	if( tblend >= INT16_MAX ) {
+		buf_strappend (&yydmap_buf, "INDENT[[]]YYDMAP_ENTRY_TYPE(YYTD_ID_BASE, yy_base, flex_int32_t)");
+	}
+	else {
+		buf_strappend (&yydmap_buf, "INDENT[[]]YYDMAP_ENTRY_TYPE(YYTD_ID_BASE, yy_base, YY_INT_ALIGNED)");
+	}
 	yybase_tbl = calloc (1, sizeof (struct yytbl_data));
 	yytbl_data_init (yybase_tbl, YYTD_ID_BASE);
 	yybase_tbl->td_lolen = (flex_uint32_t) (total_states + 1);
@@ -1358,14 +800,15 @@ void gentabs (void)
 
 	/* Begin generating yy_def */
 	out_str_dec ((total_states >= INT16_MAX || long_align) ?
-		     get_int32_decl () : get_int16_decl (),
+		     get_int32_decl () : get_int_decl (),
 		     "yy_def", total_states + 1);
 
-	buf_prints (&yydmap_buf,
-		    "\t{YYTD_ID_DEF, (void**)&yy_def, sizeof(%s)},\n",
-		    (total_states >= INT16_MAX
-		     || long_align) ? "flex_int32_t" : "flex_int16_t");
-
+	if( total_states >= INT16_MAX ) {
+          buf_strappend (&yydmap_buf, "INDENT[[]]YYDMAP_ENTRY_TYPE(YYTD_ID_DEF, yy_def, flex_int32_t)");
+	}
+	else {
+          buf_strappend (&yydmap_buf, "INDENT[[]]YYDMAP_ENTRY_TYPE(YYTD_ID_DEF, yy_def, YY_INT_ALIGNED)");
+	}
 	yydef_tbl = calloc(1, sizeof (struct yytbl_data));
 	yytbl_data_init (yydef_tbl, YYTD_ID_DEF);
 	yydef_tbl->td_lolen = (flex_uint32_t) (total_states + 1);
@@ -1390,14 +833,15 @@ void gentabs (void)
 
 	/* Begin generating yy_nxt */
 	out_str_dec ((total_states >= INT16_MAX || long_align) ?
-		     get_int32_decl () : get_int16_decl (), "yy_nxt",
+		     get_int32_decl () : get_int_decl (), "yy_nxt",
 		     tblend + 1);
 
-	buf_prints (&yydmap_buf,
-		    "\t{YYTD_ID_NXT, (void**)&yy_nxt, sizeof(%s)},\n",
-		    (total_states >= INT16_MAX
-		     || long_align) ? "flex_int32_t" : "flex_int16_t");
-
+	if( total_states >= INT16_MAX ) {
+          buf_strappend (&yydmap_buf, "INDENT[[]]YYDMAP_ENTRY_TYPE(YYTD_ID_NXT, yy_nxt, flex_int32_t)");
+	}
+	else {
+          buf_strappend (&yydmap_buf, "INDENT[[]]YYDMAP_ENTRY_TYPE(YYTD_ID_NXT, yy_nxt, YY_INT_ALIGNED)");
+	}
 	yynxt_tbl = calloc (1, sizeof (struct yytbl_data));
 	yytbl_data_init (yynxt_tbl, YYTD_ID_NXT);
 	yynxt_tbl->td_lolen = (flex_uint32_t) (tblend + 1);
@@ -1427,14 +871,15 @@ void gentabs (void)
 
 	/* Begin generating yy_chk */
 	out_str_dec ((total_states >= INT16_MAX || long_align) ?
-		     get_int32_decl () : get_int16_decl (), "yy_chk",
+		     get_int32_decl () : get_int_decl (), "yy_chk",
 		     tblend + 1);
 
-	buf_prints (&yydmap_buf,
-		    "\t{YYTD_ID_CHK, (void**)&yy_chk, sizeof(%s)},\n",
-		    (total_states >= INT16_MAX
-		     || long_align) ? "flex_int32_t" : "flex_int16_t");
-
+	if( total_states >= INT16_MAX ) {
+          buf_strappend (&yydmap_buf, "INDENT[[]]YYDMAP_ENTRY_TYPE(YYTD_ID_CHK, yy_chk, flex_int32_t)");
+	}
+	else {
+          buf_strappend (&yydmap_buf, "INDENT[[]]YYDMAP_ENTRY_TYPE(YYTD_ID_CHK, yy_chk, YY_INT_ALIGNED)");
+	}
 	yychk_tbl = calloc (1, sizeof (struct yytbl_data));
 	yytbl_data_init (yychk_tbl, YYTD_ID_CHK);
 	yychk_tbl->td_lolen = (flex_uint32_t) (tblend + 1);
@@ -1463,29 +908,6 @@ void gentabs (void)
 }
 
 
-/* Write out a formatted string (with a secondary string argument) at the
- * current indentation level, adding a final newline.
- */
-
-void indent_put2s (const char *fmt, const char *arg)
-{
-	do_indent ();
-	out_str (fmt, arg);
-	outn ("");
-}
-
-
-/* Write out a string at the current indentation level, adding a final
- * newline.
- */
-
-void indent_puts (const char *str)
-{
-	do_indent ();
-	outn (str);
-}
-
-
 /* make_tables - generate transition tables and finishes generating output file
  */
 
@@ -1495,108 +917,40 @@ void make_tables (void)
 	int did_eof_rule = false;
 	struct yytbl_data *yynultrans_tbl = NULL;
 
+	out_m4_define_dec("M4_YY_NUM_RULES", num_rules);
+	out_m4_define_dec("M4_YY_END_OF_BUFFER", num_rules + 1);
+        
+        if (interactive)
+          out_m4_define( "M4_YY_INTERACTIVE", NULL );
+        
+        if (!fullspd && !fulltbl) {
+          out_m4_define_dec( "M4_YY_JAMBASE", jambase );
+          out_m4_define_dec( "M4_YY_JAMSTATE", jamstate );
+        }
+        
+        if (nultrans) {
+          out_m4_define( "M4_YY_NULTRANS", NULL );
+        }
+        
+        if (usemecs) {
+          out_m4_define( "M4_YY_USE_MECS", NULL );
+          out_m4_define_dec( "M4_YY_LASTDFA", lastdfa );
+        }
+        
+        if(variable_trailing_context_rules) {
+          out_m4_define("M4_VARIABLE_TRAILING_CONTEXT_RULES", NULL);
+        }
+        out_m4_define_hex ("M4_YY_TRAILING_MASK", (unsigned int) YY_TRAILING_MASK);
+        out_m4_define_hex ("M4_YY_TRAILING_HEAD_MASK", (unsigned int) YY_TRAILING_HEAD_MASK);
+        
+        if (use_read) {
+          out_m4_define("M4_YY_USE_READ", NULL);
+        }
 
-	skelout ();		/* %% [2.0] - break point in skel */
-
-	/* First, take care of YY_DO_BEFORE_ACTION depending on yymore
-	 * being used.
-	 */
-	set_indent (1);
-
-	if (yymore_used && !yytext_is_array) {
-		indent_puts ("YY_G(yytext_ptr) -= YY_G(yy_more_len); \\");
-		indent_puts
-			("yyleng = (int) (yy_cp - YY_G(yytext_ptr)); \\");
-	}
-
-	else
-		indent_puts ("yyleng = (int) (yy_cp - yy_bp); \\");
-
-	/* Now also deal with copying yytext_ptr to yytext if needed. */
-	skelout ();		/* %% [3.0] - break point in skel */
-	if (yytext_is_array) {
-		if (yymore_used)
-			indent_puts
-				("if ( yyleng + YY_G(yy_more_offset) >= YYLMAX ) \\");
-		else
-			indent_puts ("if ( yyleng >= YYLMAX ) \\");
-
-		++indent_level;
-		indent_puts
-			("YY_FATAL_ERROR( \"token too large, exceeds YYLMAX\" ); \\");
-		--indent_level;
-
-		if (yymore_used) {
-			indent_puts
-				("yy_flex_strncpy( &yytext[YY_G(yy_more_offset)], YY_G(yytext_ptr), yyleng + 1 M4_YY_CALL_LAST_ARG); \\");
-			indent_puts ("yyleng += YY_G(yy_more_offset); \\");
-			indent_puts
-				("YY_G(yy_prev_more_offset) = YY_G(yy_more_offset); \\");
-			indent_puts ("YY_G(yy_more_offset) = 0; \\");
-		}
-		else {
-			indent_puts
-				("yy_flex_strncpy( yytext, YY_G(yytext_ptr), yyleng + 1 M4_YY_CALL_LAST_ARG); \\");
-		}
-	}
-
-	set_indent (0);
-
-	skelout ();		/* %% [4.0] - break point in skel */
-
-
-	/* This is where we REALLY begin generating the tables. */
-
-	out_dec ("#define YY_NUM_RULES %d\n", num_rules);
-	out_dec ("#define YY_END_OF_BUFFER %d\n", num_rules + 1);
-
-	if (fullspd) {
-		/* Need to define the transet type as a size large
-		 * enough to hold the biggest offset.
-		 */
-		int     total_table_size = tblend + numecs + 1;
-		char   *trans_offset_type =
-			(total_table_size >= INT16_MAX || long_align) ?
-			"flex_int32_t" : "flex_int16_t";
-
-		set_indent (0);
-		indent_puts ("struct yy_trans_info");
-		++indent_level;
-		indent_puts ("{");
-
-		/* We require that yy_verify and yy_nxt must be of the same size int. */
-		indent_put2s ("%s yy_verify;", trans_offset_type);
-
-		/* In cases where its sister yy_verify *is* a "yes, there is
-		 * a transition", yy_nxt is the offset (in records) to the
-		 * next state.  In most cases where there is no transition,
-		 * the value of yy_nxt is irrelevant.  If yy_nxt is the -1th
-		 * record of a state, though, then yy_nxt is the action number
-		 * for that state.
-		 */
-
-		indent_put2s ("%s yy_nxt;", trans_offset_type);
-		indent_puts ("};");
-		--indent_level;
-	}
-	else {
-		/* We generate a bogus 'struct yy_trans_info' data type
-		 * so we can guarantee that it is always declared in the skel.
-		 * This is so we can compile "sizeof(struct yy_trans_info)"
-		 * in any scanner.
-		 */
-		indent_puts
-			("/* This struct is not used in this scanner,");
-		indent_puts ("   but its presence is necessary. */");
-		indent_puts ("struct yy_trans_info");
-		++indent_level;
-		indent_puts ("{");
-		indent_puts ("flex_int32_t yy_verify;");
-		indent_puts ("flex_int32_t yy_nxt;");
-		indent_puts ("};");
-		--indent_level;
-	}
-
+        if (bol_needed) {
+          out_m4_define("M4_YY_BOL_NEEDED", NULL);
+        }
+    
 	if (fullspd) {
 		genctbl ();
 		if (tablesext) {
@@ -1649,9 +1003,15 @@ void make_tables (void)
 			}
 		}
 	}
-	else
+	else {
 		gentabs ();
-
+	}
+              
+        /* num_backing_up can be changed by gentabs() so we don't  no whether backing up is needed until here. */
+	if( num_backing_up > 0 ) {
+		out_m4_define("M4_YY_NEEDS_BACKING_UP", NULL);
+	}
+              
 	if (do_yylineno) {
 
 		geneoltbl ();
@@ -1668,29 +1028,20 @@ void make_tables (void)
 		}
 	}
 
-	/* Definitions for backing up.  We don't need them if REJECT
-	 * is being used because then we use an alternative backin-up
-	 * technique instead.
-	 */
-	if (num_backing_up > 0 && !reject) {
-		if (!C_plus_plus && !reentrant) {
-			indent_puts
-				("static yy_state_type yy_last_accepting_state;");
-			indent_puts
-				("static char *yy_last_accepting_cpos;\n");
-		}
-	}
+
 
 	if (nultrans) {
 		flex_int32_t *yynultrans_data = 0;
 
 		/* Begin generating yy_NUL_trans */
-		out_str_dec (get_state_decl (), "yy_NUL_trans",
-			     lastdfa + 1);
-		buf_prints (&yydmap_buf,
-			    "\t{YYTD_ID_NUL_TRANS, (void**)&yy_NUL_trans, sizeof(%s)},\n",
-			    (fullspd) ? "struct yy_trans_info*" :
-			    "flex_int32_t");
+		out_str_dec (get_state_decl (), "yy_NUL_trans", lastdfa + 1);
+                
+		if(fullspd) {
+			buf_strappend (&yydmap_buf, "INDENT[[]]YYDMAP_ENTRY_TYPE(YYTD_ID_NUL_TRANS, yy_NUL_trans, M4_YY_TRANS_INFO_P_TYPE)");
+		}
+		else {
+			buf_strappend (&yydmap_buf, "INDENT[[]]YYDMAP_ENTRY_LONG(YYTD_ID_NUL_TRANS, yy_NUL_trans)");
+		}
 
 		yynultrans_tbl = calloc(1, sizeof (struct yytbl_data));
 		yytbl_data_init (yynultrans_tbl, YYTD_ID_NUL_TRANS);
@@ -1703,7 +1054,7 @@ void make_tables (void)
 
 		for (i = 1; i <= lastdfa; ++i) {
 			if (fullspd) {
-				out_dec ("    &yy_transition[%d],\n",
+				out_dec ("INDENT[[]]REFERENCE_TABLE_ENTRY(yy_transition, %d)[[]]COLUMN_SEPARATOR[[]]TABLE_BLOCK[[]]",
 					 base[i]);
 				yynultrans_data[i] = base[i];
 			}
@@ -1725,433 +1076,52 @@ void make_tables (void)
 		if (yynultrans_tbl != NULL) {
 			yytbl_data_destroy (yynultrans_tbl);
 			yynultrans_tbl = NULL;
-        }
+		}
 
 		/* End generating yy_NUL_trans */
 	}
 
-	if (!C_plus_plus && !reentrant) {
-		indent_puts ("extern int yy_flex_debug;");
-		indent_put2s ("int yy_flex_debug = %s;\n",
-			      ddebug ? "1" : "0");
-	}
-
 	if (ddebug) {		/* Spit out table mapping rules to line numbers. */
-		out_str_dec (long_align ? get_int32_decl () :
-			     get_int16_decl (), "yy_rule_linenum",
-			     num_rules);
+		out_str_dec (get_int_decl (), "yy_rule_linenum", num_rules);
 		for (i = 1; i < num_rules; ++i)
 			mkdata (rule_linenum[i]);
 		dataend ();
 	}
 
-	if (reject) {
-		outn ("m4_ifdef( [[M4_YY_USES_REJECT]],\n[[");
-		/* Declare state buffer variables. */
-		if (!C_plus_plus && !reentrant) {
-			outn ("static yy_state_type *yy_state_buf=0, *yy_state_ptr=0;");
-			outn ("static char *yy_full_match;");
-			outn ("static int yy_lp;");
-		}
-
-		if (variable_trailing_context_rules) {
-			if (!C_plus_plus && !reentrant) {
-				outn ("static int yy_looking_for_trail_begin = 0;");
-				outn ("static int yy_full_lp;");
-				outn ("static int *yy_full_state;");
-			}
-
-			out_hex ("#define YY_TRAILING_MASK 0x%x\n",
-				 (unsigned int) YY_TRAILING_MASK);
-			out_hex ("#define YY_TRAILING_HEAD_MASK 0x%x\n",
-				 (unsigned int) YY_TRAILING_HEAD_MASK);
-		}
-
-		outn ("#define REJECT \\");
-		outn ("{ \\");
-		outn ("*yy_cp = YY_G(yy_hold_char); /* undo effects of setting up yytext */ \\");
-		outn ("yy_cp = YY_G(yy_full_match); /* restore poss. backed-over text */ \\");
-
-		if (variable_trailing_context_rules) {
-			outn ("YY_G(yy_lp) = YY_G(yy_full_lp); /* restore orig. accepting pos. */ \\");
-			outn ("YY_G(yy_state_ptr) = YY_G(yy_full_state); /* restore orig. state */ \\");
-			outn ("yy_current_state = *YY_G(yy_state_ptr); /* restore curr. state */ \\");
-		}
-
-		outn ("++YY_G(yy_lp); \\");
-		outn ("goto find_rule; \\");
-
-		outn ("}");
-		outn ("]])\n");
-	}
-
-	else {
-		outn ("/* The intent behind this definition is that it'll catch");
-		outn (" * any uses of REJECT which flex missed.");
-		outn (" */");
-		outn ("#define REJECT reject_used_but_not_detected");
-	}
-
-	if (yymore_used) {
-		if (!C_plus_plus) {
-			if (yytext_is_array) {
-				if (!reentrant){
-    				indent_puts ("static int yy_more_offset = 0;");
-                    indent_puts ("static int yy_prev_more_offset = 0;");
-                }
-			}
-			else if (!reentrant) {
-				indent_puts
-					("static int yy_more_flag = 0;");
-				indent_puts
-					("static int yy_more_len = 0;");
-			}
-		}
-
-		if (yytext_is_array) {
-			indent_puts
-				("#define yymore() (YY_G(yy_more_offset) = yy_flex_strlen( yytext M4_YY_CALL_LAST_ARG))");
-			indent_puts ("#define YY_NEED_STRLEN");
-			indent_puts ("#define YY_MORE_ADJ 0");
-			indent_puts
-				("#define YY_RESTORE_YY_MORE_OFFSET \\");
-			++indent_level;
-			indent_puts ("{ \\");
-			indent_puts
-				("YY_G(yy_more_offset) = YY_G(yy_prev_more_offset); \\");
-			indent_puts ("yyleng -= YY_G(yy_more_offset); \\");
-			indent_puts ("}");
-			--indent_level;
-		}
-		else {
-			indent_puts
-				("#define yymore() (YY_G(yy_more_flag) = 1)");
-			indent_puts
-				("#define YY_MORE_ADJ YY_G(yy_more_len)");
-			indent_puts ("#define YY_RESTORE_YY_MORE_OFFSET");
-		}
-	}
-
-	else {
-		indent_puts
-			("#define yymore() yymore_used_but_not_detected");
-		indent_puts ("#define YY_MORE_ADJ 0");
-		indent_puts ("#define YY_RESTORE_YY_MORE_OFFSET");
-	}
-
-	if (!C_plus_plus) {
-		if (yytext_is_array) {
-			outn ("#ifndef YYLMAX");
-			outn ("#define YYLMAX 8192");
-			outn ("#endif\n");
-			if (!reentrant){
-                outn ("char yytext[YYLMAX];");
-                outn ("char *yytext_ptr;");
-            }
-		}
-
-		else {
-			if(! reentrant)
-                outn ("char *yytext;");
-		}
-	}
-
+    
+	/* Emit the user's section 1 definitions into the output file. */
+	skelout ();		/* %% [3.0] - break point in skel */
 	out (&action_array[defs1_offset]);
-
 	line_directive_out (stdout, 0);
-
-	skelout ();		/* %% [5.0] - break point in skel */
-
-	if (!C_plus_plus) {
-		if (use_read) {
-			outn ("\terrno=0; \\");
-			outn ("\twhile ( (result = (int) read( fileno(yyin), buf, (yy_size_t) max_size )) < 0 ) \\");
-			outn ("\t{ \\");
-			outn ("\t\tif( errno != EINTR) \\");
-			outn ("\t\t{ \\");
-			outn ("\t\t\tYY_FATAL_ERROR( \"input in flex scanner failed\" ); \\");
-			outn ("\t\t\tbreak; \\");
-			outn ("\t\t} \\");
-			outn ("\t\terrno=0; \\");
-			outn ("\t\tclearerr(yyin); \\");
-			outn ("\t}\\");
-		}
-
-		else {
-			outn ("\tif ( YY_CURRENT_BUFFER_LVALUE->yy_is_interactive ) \\");
-			outn ("\t\t{ \\");
-			outn ("\t\tint c = '*'; \\");
-			outn ("\t\tint n; \\");
-			outn ("\t\tfor ( n = 0; n < max_size && \\");
-			outn ("\t\t\t     (c = getc( yyin )) != EOF && c != '\\n'; ++n ) \\");
-			outn ("\t\t\tbuf[n] = (char) c; \\");
-			outn ("\t\tif ( c == '\\n' ) \\");
-			outn ("\t\t\tbuf[n++] = (char) c; \\");
-			outn ("\t\tif ( c == EOF && ferror( yyin ) ) \\");
-			outn ("\t\t\tYY_FATAL_ERROR( \"input in flex scanner failed\" ); \\");
-			outn ("\t\tresult = n; \\");
-			outn ("\t\t} \\");
-			outn ("\telse \\");
-			outn ("\t\t{ \\");
-			outn ("\t\terrno=0; \\");
-			outn ("\t\twhile ( (result = (int) fread(buf, 1, (yy_size_t) max_size, yyin)) == 0 && ferror(yyin)) \\");
-			outn ("\t\t\t{ \\");
-			outn ("\t\t\tif( errno != EINTR) \\");
-			outn ("\t\t\t\t{ \\");
-			outn ("\t\t\t\tYY_FATAL_ERROR( \"input in flex scanner failed\" ); \\");
-			outn ("\t\t\t\tbreak; \\");
-			outn ("\t\t\t\t} \\");
-			outn ("\t\t\terrno=0; \\");
-			outn ("\t\t\tclearerr(yyin); \\");
-			outn ("\t\t\t} \\");
-			outn ("\t\t}\\");
-		}
-	}
-
-	skelout ();		/* %% [6.0] - break point in skel */
-
-	indent_puts ("#define YY_RULE_SETUP \\");
-	++indent_level;
-	if (bol_needed) {
-		indent_puts ("if ( yyleng > 0 ) \\");
-		++indent_level;
-		indent_puts ("YY_CURRENT_BUFFER_LVALUE->yy_at_bol = \\");
-		indent_puts ("\t\t(yytext[yyleng - 1] == '\\n'); \\");
-		--indent_level;
-	}
-	indent_puts ("YY_USER_ACTION");
-	--indent_level;
-
-	skelout ();		/* %% [7.0] - break point in skel */
-
-	/* Copy prolog to output file. */
+    
+	/* Emit the user's prolog into the output file. */
+	skelout ();		/* %% [4.0] - break point in skel */
 	out (&action_array[prolog_offset]);
-
 	line_directive_out (stdout, 0);
-
-	skelout ();		/* %% [8.0] - break point in skel */
-
-	set_indent (2);
-
-	if (yymore_used && !yytext_is_array) {
-		indent_puts ("YY_G(yy_more_len) = 0;");
-		indent_puts ("if ( YY_G(yy_more_flag) )");
-		++indent_level;
-		indent_puts ("{");
-		indent_puts
-			("YY_G(yy_more_len) = (int) (YY_G(yy_c_buf_p) - YY_G(yytext_ptr));");
-		indent_puts ("YY_G(yy_more_flag) = 0;");
-		indent_puts ("}");
-		--indent_level;
-	}
-
-	skelout ();		/* %% [9.0] - break point in skel */
-
-	gen_start_state ();
-
-	/* Note, don't use any indentation. */
-	outn ("yy_match:");
-	gen_next_match ();
-
-	skelout ();		/* %% [10.0] - break point in skel */
-	set_indent (2);
-	gen_find_action ();
-
-	skelout ();		/* %% [11.0] - break point in skel */
-	outn ("m4_ifdef( [[M4_YY_USE_LINENO]],[[");
-	indent_puts
-		("if ( yy_act != YY_END_OF_BUFFER && yy_rule_can_match_eol[yy_act] )");
-	++indent_level;
-	indent_puts ("{");
-	indent_puts ("int yyl;");
-	do_indent ();
-	out_str ("for ( yyl = %s; yyl < yyleng; ++yyl )\n",
-		 yymore_used ? (yytext_is_array ? "YY_G(yy_prev_more_offset)" :
-				"YY_G(yy_more_len)") : "0");
-	++indent_level;
-	indent_puts ("if ( yytext[yyl] == '\\n' )");
-	++indent_level;
-	indent_puts ("M4_YY_INCR_LINENO();");
-	--indent_level;
-	--indent_level;
-	indent_puts ("}");
-	--indent_level;
-	outn ("]])");
-
-	skelout ();		/* %% [12.0] - break point in skel */
-	if (ddebug) {
-		indent_puts ("if ( yy_flex_debug )");
-		++indent_level;
-
-		indent_puts ("{");
-		indent_puts ("if ( yy_act == 0 )");
-		++indent_level;
-		indent_puts (C_plus_plus ?
-			     "std::cerr << \"--scanner backing up\\n\";" :
-			     "fprintf( stderr, \"--scanner backing up\\n\" );");
-		--indent_level;
-
-		do_indent ();
-		out_dec ("else if ( yy_act < %d )\n", num_rules);
-		++indent_level;
-
-		if (C_plus_plus) {
-			indent_puts
-				("std::cerr << \"--accepting rule at line \" << yy_rule_linenum[yy_act] <<");
-			indent_puts
-				("         \"(\\\"\" << yytext << \"\\\")\\n\";");
-		}
-		else {
-			indent_puts
-				("fprintf( stderr, \"--accepting rule at line %ld (\\\"%s\\\")\\n\",");
-
-			indent_puts
-				("         (long)yy_rule_linenum[yy_act], yytext );");
-		}
-
-		--indent_level;
-
-		do_indent ();
-		out_dec ("else if ( yy_act == %d )\n", num_rules);
-		++indent_level;
-
-		if (C_plus_plus) {
-			indent_puts
-				("std::cerr << \"--accepting default rule (\\\"\" << yytext << \"\\\")\\n\";");
-		}
-		else {
-			indent_puts
-				("fprintf( stderr, \"--accepting default rule (\\\"%s\\\")\\n\",");
-			indent_puts ("         yytext );");
-		}
-
-		--indent_level;
-
-		do_indent ();
-		out_dec ("else if ( yy_act == %d )\n", num_rules + 1);
-		++indent_level;
-
-		indent_puts (C_plus_plus ?
-			     "std::cerr << \"--(end of buffer or a NUL)\\n\";" :
-			     "fprintf( stderr, \"--(end of buffer or a NUL)\\n\" );");
-
-		--indent_level;
-
-		do_indent ();
-		outn ("else");
-		++indent_level;
-
-		if (C_plus_plus) {
-			indent_puts
-				("std::cerr << \"--EOF (start condition \" << YY_START << \")\\n\";");
-		}
-		else {
-			indent_puts
-				("fprintf( stderr, \"--EOF (start condition %d)\\n\", YY_START );");
-		}
-
-		--indent_level;
-
-		indent_puts ("}");
-		--indent_level;
-	}
 
 	/* Copy actions to output file. */
-	skelout ();		/* %% [13.0] - break point in skel */
-	++indent_level;
-	gen_bu_action ();
+	skelout ();		/* %% [5.0] - break point in skel */
 	out (&action_array[action_offset]);
-
 	line_directive_out (stdout, 0);
 
+        
 	/* generate cases for any missing EOF rules */
 	for (i = 1; i <= lastsc; ++i)
 		if (!sceof[i]) {
-			do_indent ();
-			out_str ("case YY_STATE_EOF(%s):\n", scname[i]);
+			out_str ("EOF_RULE(%s)", scname[i]);
 			did_eof_rule = true;
 		}
 
 	if (did_eof_rule) {
-		++indent_level;
-		indent_puts ("yyterminate();");
-		--indent_level;
+                out_m4_define("M4_YY_DID_EOF_RULE", NULL);
 	}
 
 
-	/* Generate code for handling NUL's, if needed. */
-
-	/* First, deal with backing up and setting up yy_cp if the scanner
-	 * finds that it should JAM on the NUL.
-	 */
-	skelout ();		/* %% [14.0] - break point in skel */
-	set_indent (4);
-
-	if (fullspd || fulltbl)
-		indent_puts ("yy_cp = YY_G(yy_c_buf_p);");
-
-	else {			/* compressed table */
-		if (!reject && !interactive) {
-			/* Do the guaranteed-needed backing up to figure
-			 * out the match.
-			 */
-			indent_puts
-				("yy_cp = YY_G(yy_last_accepting_cpos);");
-			indent_puts
-				("yy_current_state = YY_G(yy_last_accepting_state);");
-		}
-
-		else
-			/* Still need to initialize yy_cp, though
-			 * yy_current_state was set up by
-			 * yy_get_previous_state().
-			 */
-			indent_puts ("yy_cp = YY_G(yy_c_buf_p);");
-	}
-
-
-	/* Generate code for yy_get_previous_state(). */
-	set_indent (1);
-	skelout ();		/* %% [15.0] - break point in skel */
-
-	gen_start_state ();
-
-	set_indent (2);
-	skelout ();		/* %% [16.0] - break point in skel */
-	gen_next_state (true);
-
-	set_indent (1);
-	skelout ();		/* %% [17.0] - break point in skel */
-	gen_NUL_trans ();
-
-	skelout ();		/* %% [18.0] - break point in skel */
-	skelout ();		/* %% [19.0] - break point in skel */
-	/* Update BOL and yylineno inside of input(). */
-	if (bol_needed) {
-		indent_puts
-			("YY_CURRENT_BUFFER_LVALUE->yy_at_bol = (c == '\\n');");
-		if (do_yylineno) {
-			indent_puts
-				("if ( YY_CURRENT_BUFFER_LVALUE->yy_at_bol )");
-			++indent_level;
-			indent_puts ("M4_YY_INCR_LINENO();");
-			--indent_level;
-		}
-	}
-
-	else if (do_yylineno) {
-		indent_puts ("if ( c == '\\n' )");
-		++indent_level;
-		indent_puts ("M4_YY_INCR_LINENO();");
-		--indent_level;
-	}
-
-	skelout ();
-
-	/* Copy remainder of input to output. */
-
+	/* Copy remainder of skeleton to output. */
+	skelout (); /* %% [6.0] - break point in skel */
 	line_directive_out (stdout, 1);
 
+        /* Emit the user's section 3 into the output file. */
 	if (sectnum == 3) {
 		OUT_BEGIN_CODE ();
                 if (!no_section3_escape)

--- a/src/main.c
+++ b/src/main.c
@@ -168,9 +168,14 @@ int flex_main (int argc, char *argv[])
 	flexinit (argc, argv);
 
 	readin ();
+        
+        skelout (); /* %% [1.0] */
+        
+        if (did_outfilename)
+          line_directive_out (stdout, 0);
 
-	skelout ();
-	/* %% [1.5] DFA */
+	skelout (); 	/* %% [2.0] DFA */
+
 	ntod ();
 
 	for (i = 1; i <= num_rules; ++i)
@@ -435,7 +440,7 @@ void check_options (void)
 		lerr (_("can't open skeleton file %s"), skelname);
 
 	if (reentrant) {
-        buf_m4_define (&m4defs_buf, "M4_YY_REENTRANT", NULL);
+		buf_m4_define (&m4defs_buf, "M4_YY_REENTRANT", NULL);
 		if (yytext_is_array)
 			buf_m4_define (&m4defs_buf, "M4_YY_TEXT_IS_ARRAY", NULL);
 	}
@@ -444,28 +449,33 @@ void check_options (void)
 		buf_m4_define (&m4defs_buf, "M4_YY_BISON_LVAL", NULL);
 
 	if ( bison_bridge_lloc)
-        buf_m4_define (&m4defs_buf, "<M4_YY_BISON_LLOC>", NULL);
+		buf_m4_define (&m4defs_buf, "<M4_YY_BISON_LLOC>", NULL);
 
-    if (strchr(prefix, '[') || strchr(prefix, ']'))
-        flexerror(_("Prefix cannot include '[' or ']'"));
-    buf_m4_define(&m4defs_buf, "M4_YY_PREFIX", prefix);
+	if (strchr(prefix, '[') || strchr(prefix, ']'))
+		flexerror(_("Prefix cannot include '[' or ']'"));
+    
+	buf_m4_define(&m4defs_buf, "M4_YY_PREFIX", prefix);
 
-	if (did_outfilename)
-		line_directive_out (stdout, 0);
+	
 
 	if (do_yylineno)
 		buf_m4_define (&m4defs_buf, "M4_YY_USE_LINENO", NULL);
 
 	/* Create the alignment type. */
-	buf_strdefine (&userdef_buf, "YY_INT_ALIGNED",
-		       long_align ? "long int" : "short int");
+	if (long_align) {
+		buf_m4_define(&m4defs_buf, "M4_YY_LONG_ALIGNED", NULL);
+	}
 
     /* Define the start condition macros. */
     {
         struct Buf tmpbuf;
         buf_init(&tmpbuf, sizeof(char));
+        /* buf_m4_define() strongly protects its arguments from expansion.
+         * We specifically need to defeat that in this case.
+         */
+        buf_strappend(&tmpbuf, "]]");
         for (i = 1; i <= lastsc; i++) {
-             char *str, *fmt = "#define %s %d\n";
+             char *str, *fmt = "M4_YY_ALIAS( [[%s]], [[%d]] )\n";
              size_t strsz;
 
              strsz = strlen(fmt) + strlen(scname[i]) + (size_t)(1 + ceil (log10(i))) + 2;
@@ -476,30 +486,33 @@ void check_options (void)
              buf_strappend(&tmpbuf, str);
              free(str);
         }
+        /* Complete bypass of buf_m4_define quoting. */
+        buf_strappend(&tmpbuf, "[[");
         buf_m4_define(&m4defs_buf, "M4_YY_SC_DEFS", tmpbuf.elts);
         buf_destroy(&tmpbuf);
     }
 
-    /* This is where we begin writing to the file. */
+    /* Put the %top code into an M4 variable. */
+    if( top_buf.elts) {
+        buf_m4_define(&m4defs_buf, "M4_YY_TOP_BLOCK", top_buf.elts);
+        buf_destroy(&top_buf);
+		buf_init(&top_buf, sizeof(char));
+    }
 
-    /* Dump the %top code. */
-    if( top_buf.elts)
-        outn((char*) top_buf.elts);
+    /* Put the user defined preproc directives into an M4 variable. */
+    if (userdef_buf.elts) {
+        buf_m4_define(&m4defs_buf, "M4_YY_USERDEF", userdef_buf.elts);
+        buf_destroy(&userdef_buf);
+		buf_init(&userdef_buf, sizeof(char));
+    }
+
+    /* This is where we begin writing to the file. */
 
     /* Dump the m4 definitions. */
     buf_print_strings(&m4defs_buf, stdout);
-    m4defs_buf.nelts = 0; /* memory leak here. */
+    buf_destroy(&m4defs_buf);
+	buf_init(&m4defs_buf, sizeof(char *));
 
-    /* Place a bogus line directive, it will be fixed in the filter. */
-    if (gen_line_dirs)
-        outn("#line 0 \"M4_YY_OUTFILE_NAME\"\n");
-
-	/* Dump the user defined preproc directives. */
-	if (userdef_buf.elts)
-		outn ((char *) (userdef_buf.elts));
-
-	skelout ();
-	/* %% [1.0] */
 }
 
 /* flexend - terminate flex
@@ -1128,12 +1141,13 @@ void flexinit (int argc, char **argv)
             break;
 
 		case OPT_MAIN:
-			buf_strdefine (&userdef_buf, "YY_MAIN", "1");
+			/* buf_strdefine (&userdef_buf, "YY_MAIN", "1"); */
+            buf_m4_define( &m4defs_buf, "M4_YY_MAIN", NULL );
 			do_yywrap = false;
 			break;
 
 		case OPT_NO_MAIN:
-			buf_strdefine (&userdef_buf, "YY_MAIN", "0");
+			/* buf_strdefine (&userdef_buf, "YY_MAIN", "0"); */
 			break;
 
 		case OPT_NO_LINE:
@@ -1163,6 +1177,7 @@ void flexinit (int argc, char **argv)
 
 		case OPT_REENTRANT:
 			reentrant = true;
+            buf_m4_define( &m4defs_buf, "M4_YY_REENTRANT", NULL );
 			break;
 
 		case OPT_NO_REENTRANT:
@@ -1245,6 +1260,7 @@ void flexinit (int argc, char **argv)
 
 		case OPT_ARRAY:
 			yytext_is_array = true;
+            buf_m4_define( &m4defs_buf, "M4_YY_TEXT_IS_ARRAY", 0);
 			break;
 
 		case OPT_POINTER:
@@ -1315,6 +1331,7 @@ void flexinit (int argc, char **argv)
 
 		case OPT_YYCLASS:
 			yyclass = arg;
+            buf_m4_define( &m4defs_buf, "M4_YYCLASS", yyclass );
 			break;
 
 		case OPT_YYLINENO:
@@ -1527,8 +1544,10 @@ void readin (void)
 	else
 		backing_up_file = NULL;
 
-	if (yymore_really_used == true)
+	if (yymore_really_used == true) {
 		yymore_used = true;
+		out_m4_define( "M4_YY_MORE_USED", NULL);
+	}
 	else if (yymore_really_used == false)
 		yymore_used = false;
 
@@ -1536,7 +1555,7 @@ void readin (void)
 		reject = true;
 	else if (reject_really_used == false)
 		reject = false;
-
+              
 	if (performance_report > 0) {
 		if (lex_compat) {
 			fprintf (stderr,
@@ -1595,138 +1614,77 @@ void readin (void)
 	}
 
 	if (reject){
-        out_m4_define( "M4_YY_USES_REJECT", NULL);
+        out_m4_define( "M4_YY_USES_REJECT", NULL );
 		//outn ("\n#define YY_USES_REJECT");
-    }
+	}
 
 	if (!do_yywrap) {
-		if (!C_plus_plus) {
-			 if (reentrant)
-				out_str ("\n#define %swrap(yyscanner) (/*CONSTCOND*/1)\n", prefix);
-			 else
-				out_str ("\n#define %swrap() (/*CONSTCOND*/1)\n", prefix);
-		}
-		outn ("#define YY_SKIP_YYWRAP");
+        out_m4_define( "M4_YY_SKIP_YYWRAP", NULL );
 	}
 
 	if (ddebug)
-		outn ("\n#define FLEX_DEBUG");
-
-	OUT_BEGIN_CODE ();
-	outn ("typedef flex_uint8_t YY_CHAR;");
-	OUT_END_CODE ();
-
+        out_m4_define( "M4_FLEX_DEBUG", NULL );
+    
 	if (C_plus_plus) {
-		outn ("#define yytext_ptr yytext");
+        out_m4_define( "M4_YYTEXT_PTR", NULL );
 
-		if (interactive)
-			outn ("#define YY_INTERACTIVE");
+	    if (interactive)
+            out_m4_define( "M4_YY_INTERACTIVE", NULL );
 	}
-
 	else {
-		OUT_BEGIN_CODE ();
-		/* In reentrant scanner, stdinit is handled in flex.skl. */
-		if (do_stdinit) {
-			if (reentrant){
-                outn ("#ifdef VMS");
-                outn ("#ifdef __VMS_POSIX");
-                outn ("#define YY_STDINIT");
-                outn ("#endif");
-                outn ("#else");
-                outn ("#define YY_STDINIT");
-                outn ("#endif");
+	    if (do_stdinit) {
+                out_m4_define( "M4_DO_STDINIT", NULL );
             }
-
-			outn ("#ifdef VMS");
-			outn ("#ifndef __VMS_POSIX");
-			outn (yy_nostdinit);
-			outn ("#else");
-			outn (yy_stdinit);
-			outn ("#endif");
-			outn ("#else");
-			outn (yy_stdinit);
-			outn ("#endif");
-		}
-
-		else {
-			if(!reentrant)
-                outn (yy_nostdinit);
-		}
-		OUT_END_CODE ();
 	}
-
-	OUT_BEGIN_CODE ();
+    
 	if (fullspd)
-		outn ("typedef const struct yy_trans_info *yy_state_type;");
-	else if (!C_plus_plus)
-		outn ("typedef int yy_state_type;");
-	OUT_END_CODE ();
+        out_m4_define( "M4_YY_FULLSPD", NULL );
+      
+        if (fulltbl)
+        out_m4_define( "M4_YY_FULLTBL", NULL );
+      
+        if (gentables)
+        out_m4_define( "M4_YY_GENTABLES", NULL );
 
 	if (lex_compat)
-		outn ("#define YY_FLEX_LEX_COMPAT");
+        out_m4_define( "M4_LEX_COMPAT", NULL );
+      
+	if (do_yylineno)
+	out_m4_define( "M4_YY_LINENO", NULL );
 
-	if (!C_plus_plus && !reentrant) {
-		outn ("extern int yylineno;");
-		OUT_BEGIN_CODE ();
-		outn ("int yylineno = 1;");
-		OUT_END_CODE ();
-	}
-
-	if (C_plus_plus) {
-		outn ("\n#include <FlexLexer.h>");
-
- 		if (!do_yywrap) {
-			outn("\nint yyFlexLexer::yywrap() { return 1; }");
-		}
-
-		if (yyclass) {
-			outn ("int yyFlexLexer::yylex()");
-			outn ("\t{");
-			outn ("\tLexerError( \"yyFlexLexer::yylex invoked but %option yyclass used\" );");
-			outn ("\treturn 0;");
-			outn ("\t}");
-
-			out_str ("\n#define YY_DECL int %s::yylex()\n",
-				 yyclass);
-		}
-	}
-
-	else {
-
+	if (!C_plus_plus) {
 		/* Watch out: yytext_ptr is a variable when yytext is an array,
 		 * but it's a macro when yytext is a pointer.
 		 */
-		if (yytext_is_array) {
-			if (!reentrant)
-				outn ("extern char yytext[];\n");
-		}
-		else {
-			if (reentrant) {
-				outn ("#define yytext_ptr yytext_r");
-			}
-			else {
-				outn ("extern char *yytext;");
-
-				outn("#ifdef yytext_ptr");
-				outn("#undef yytext_ptr");
-				outn("#endif");
-				outn ("#define yytext_ptr yytext");
-			}
-		}
-
 		if (yyclass)
-			flexerror (_
-				   ("%option yyclass only meaningful for C++ scanners"));
+		    flexerror (_("%option yyclass only meaningful for C++ scanners"));
 	}
 
-	if (useecs)
+	if (useecs) {
 		numecs = cre8ecs (nextecm, ecgroup, csize);
+                out_m4_define( "M4_YY_USE_ECS", NULL );
+        }
 	else
 		numecs = csize;
 
 	/* Now map the equivalence class for NUL to its expected place. */
 	ecgroup[0] = ecgroup[csize];
 	NUL_ec = ABS (ecgroup[0]);
+        out_m4_define_dec( "M4_YY_NUL_EC", NUL_ec );
+        
+        if (fullspd) {
+          /* Need to define the transet type as a size large
+           * enough to hold the biggest offset.
+           */
+          int     total_table_size = tblend + numecs + 1;
+          char   *trans_offset_type = 
+              (total_table_size >= INT16_MAX || long_align) ? "32" : "16";
+
+          out_m4_define("M4_YY_TRANS_OFFSET_TYPE", trans_offset_type);
+        }
+        else {
+          out_m4_define("M4_YY_TRANS_OFFSET_TYPE", "32");
+        }
 
 	if (useecs)
 		ccl2ecl ();

--- a/src/misc.c
+++ b/src/misc.c
@@ -102,7 +102,7 @@ void action_define (const char *defname, int value)
 		return;
 	}
 
-	snprintf (buf, sizeof(buf), "#define %s %d\n", defname, value);
+	snprintf (buf, sizeof(buf), "M4_YY_ALIAS( [[%s]], [[%d]])\n", defname, value);
 	add_action (buf);
 
 	/* track #defines so we can undef them when we're done. */
@@ -260,7 +260,7 @@ void dataend (void)
 			dataflush ();
 
 		/* add terminator for initialization; { for vi */
-		outn ("    } ;\n");
+		outn ("INDENT[[]]LAST_ROW");
 	}
 	dataline = 0;
 	datapos = 0;
@@ -275,13 +275,13 @@ void dataflush (void)
 	if (!gentables)
 		return;
 
-	outc ('\n');
+	out ("TABLE_BLOCK[[]]");
 
 	if (++dataline >= NUMDATALINES) {
 		/* Put out a blank line so that the table is grouped into
 		 * large blocks that enable the user to find elements easily.
 		 */
-		outc ('\n');
+		out ("TABLE_BLOCK[[]]");
 		dataline = 0;
 	}
 
@@ -343,7 +343,7 @@ void line_directive_out (FILE *output_file, int do_infile)
 {
 	char    directive[MAXLINE*2], filename[MAXLINE];
 	char   *s1, *s2, *s3;
-	static const char line_fmt[] = "#line %d \"%s\"\n";
+	static const char line_fmt[] = "M4_YY_LINE_DIRECTIVE( [[%d]], %s)\n";
 
 	if (!gen_line_dirs)
 		return;
@@ -418,20 +418,20 @@ void mk2data (int value)
 		return;
 
 	if (datapos >= NUMDATAITEMS) {
-		outc (',');
+		out ("COLUMN_SEPARATOR[[]]");
 		dataflush ();
 	}
 
 	if (datapos == 0)
 		/* Indent. */
-		out ("    ");
+		out ("INDENT[[]]");
 
 	else
-		outc (',');
+		out ("COLUMN_SEPARATOR[[]]");
 
 	++datapos;
 
-	out_dec ("%5d", value);
+	out_dec ("TABLE_DATA(%5d)[[]]", value);
 }
 
 
@@ -447,19 +447,19 @@ void mkdata (int value)
 		return;
 
 	if (datapos >= NUMDATAITEMS) {
-		outc (',');
+		out ("COLUMN_SEPARATOR[[]]");
 		dataflush ();
 	}
 
 	if (datapos == 0)
 		/* Indent. */
-		out ("    ");
+		out ("INDENT[[]]");
 	else
-		outc (',');
+		out ("COLUMN_SEPARATOR[[]]");
 
 	++datapos;
 
-	out_dec ("%5d", value);
+	out_dec ("TABLE_DATA(%5d)[[]]", value);
 }
 
 
@@ -579,6 +579,11 @@ void out_str (const char *fmt, const char str[])
 	fprintf (stdout,fmt, str);
 }
 
+void out_str2 (const char *fmt, const char s1[], const char s2[])
+{
+  fprintf (stdout,fmt, s1, s2);
+}
+
 void out_str3 (const char *fmt, const char s1[], const char s2[], const char s3[])
 {
 	fprintf (stdout,fmt, s1, s2, s3);
@@ -587,6 +592,11 @@ void out_str3 (const char *fmt, const char s1[], const char s2[], const char s3[
 void out_str_dec (const char *fmt, const char str[], int n)
 {
 	fprintf (stdout,fmt, str, n);
+}
+
+void out_str2_dec (const char *fmt, const char s1[], const char s2[], int n)
+{
+  fprintf (stdout,fmt, s1, s2, n);
 }
 
 void outc (int c)
@@ -610,6 +620,25 @@ void out_m4_define (const char* def, const char* val)
     fprintf(stdout, fmt, def, val?val:"");
 }
 
+/** Print "m4_define( [[def]], [[val]])m4_dnl\n".
+ * @param def The m4 symbol to define.
+ * @param val The definition; may be NULL.
+ */
+void out_m4_define_dec (const char* def, const int val)
+{
+    const char * fmt = "m4_define( [[%s]], [[%d]])m4_dnl\n";
+    fprintf(stdout, fmt, def, val);
+}
+
+/** Print "m4_define( [[def]], 0x[[val]])m4_dnl\n".
+ * @param def The m4 symbol to define.
+ * @param val The definition; may be NULL.
+ */
+void out_m4_define_hex (const char* def, const unsigned int val)
+{
+    const char * fmt = "m4_define( [[%s]], [[0x%x]])m4_dnl\n";
+    fprintf(stdout, fmt, def, val);
+}
 
 /* readable_form - return the the human-readable form of a character
  *
@@ -716,9 +745,9 @@ void skelout (void)
 			/* print the control line as a comment. */
 			if (ddebug && buf[1] != '#') {
 				if (buf[strlen (buf) - 1] == '\\')
-					out_str ("/* %s */\\\n", buf);
+					out_str ("M4_YY_COMMENT([[ %s ]])\\\n", buf);
 				else
-					out_str ("/* %s */\n", buf);
+					out_str ("M4_YY_COMMENT([[ %s ]])\n", buf);
 			}
 
 			/* We've been accused of using cryptic markers in the skel.
@@ -738,14 +767,14 @@ void skelout (void)
             else if (cmd_match (CMD_PUSH)){
                 sko_push(do_copy);
                 if(ddebug){
-                    out_str("/*(state = (%s) */",do_copy?"true":"false");
+                    out_str("M4_YY_COMMENT([[ (state = (%s)) ]])",do_copy?"true":"false");
                 }
                 out_str("%s\n", buf[strlen (buf) - 1] =='\\' ? "\\" : "");
             }
             else if (cmd_match (CMD_POP)){
                 sko_pop(&do_copy);
                 if(ddebug){
-                    out_str("/*(state = (%s) */",do_copy?"true":"false");
+                    out_str("M4_YY_COMMENT([[ (state = (%s)) ]])",do_copy?"true":"false");
                 }
                 out_str("%s\n", buf[strlen (buf) - 1] =='\\' ? "\\" : "");
             }
@@ -777,7 +806,7 @@ void skelout (void)
 			}
             else if (cmd_match (CMD_DEFINE_YYTABLES)) {
                 if ( tablesext )
-                    out_str( "#define YYTABLES_NAME \"%s\"\n",
+                    out_str( "M4_YY_ALIAS( YYTABLES_NAME, \"%s\")",
                            tablesname ? tablesname : "yytables" );
             }
 			else if (cmd_match (CMD_IF_CPP_ONLY)) {
@@ -827,15 +856,15 @@ void transition_struct_out (int element_v, int element_n)
 	if (!gentables)
 		return;
 
-	out_dec2 (" {%4d,%4d },", element_v, element_n);
+	out_dec2 ("BEGIN_STRUCT[[]]%4d[[]]NEXT_SLOT[[]]%4d[[]]LAST_SLOT[[]]NEXT_STRUCT[[]]", element_v, element_n);
 
 	datapos += TRANS_STRUCT_PRINT_LENGTH;
 
 	if (datapos >= 79 - TRANS_STRUCT_PRINT_LENGTH) {
-		outc ('\n');
+		outn ("[[]]TABLE_BLOCK[[]]");
 
 		if (++dataline % 10 == 0)
-			outc ('\n');
+			outn ("[[]]TABLE_BLOCK[[]]");
 
 		datapos = 0;
 	}

--- a/src/parse.y
+++ b/src/parse.y
@@ -972,7 +972,7 @@ void build_eof_action(void)
 			if (previous_continued_action /* && previous action was regular */)
 				add_action("YY_RULE_SETUP\n");
 
-			snprintf( action_text, sizeof(action_text), "case YY_STATE_EOF(%s):\n",
+			snprintf( action_text, sizeof(action_text), "EOF_RULE(%s)\n",
 				scname[scon_stk[i]] );
 			add_action( action_text );
 			}

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -406,6 +406,9 @@ posixly_correct.c: posixly_correct.l $(FLEX)
 
 reject_nr.reject.c: reject.l4 $(FLEX)
 	$(AM_V_LEX)$(FLEX) --unsafe-no-m4-sect3-escape -o $@ $<
+	
+reject_nr.reject.$(OBJEXT): reject_nr.reject.c
+	$(AM_V_CC)$(COMPILE) -c -o $@ $<
 
 reject_nr.reject$(EXEEXT): reject_nr.reject.$(OBJEXT)
 	$(AM_V_CCLD)$(LINK) $^


### PR DESCRIPTION
Hello!

I finally finished the fork I started back in 2015 to move all the C code emissions into the skeleton. This will make maintenance of the built scanner simpler by keeping it (almost) all in one place instead of spread out among the flex sources. 

The few emissions that have to come from flex are done through skeleton macros, now. This is to enable my next project - multi-language support. I'm going to start by improving -S option support and then split the C and C++ scanners apart as a first example. 

The squashed log message for the PR follows:

Move all C language emissions to the skeleton and translate the
options logic to m4.

Emit top_buf and userdef_buf into m4 vars.

Add emission of top_buf and userdef_buf m4 var values to flex.skl.

The %top block and user-defined preprocessor definitions are benign
chunks of target code that can be emitted wholesale into the scanner.
However, their placement in the scanner source should be determined by
the skeleton rather than hardcoded in the main.c:check_options() function.
Now it is.

Change emission of YY_INT_ALIGNED to definition of an m4 variable.
Add emission of new m4 variable to flex.skl.

The optimization intended by YY_INT_ALIGNED is tied to the target
language.  The skeleton should be responsible for whether and where
to emit the type definition, even as the user is responsible for
determining whether it is wanted.

Add macros defining language-specific table structure to flex.skl.
Refactor dfa.c and misc.c methods used by ntod() to use the new table macros.
Replace obsolete yyconst uses with const.

Move CLI and %option switches from main.c to flex.skl.
Document the M4_ macros that implement the switches in flex.skl for the
benefit of skeleton authors.

Define a flag when backing-up states are used.
Transliterate gen_backing_up() and gen_bu_action() into macros.

Add variadic buf_printns like buf_prints to handle macro emissions with 2
or more parameters.

Add out_m4_define_hex that prints its numeric argument in hex format.

Add skeleton macros for emitting table elements and references.

Start using YYDMAP_ENTRY macros for emitting yydmap table entries.

Remove dead code.