### PR TITLE
WIP: Adding "push lexer" functionality.

### DIFF
--- a/src/flex.skl
+++ b/src/flex.skl
@@ -65,6 +65,7 @@ m4_ifelse(M4_YY_PREFIX,yy,,
 #define yy_scan_buffer M4_YY_PREFIX[[_scan_buffer]]
 #define yy_scan_string M4_YY_PREFIX[[_scan_string]]
 #define yy_scan_bytes M4_YY_PREFIX[[_scan_bytes]]
+#define yy_append_bytes M4_YY_PREFIX[[_append_bytes]]
 #define yy_init_buffer M4_YY_PREFIX[[_init_buffer]]
 #define yy_flush_buffer M4_YY_PREFIX[[_flush_buffer]]
 #define yy_load_buffer_state M4_YY_PREFIX[[_load_buffer_state]]
@@ -140,6 +141,7 @@ m4_ifelse(M4_YY_PREFIX,yy,,
     M4_GEN_PREFIX(`_scan_buffer')
     M4_GEN_PREFIX(`_scan_string')
     M4_GEN_PREFIX(`_scan_bytes')
+    M4_GEN_PREFIX(`_append_bytes')
     M4_GEN_PREFIX(`_init_buffer')
     M4_GEN_PREFIX(`_flush_buffer')
     M4_GEN_PREFIX(`_load_buffer_state')
@@ -432,6 +434,9 @@ m4_ifdef( [[M4_YY_NOT_IN_HEADER]],
 #define EOB_ACT_CONTINUE_SCAN 0
 #define EOB_ACT_END_OF_FILE 1
 #define EOB_ACT_LAST_MATCH 2
+#if defined(YY_STALLED)
+#define EOB_ACT_STALLED 3
+#endif /* defined(YY_STALLED) */
     m4_ifdef( [[M4_YY_USE_LINENO]],
     [[
     /* Note: We specifically omit the test for yy_rule_can_match_eol because it requires
@@ -451,7 +456,7 @@ m4_ifdef( [[M4_YY_NOT_IN_HEADER]],
     #define YY_LINENO_REWIND_TO(dst) \
             do {\
                 const char *p;\
-                for ( p = yy_cp-1; p >= (dst); --p)\
+                for ( p = YY_G(yy_cp)-1; p >= (dst); --p)\
                     if ( *p == '\n' )\
                         --yylineno;\
             }while(0)
@@ -467,9 +472,9 @@ m4_ifdef( [[M4_YY_NOT_IN_HEADER]],
 		/* Undo effects of setting up yytext. */ \
         int yyless_macro_arg = (n); \
         YY_LESS_LINENO(yyless_macro_arg);\
-		*yy_cp = YY_G(yy_hold_char); \
+		*YY_G(yy_cp) = YY_G(yy_hold_char); \
 		YY_RESTORE_YY_MORE_OFFSET \
-		YY_G(yy_c_buf_p) = yy_cp = yy_bp + yyless_macro_arg - YY_MORE_ADJ; \
+		YY_G(yy_c_buf_p) = YY_G(yy_cp) = YY_G(yy_bp) + yyless_macro_arg - YY_MORE_ADJ; \
 		YY_DO_BEFORE_ACTION; /* set up yytext again */ \
 		} \
 	while ( 0 )
@@ -671,16 +676,22 @@ static void yynoreturn yy_fatal_error ( const char* msg M4_YY_PROTO_LAST_ARG );
 
 m4_ifdef( [[M4_YY_NOT_IN_HEADER]],
 [[
+%if-not-reentrant
+static char *yy_cp = NULL;		/*  */
+static char *yy_bp = NULL;		/*  */
+static yy_state_type yy_current_state = 0;
+%endif
+
 /* Done after the current pattern has been matched and before the
  * corresponding action - sets up yytext.
  */
 #define YY_DO_BEFORE_ACTION \
-	YY_G(yytext_ptr) = yy_bp; \
+	YY_G(yytext_ptr) = YY_G(yy_bp); \
 %% [2.0] code to fiddle yytext and yyleng for yymore() goes here \
-	YY_G(yy_hold_char) = *yy_cp; \
-	*yy_cp = '\0'; \
+	YY_G(yy_hold_char) = *YY_G(yy_cp); \
+	*YY_G(yy_cp) = '\0'; \
 %% [3.0] code to copy yytext_ptr to yytext[] goes here, if %array \
-	YY_G(yy_c_buf_p) = yy_cp;
+	YY_G(yy_c_buf_p) = YY_G(yy_cp);
 %% [4.0] data tables for the DFA and the user's section 1 definitions go here
 ]])
 
@@ -732,12 +743,15 @@ struct yyguts_t
     size_t yy_buffer_stack_top; /**< index of top of stack. */
     size_t yy_buffer_stack_max; /**< capacity of stack. */
     YY_BUFFER_STATE * yy_buffer_stack; /**< Stack as an array. */
-    char yy_hold_char;
-    int yy_n_chars;
-    int yyleng_r;
-    char *yy_c_buf_p;
-    int yy_init;
-    int yy_start;
+    char yy_hold_char; /**< This variable holds the character that is replace by '\0' in order to terminate yytext (in-place in the buffer). */
+    int yy_n_chars; /**< Number of characters read into yy_ch_buf. */
+    int yyleng_r; /**< yyleng for current scanner */
+    char *yy_c_buf_p; /**< Points to current character in buffer. */
+    int yy_init; /**< whether we need to initialize */
+    int yy_start; /**< start state number */
+#if defined(YY_STALLED)
+    int yy_resume; /**< resume after YY_STALLED */
+#endif /* defined(YY_STALLED) */
     int yy_did_buffer_switch_on_eof;
     int yy_start_stack_ptr;
     int yy_start_stack_depth;
@@ -746,7 +760,7 @@ struct yyguts_t
     char* yy_last_accepting_cpos;
 
     int yylineno_r;
-    int yy_flex_debug_r;
+    int yy_flex_debug_r; /**< yy_flex_debug for current scanner */
 
 m4_ifdef( [[M4_YY_USES_REJECT]],
 [[
@@ -770,20 +784,23 @@ m4_ifdef( [[M4_YY_TEXT_IS_ARRAY]],
     int yy_prev_more_offset;
 ]],
 [[
-    char *yytext_r;
+    char *yytext_r; /**< yytext for current scanner */
     int yy_more_flag;
     int yy_more_len;
 ]])
 
 m4_ifdef( [[M4_YY_BISON_LVAL]],
 [[
-    YYSTYPE * yylval_r;
+    YYSTYPE * yylval_r; /**< yylval for current scanner */
 ]])
 
 m4_ifdef( [[<M4_YY_BISON_LLOC>]],
 [[
     YYLTYPE * yylloc_r;
 ]])
+    yy_state_type yy_current_state;
+    char *yy_cp;			/**<  */
+    char *yy_bp;			/**<  */
 
     }; /* end struct yyguts_t */
 ]])
@@ -1188,8 +1205,6 @@ m4_ifdef( [[M4_YY_NOT_IN_HEADER]],
  */
 YY_DECL
 {
-	yy_state_type yy_current_state;
-	char *yy_cp, *yy_bp;
 	int yy_act;
     M4_YY_DECL_GUTS_VAR();
 
@@ -1218,6 +1233,9 @@ m4_ifdef( [[<M4_YY_BISON_LLOC>]],
 	if ( !YY_G(yy_init) )
 		{
 		YY_G(yy_init) = 1;
+#if defined(YY_STALLED)
+		YY_G(yy_resume) = 0;
+#endif /* defined(YY_STALLED) */
 
 #ifdef YY_USER_INIT
 		YY_USER_INIT;
@@ -1263,18 +1281,25 @@ m4_ifdef( [[M4_YY_USES_REJECT]],
 	{
 %% [7.0] user's declarations go here
 
+#if defined(YY_STALLED)
+		if(YY_G(yy_resume)){
+			YY_G(yy_resume)=0;
+			goto yy_match;
+		}
+#endif /* defined(YY_STALLED) */
+
 	while ( /*CONSTCOND*/1 )		/* loops until end-of-file is reached */
 		{
 %% [8.0] yymore()-related code goes here
-		yy_cp = YY_G(yy_c_buf_p);
+		YY_G(yy_cp) = YY_G(yy_c_buf_p);
 
 		/* Support of yytext. */
-		*yy_cp = YY_G(yy_hold_char);
+		*YY_G(yy_cp) = YY_G(yy_hold_char);
 
 		/* yy_bp points to the position in yy_ch_buf of the start of
 		 * the current run.
 		 */
-		yy_bp = yy_cp;
+		YY_G(yy_bp) = YY_G(yy_cp);
 
 %% [9.0] code to set up and find next match goes here
 
@@ -1296,10 +1321,10 @@ do_action:	/* This label is used only to access EOF actions. */
 	case YY_END_OF_BUFFER:
 		{
 		/* Amount of text matched not including the EOB char. */
-		int yy_amount_of_matched_text = (int) (yy_cp - YY_G(yytext_ptr)) - 1;
+		int yy_amount_of_matched_text = (int) (YY_G(yy_cp) - YY_G(yytext_ptr)) - 1;
 
 		/* Undo the effects of YY_DO_BEFORE_ACTION. */
-		*yy_cp = YY_G(yy_hold_char);
+		*YY_G(yy_cp) = YY_G(yy_hold_char);
 		YY_RESTORE_YY_MORE_OFFSET
 
 		if ( YY_CURRENT_BUFFER_LVALUE->yy_buffer_status == YY_BUFFER_NEW )
@@ -1336,7 +1361,7 @@ do_action:	/* This label is used only to access EOF actions. */
 
 			YY_G(yy_c_buf_p) = YY_G(yytext_ptr) + yy_amount_of_matched_text;
 
-			yy_current_state = yy_get_previous_state( M4_YY_CALL_ONLY_ARG );
+			YY_G(yy_current_state) = yy_get_previous_state( M4_YY_CALL_ONLY_ARG );
 
 			/* Okay, we're now positioned to make the NUL
 			 * transition.  We couldn't have
@@ -1347,15 +1372,15 @@ do_action:	/* This label is used only to access EOF actions. */
 			 * will run more slowly).
 			 */
 
-			yy_next_state = yy_try_NUL_trans( yy_current_state M4_YY_CALL_LAST_ARG);
+			yy_next_state = yy_try_NUL_trans( YY_G(yy_current_state) M4_YY_CALL_LAST_ARG);
 
-			yy_bp = YY_G(yytext_ptr) + YY_MORE_ADJ;
+			YY_G(yy_bp) = YY_G(yytext_ptr) + YY_MORE_ADJ;
 
 			if ( yy_next_state )
 				{
 				/* Consume the NUL. */
-				yy_cp = ++YY_G(yy_c_buf_p);
-				yy_current_state = yy_next_state;
+				YY_G(yy_cp) = ++YY_G(yy_c_buf_p);
+				YY_G(yy_current_state) = yy_next_state;
 				goto yy_match;
 				}
 
@@ -1401,21 +1426,41 @@ do_action:	/* This label is used only to access EOF actions. */
 				YY_G(yy_c_buf_p) =
 					YY_G(yytext_ptr) + yy_amount_of_matched_text;
 
-				yy_current_state = yy_get_previous_state( M4_YY_CALL_ONLY_ARG );
+				YY_G(yy_current_state) = yy_get_previous_state( M4_YY_CALL_ONLY_ARG );
 
-				yy_cp = YY_G(yy_c_buf_p);
-				yy_bp = YY_G(yytext_ptr) + YY_MORE_ADJ;
+				YY_G(yy_cp) = YY_G(yy_c_buf_p);
+				YY_G(yy_bp) = YY_G(yytext_ptr) + YY_MORE_ADJ;
 				goto yy_match;
 
 			case EOB_ACT_LAST_MATCH:
 				YY_G(yy_c_buf_p) =
 				&YY_CURRENT_BUFFER_LVALUE->yy_ch_buf[YY_G(yy_n_chars)];
 
-				yy_current_state = yy_get_previous_state( M4_YY_CALL_ONLY_ARG );
+				YY_G(yy_current_state) = yy_get_previous_state( M4_YY_CALL_ONLY_ARG );
 
-				yy_cp = YY_G(yy_c_buf_p);
-				yy_bp = YY_G(yytext_ptr) + YY_MORE_ADJ;
+				YY_G(yy_cp) = YY_G(yy_c_buf_p);
+				YY_G(yy_bp) = YY_G(yytext_ptr) + YY_MORE_ADJ;
 				goto yy_find_action;
+#if defined(YY_STALLED)
+			case EOB_ACT_STALLED:
+				YY_G(yy_c_buf_p) =
+					YY_G(yytext_ptr) + yy_amount_of_matched_text;
+
+				YY_G(yy_current_state) = yy_get_previous_state( yyscanner );
+
+				YY_G(yy_cp) = YY_G(yy_c_buf_p);
+				YY_G(yy_bp) = YY_G(yytext_ptr) + YY_MORE_ADJ;
+				YY_G(yy_resume)=1;
+				
+				printf("yytext_ptr='%s'\n", YY_G(yytext_ptr));
+				YY_BUFFER_STATE b = YY_CURRENT_BUFFER;
+				printf("yy_ch_buf[%d]=\n", b->yy_buf_size, b->yy_ch_buf);
+/*				dump_buffer(b->yy_ch_buf, b->yy_buf_size);*/
+				
+				printf("yy_current_state=%d\n", YY_G(yy_current_state));
+
+				return YY_STALLED;
+#endif /* defined(YY_STALLED) */
 			}
 		break;
 		}
@@ -1567,6 +1612,7 @@ m4_ifdef( [[M4_YY_NOT_IN_HEADER]],
  *	EOB_ACT_LAST_MATCH -
  *	EOB_ACT_CONTINUE_SCAN - continue scanning from current position
  *	EOB_ACT_END_OF_FILE - end of file
+ * 	EOB_ACT_STALLED - push lexer stalled, needs more data to resume
  */
 %if-c-only
 static int yy_get_next_buffer (M4_YY_DEF_ONLY_ARG)
@@ -1580,6 +1626,12 @@ int yyFlexLexer::yy_get_next_buffer()
 	char *source = YY_G(yytext_ptr);
 	int number_to_move, i;
 	int ret_val;
+
+#if defined(YY_STALLED)
+	if ( YY_CURRENT_BUFFER_LVALUE->yy_fill_buffer == 2 ){
+		return EOB_ACT_STALLED;
+	}
+#endif /* defined(YY_STALLED) */
 
 	if ( YY_G(yy_c_buf_p) > &YY_CURRENT_BUFFER_LVALUE->yy_ch_buf[YY_G(yy_n_chars) + 1] )
 		YY_FATAL_ERROR(
@@ -1726,18 +1778,16 @@ m4_ifdef( [[M4_YY_USES_REJECT]],
     yy_state_type yyFlexLexer::yy_get_previous_state()
 %endif
 {
-	yy_state_type yy_current_state;
-	char *yy_cp;
     M4_YY_DECL_GUTS_VAR();
 
 %% [15.0] code to get the start state into yy_current_state goes here
 
-	for ( yy_cp = YY_G(yytext_ptr) + YY_MORE_ADJ; yy_cp < YY_G(yy_c_buf_p); ++yy_cp )
+	for ( YY_G(yy_cp) = YY_G(yytext_ptr) + YY_MORE_ADJ; YY_G(yy_cp) < YY_G(yy_c_buf_p); ++YY_G(yy_cp) )
 		{
 %% [16.0] code to find the next state goes here
 		}
 
-	return yy_current_state;
+	return YY_G(yy_current_state);
 }
 
 
@@ -1747,18 +1797,19 @@ m4_ifdef( [[M4_YY_USES_REJECT]],
  *	next_state = yy_try_NUL_trans( current_state );
  */
 %if-c-only
-    static yy_state_type yy_try_NUL_trans  YYFARGS1( yy_state_type, yy_current_state)
+    static yy_state_type yy_try_NUL_trans  YYFARGS1( yy_state_type, yy_cur_state)
 %endif
 %if-c++-only
-    yy_state_type yyFlexLexer::yy_try_NUL_trans( yy_state_type yy_current_state )
+    yy_state_type yyFlexLexer::yy_try_NUL_trans( yy_state_type yy_cur_state )
 %endif
 {
 	int yy_is_jam;
     M4_YY_DECL_GUTS_VAR(); /* This var may be unused depending upon options. */
+	YY_G(yy_current_state) = yy_cur_state;
 %% [17.0] code to find the next state, and perhaps do backing up, goes here
 
 	M4_YY_NOOP_GUTS_VAR();
-return yy_is_jam ? 0 : yy_current_state;
+return yy_is_jam ? 0 : YY_G(yy_current_state);
 }
 
 
@@ -2395,6 +2446,85 @@ YY_BUFFER_STATE yy_scan_bytes  YYFARGS2( const char *,yybytes, int ,_yybytes_len
 	 * away when we're done.
 	 */
 	b->yy_is_our_buffer = 1;
+
+	return b;
+}
+%endif
+]])
+
+
+m4_ifdef( [[M4_YY_NO_APPEND_BYTES]],,
+[[
+%if-c-only
+YY_BUFFER_STATE yy_append_bytes  YYFARGS2( const char *,yybytes, int ,_yybytes_len)
+{
+    M4_YY_DECL_GUTS_VAR();
+	YY_BUFFER_STATE b = YY_CURRENT_BUFFER;
+	char *buf;
+	yy_size_t n;
+	int i;
+
+	if(!b){
+/*		return yy_scan_bytes(yybytes, _yybytes_len M4_YY_CALL_LAST_ARG);		*/
+		b = yy_scan_bytes( yybytes, _yybytes_len M4_YY_CALL_LAST_ARG);
+		b->yy_fill_buffer = 2;
+		printf("Leaving yy_append_bytes buf@%p:%d:%d\n", b->yy_ch_buf, b->yy_buf_size, b->yy_n_chars);
+/*		dump_buffer(b->yy_ch_buf, b->yy_n_chars+2);*/
+		return b;
+	}else{
+		printf("Entering yy_append_bytes buf@%p:%d:%d\n", b->yy_ch_buf, b->yy_buf_size, b->yy_n_chars);
+/*		dump_buffer(b->yy_ch_buf, b->yy_n_chars+2);*/
+	}
+
+// Do we need more room?
+	if(b->yy_n_chars+_yybytes_len>b->yy_buf_size){		// First try some clean up
+								// Chars before yytext_ptr aren't acutally needed any more.
+		int cbp_offs = YY_G(yy_c_buf_p) - YY_G(yytext_ptr);
+		int cp_offs = YY_G(yy_cp) - YY_G(yytext_ptr);
+		int bp_offs = YY_G(yy_bp) - YY_G(yytext_ptr);
+		int nbActive = b->yy_n_chars - (YY_G(yytext_ptr) - b->yy_ch_buf);
+		int cnt;
+		printf("Moving %d character(s) back %d places.\n", nbActive, (int)(YY_G(yytext_ptr) - b->yy_ch_buf));
+		for(cnt=0;cnt<nbActive;cnt++){
+			b->yy_ch_buf[cnt] = YY_G(yytext_ptr)[cnt];
+		}
+
+		YY_G(yytext_ptr) = b->yy_ch_buf;
+		YY_G(yy_c_buf_p) = YY_G(yytext_ptr) + cbp_offs;
+		YY_G(yy_cp) = YY_G(yytext_ptr) + cp_offs;
+		YY_G(yy_bp) = YY_G(yytext_ptr) + bp_offs;
+		b->yy_n_chars = nbActive;
+	}
+
+	if(b->yy_n_chars+_yybytes_len>b->yy_buf_size){		// If clean up wasn't enough, let's allocate more memory
+//		printf("~~~ yy_append_bytes MUST realloc\n");
+		printf("~~~ yy_append_bytes reallocating\n");
+		int cbp_offs = YY_G(yy_c_buf_p) - b->yy_ch_buf;
+		int cp_offs = YY_G(yy_cp) - b->yy_ch_buf;
+		int bp_offs = YY_G(yy_bp) - b->yy_ch_buf;
+		int text_offs = YY_G(yytext_ptr) - b->yy_ch_buf;
+		int new_size = b->yy_buf_size*2;
+		if(new_size<b->yy_n_chars+_yybytes_len){new_size = b->yy_n_chars+_yybytes_len;}
+		if(new_size<256){new_size=256;}
+		buf = (char *) yyrealloc( b->yy_ch_buf, new_size+2 M4_YY_CALL_LAST_ARG );
+		if ( ! buf )
+			YY_FATAL_ERROR( "out of dynamic memory in yy_scan_bytes()" );
+		b->yy_ch_buf = buf;
+		b->yy_buf_size = new_size;
+		YY_G(yy_c_buf_p) = b->yy_ch_buf + cbp_offs;
+		YY_G(yy_cp) = b->yy_ch_buf + cp_offs;
+		YY_G(yy_bp) = b->yy_ch_buf + bp_offs;
+		YY_G(yytext_ptr) = b->yy_ch_buf + text_offs;
+	}
+	
+	for(int cnt=0; cnt<_yybytes_len; cnt++){
+		b->yy_ch_buf[b->yy_n_chars+cnt] = yybytes[cnt];
+	}
+	b->yy_n_chars += _yybytes_len;
+	b->yy_ch_buf[b->yy_n_chars] = b->yy_ch_buf[b->yy_n_chars+1] = YY_END_OF_BUFFER_CHAR;
+
+	printf("Leaving yy_append_bytes buf@%p:%d:%d\n", b->yy_ch_buf, b->yy_buf_size, b->yy_n_chars);
+/*	dump_buffer(b->yy_ch_buf, b->yy_n_chars+2);*/
 
 	return b;
 }

--- a/src/gen.c
+++ b/src/gen.c
@@ -153,14 +153,14 @@ void gen_backing_up (void)
 		return;
 
 	if (fullspd)
-		indent_puts ("if ( yy_current_state[-1].yy_nxt )");
+		indent_puts ("if ( YY_G(yy_current_state)[-1].yy_nxt )");
 	else
-		indent_puts ("if ( yy_accept[yy_current_state] )");
+		indent_puts ("if ( yy_accept[YY_G(yy_current_state)] )");
 
 	++indent_level;
 	indent_puts ("{");
-	indent_puts ("YY_G(yy_last_accepting_state) = yy_current_state;");
-	indent_puts ("YY_G(yy_last_accepting_cpos) = yy_cp;");
+	indent_puts ("YY_G(yy_last_accepting_state) = YY_G(yy_current_state);");
+	indent_puts ("YY_G(yy_last_accepting_cpos) = YY_G(yy_cp);");
 	indent_puts ("}");
 	--indent_level;
 }
@@ -177,17 +177,17 @@ void gen_bu_action (void)
 
 	indent_puts ("case 0: /* must back up */");
 	indent_puts ("/* undo the effects of YY_DO_BEFORE_ACTION */");
-	indent_puts ("*yy_cp = YY_G(yy_hold_char);");
+	indent_puts ("*YY_G(yy_cp) = YY_G(yy_hold_char);");
 
 	if (fullspd || fulltbl)
-		indent_puts ("yy_cp = YY_G(yy_last_accepting_cpos) + 1;");
+		indent_puts ("YY_G(yy_cp) = YY_G(yy_last_accepting_cpos) + 1;");
 	else
 		/* Backing-up info for compressed tables is taken \after/
 		 * yy_cp has been incremented for the next state.
 		 */
-		indent_puts ("yy_cp = YY_G(yy_last_accepting_cpos);");
+		indent_puts ("YY_G(yy_cp) = YY_G(yy_last_accepting_cpos);");
 
-	indent_puts ("yy_current_state = YY_G(yy_last_accepting_state);");
+	indent_puts ("YY_G(yy_current_state) = YY_G(yy_last_accepting_state);");
 	indent_puts ("goto yy_find_action;");
 	outc ('\n');
 
@@ -501,14 +501,14 @@ void genecs (void)
 void gen_find_action (void)
 {
 	if (fullspd)
-		indent_puts ("yy_act = yy_current_state[-1].yy_nxt;");
+		indent_puts ("yy_act = YY_G(yy_current_state)[-1].yy_nxt;");
 
 	else if (fulltbl)
-		indent_puts ("yy_act = yy_accept[yy_current_state];");
+		indent_puts ("yy_act = yy_accept[YY_G(yy_current_state)];");
 
 	else if (reject) {
-		indent_puts ("yy_current_state = *--YY_G(yy_state_ptr);");
-		indent_puts ("YY_G(yy_lp) = yy_accept[yy_current_state];");
+		indent_puts ("YY_G(yy_current_state) = *--YY_G(yy_state_ptr);");
+		indent_puts ("YY_G(yy_lp) = yy_accept[YY_G(yy_current_state)];");
 
 		if (!variable_trailing_context_rules)
 			outn ("m4_ifdef( [[M4_YY_USES_REJECT]],\n[[");
@@ -525,7 +525,7 @@ void gen_find_action (void)
 		indent_puts ("{");
 
 		indent_puts
-			("if ( YY_G(yy_lp) && YY_G(yy_lp) < yy_accept[yy_current_state + 1] )");
+			("if ( YY_G(yy_lp) && YY_G(yy_lp) < yy_accept[YY_G(yy_current_state) + 1] )");
 		++indent_level;
 		indent_puts ("{");
 		indent_puts ("yy_act = yy_acclist[YY_G(yy_lp)];");
@@ -564,7 +564,7 @@ void gen_find_action (void)
 				 * due to REJECT.
 				 */
 				indent_puts
-					("YY_G(yy_full_match) = yy_cp;");
+					("YY_G(yy_full_match) = YY_G(yy_cp);");
 				indent_puts
 					("YY_G(yy_full_state) = YY_G(yy_state_ptr);");
 				indent_puts ("YY_G(yy_full_lp) = YY_G(yy_lp);");
@@ -576,7 +576,7 @@ void gen_find_action (void)
 			indent_puts ("else");
 			++indent_level;
 			indent_puts ("{");
-			indent_puts ("YY_G(yy_full_match) = yy_cp;");
+			indent_puts ("YY_G(yy_full_match) = YY_G(yy_cp);");
 			indent_puts
 				("YY_G(yy_full_state) = YY_G(yy_state_ptr);");
 			indent_puts ("YY_G(yy_full_lp) = YY_G(yy_lp);");
@@ -594,7 +594,7 @@ void gen_find_action (void)
 			 */
 			++indent_level;
 			indent_puts ("{");
-			indent_puts ("YY_G(yy_full_match) = yy_cp;");
+			indent_puts ("YY_G(yy_full_match) = YY_G(yy_cp);");
 			indent_puts ("break;");
 			indent_puts ("}");
 			--indent_level;
@@ -603,14 +603,14 @@ void gen_find_action (void)
 		indent_puts ("}");
 		--indent_level;
 
-		indent_puts ("--yy_cp;");
+		indent_puts ("--YY_G(yy_cp);");
 
 		/* We could consolidate the following two lines with those at
 		 * the beginning, but at the cost of complaints that we're
 		 * branching inside a loop.
 		 */
-		indent_puts ("yy_current_state = *--YY_G(yy_state_ptr);");
-		indent_puts ("YY_G(yy_lp) = yy_accept[yy_current_state];");
+		indent_puts ("YY_G(yy_current_state) = *--YY_G(yy_state_ptr);");
+		indent_puts ("YY_G(yy_lp) = yy_accept[YY_G(yy_current_state)];");
 
 		indent_puts ("}");
 
@@ -618,7 +618,7 @@ void gen_find_action (void)
 	}
 
 	else {			/* compressed */
-		indent_puts ("yy_act = yy_accept[yy_current_state];");
+		indent_puts ("yy_act = yy_accept[YY_G(yy_current_state)];");
 
 		if (interactive && !reject) {
 			/* Do the guaranteed-needed backing up to figure out
@@ -628,11 +628,11 @@ void gen_find_action (void)
 			++indent_level;
 			indent_puts ("{ /* have to back up */");
 			indent_puts
-				("yy_cp = YY_G(yy_last_accepting_cpos);");
+				("YY_G(yy_cp) = YY_G(yy_last_accepting_cpos);");
 			indent_puts
-				("yy_current_state = YY_G(yy_last_accepting_state);");
+				("YY_G(yy_current_state) = YY_G(yy_last_accepting_state);");
 			indent_puts
-				("yy_act = yy_accept[yy_current_state];");
+				("yy_act = yy_accept[YY_G(yy_current_state)];");
 			indent_puts ("}");
 			--indent_level;
 		}
@@ -724,10 +724,10 @@ void gen_next_compressed_state (char *char_map)
 	gen_backing_up ();
 
 	indent_puts
-		("while ( yy_chk[yy_base[yy_current_state] + yy_c] != yy_current_state )");
+		("while ( yy_chk[yy_base[YY_G(yy_current_state)] + yy_c] != YY_G(yy_current_state) )");
 	++indent_level;
 	indent_puts ("{");
-	indent_puts ("yy_current_state = (int) yy_def[yy_current_state];");
+	indent_puts ("YY_G(yy_current_state) = (int) yy_def[YY_G(yy_current_state)];");
 
 	if (usemecs) {
 		/* We've arrange it so that templates are never chained
@@ -740,7 +740,7 @@ void gen_next_compressed_state (char *char_map)
 		do_indent ();
 
 		/* lastdfa + 2 is the beginning of the templates */
-		out_dec ("if ( yy_current_state >= %d )\n", lastdfa + 2);
+		out_dec ("if ( YY_G(yy_current_state) >= %d )\n", lastdfa + 2);
 
 		++indent_level;
 		indent_puts ("yy_c = yy_meta[yy_c];");
@@ -751,7 +751,7 @@ void gen_next_compressed_state (char *char_map)
 	--indent_level;
 
 	indent_puts
-		("yy_current_state = yy_nxt[yy_base[yy_current_state] + yy_c];");
+		("YY_G(yy_current_state) = yy_nxt[yy_base[YY_G(yy_current_state)] + yy_c];");
 }
 
 
@@ -763,19 +763,19 @@ void gen_next_match (void)
 	 * gen_NUL_trans().
 	 */
 	char   *char_map = useecs ?
-		"yy_ec[YY_SC_TO_UI(*yy_cp)] " : "YY_SC_TO_UI(*yy_cp)";
+		"yy_ec[YY_SC_TO_UI(*YY_G(yy_cp))] " : "YY_SC_TO_UI(*YY_G(yy_cp))";
 
 	char   *char_map_2 = useecs ?
-		"yy_ec[YY_SC_TO_UI(*++yy_cp)] " : "YY_SC_TO_UI(*++yy_cp)";
+		"yy_ec[YY_SC_TO_UI(*++YY_G(yy_cp))] " : "YY_SC_TO_UI(*++YY_G(yy_cp))";
 
 	if (fulltbl) {
 		if (gentables)
 			indent_put2s
-				("while ( (yy_current_state = yy_nxt[yy_current_state][ %s ]) > 0 )",
+				("while ( (YY_G(yy_current_state) = yy_nxt[YY_G(yy_current_state)][ %s ]) > 0 )",
 				 char_map);
 		else
 			indent_put2s
-				("while ( (yy_current_state = yy_nxt[yy_current_state*YY_NXT_LOLEN +  %s ]) > 0 )",
+				("while ( (YY_G(yy_current_state) = yy_nxt[YY_G(yy_current_state)*YY_NXT_LOLEN +  %s ]) > 0 )",
 				 char_map);
 
 		++indent_level;
@@ -786,7 +786,7 @@ void gen_next_match (void)
 			outc ('\n');
 		}
 
-		indent_puts ("++yy_cp;");
+		indent_puts ("++YY_G(yy_cp);");
 
 		if (num_backing_up > 0)
 
@@ -795,7 +795,7 @@ void gen_next_match (void)
 		--indent_level;
 
 		outc ('\n');
-		indent_puts ("yy_current_state = -yy_current_state;");
+		indent_puts ("YY_G(yy_current_state) = -YY_G(yy_current_state);");
 	}
 
 	else if (fullspd) {
@@ -805,7 +805,7 @@ void gen_next_match (void)
 		indent_puts ("YY_CHAR yy_c;\n");
 		indent_put2s ("for ( yy_c = %s;", char_map);
 		indent_puts
-			("      (yy_trans_info = &yy_current_state[yy_c])->");
+			("      (yy_trans_info = &YY_G(yy_current_state)[yy_c])->");
 		indent_puts ("yy_verify == yy_c;");
 		indent_put2s ("      yy_c = %s )", char_map_2);
 
@@ -814,7 +814,7 @@ void gen_next_match (void)
 		if (num_backing_up > 0)
 			indent_puts ("{");
 
-		indent_puts ("yy_current_state += yy_trans_info->yy_nxt;");
+		indent_puts ("YY_G(yy_current_state) += yy_trans_info->yy_nxt;");
 
 		if (num_backing_up > 0) {
 			outc ('\n');
@@ -834,7 +834,7 @@ void gen_next_match (void)
 
 		gen_next_state (false);
 
-		indent_puts ("++yy_cp;");
+		indent_puts ("++YY_G(yy_cp);");
 
 
 		indent_puts ("}");
@@ -843,9 +843,9 @@ void gen_next_match (void)
 		do_indent ();
 
 		if (interactive)
-			out_dec ("while ( yy_base[yy_current_state] != %d );\n", jambase);
+			out_dec ("while ( yy_base[YY_G(yy_current_state)] != %d );\n", jambase);
 		else
-			out_dec ("while ( yy_current_state != %d );\n",
+			out_dec ("while ( YY_G(yy_current_state) != %d );\n",
 				 jamstate);
 
 		if (!reject && !interactive) {
@@ -853,9 +853,9 @@ void gen_next_match (void)
 			 * the match.
 			 */
 			indent_puts
-				("yy_cp = YY_G(yy_last_accepting_cpos);");
+				("YY_G(yy_cp) = YY_G(yy_last_accepting_cpos);");
 			indent_puts
-				("yy_current_state = YY_G(yy_last_accepting_state);");
+				("YY_G(yy_current_state) = YY_G(yy_last_accepting_state);");
 		}
 	}
 }
@@ -870,25 +870,25 @@ void gen_next_state (int worry_about_NULs)
 	if (worry_about_NULs && !nultrans) {
 		if (useecs)
 			snprintf (char_map, sizeof(char_map),
-					"(*yy_cp ? yy_ec[YY_SC_TO_UI(*yy_cp)] : %d)",
+					"(*YY_G(yy_cp) ? yy_ec[YY_SC_TO_UI(*YY_G(yy_cp))] : %d)",
 					NUL_ec);
 		else
             snprintf (char_map, sizeof(char_map),
-					"(*yy_cp ? YY_SC_TO_UI(*yy_cp) : %d)",
+					"(*YY_G(yy_cp) ? YY_SC_TO_UI(*YY_G(yy_cp)) : %d)",
 					NUL_ec);
 	}
 
 	else
 		strcpy (char_map, useecs ?
-			"yy_ec[YY_SC_TO_UI(*yy_cp)] " :
-			"YY_SC_TO_UI(*yy_cp)");
+			"yy_ec[YY_SC_TO_UI(*YY_G(yy_cp))] " :
+			"YY_SC_TO_UI(*YY_G(yy_cp))");
 
 	if (worry_about_NULs && nultrans) {
 		if (!fulltbl && !fullspd)
 			/* Compressed tables back up *before* they match. */
 			gen_backing_up ();
 
-		indent_puts ("if ( *yy_cp )");
+		indent_puts ("if ( *YY_G(yy_cp) )");
 		++indent_level;
 		indent_puts ("{");
 	}
@@ -896,17 +896,17 @@ void gen_next_state (int worry_about_NULs)
 	if (fulltbl) {
 		if (gentables)
 			indent_put2s
-				("yy_current_state = yy_nxt[yy_current_state][%s];",
+				("YY_G(yy_current_state) = yy_nxt[YY_G(yy_current_state)][%s];",
 				 char_map);
 		else
 			indent_put2s
-				("yy_current_state = yy_nxt[yy_current_state*YY_NXT_LOLEN + %s];",
+				("YY_G(yy_current_state) = yy_nxt[YY_G(yy_current_state)*YY_NXT_LOLEN + %s];",
 				 char_map);
 	}
 
 	else if (fullspd)
 		indent_put2s
-			("yy_current_state += yy_current_state[%s].yy_nxt;",
+			("YY_G(yy_current_state) += YY_G(yy_current_state)[%s].yy_nxt;",
 			 char_map);
 
 	else
@@ -919,7 +919,7 @@ void gen_next_state (int worry_about_NULs)
 		indent_puts ("else");
 		++indent_level;
 		indent_puts
-			("yy_current_state = yy_NUL_trans[yy_current_state];");
+			("YY_G(yy_current_state) = yy_NUL_trans[YY_G(yy_current_state)];");
 		--indent_level;
 	}
 
@@ -927,7 +927,7 @@ void gen_next_state (int worry_about_NULs)
 		gen_backing_up ();
 
 	if (reject)
-		indent_puts ("*YY_G(yy_state_ptr)++ = yy_current_state;");
+		indent_puts ("*YY_G(yy_state_ptr)++ = YY_G(yy_current_state);");
 }
 
 
@@ -944,23 +944,23 @@ void gen_NUL_trans (void)
 		/* We're going to need yy_cp lying around for the call
 		 * below to gen_backing_up().
 		 */
-		indent_puts ("char *yy_cp = YY_G(yy_c_buf_p);");
+		indent_puts ("YY_G(yy_cp) = YY_G(yy_c_buf_p);");
 
 	outc ('\n');
 
 	if (nultrans) {
 		indent_puts
-			("yy_current_state = yy_NUL_trans[yy_current_state];");
-		indent_puts ("yy_is_jam = (yy_current_state == 0);");
+			("YY_G(yy_current_state) = yy_NUL_trans[YY_G(yy_current_state)];");
+		indent_puts ("yy_is_jam = (YY_G(yy_current_state) == 0);");
 	}
 
 	else if (fulltbl) {
 		do_indent ();
 		if (gentables)
-			out_dec ("yy_current_state = yy_nxt[yy_current_state][%d];\n", NUL_ec);
+			out_dec ("YY_G(yy_current_state) = yy_nxt[YY_G(yy_current_state)][%d];\n", NUL_ec);
 		else
-			out_dec ("yy_current_state = yy_nxt[yy_current_state*YY_NXT_LOLEN + %d];\n", NUL_ec);
-		indent_puts ("yy_is_jam = (yy_current_state <= 0);");
+			out_dec ("YY_G(yy_current_state) = yy_nxt[YY_G(yy_current_state)*YY_NXT_LOLEN + %d];\n", NUL_ec);
+		indent_puts ("yy_is_jam = (YY_G(yy_current_state) <= 0);");
 	}
 
 	else if (fullspd) {
@@ -970,8 +970,8 @@ void gen_NUL_trans (void)
 		indent_puts
 			("const struct yy_trans_info *yy_trans_info;\n");
 		indent_puts
-			("yy_trans_info = &yy_current_state[(unsigned int) yy_c];");
-		indent_puts ("yy_current_state += yy_trans_info->yy_nxt;");
+			("yy_trans_info = &YY_G(yy_current_state)[(unsigned int) yy_c];");
+		indent_puts ("YY_G(yy_current_state) += yy_trans_info->yy_nxt;");
 
 		indent_puts
 			("yy_is_jam = (yy_trans_info->yy_verify != yy_c);");
@@ -984,7 +984,7 @@ void gen_NUL_trans (void)
 		gen_next_compressed_state (NUL_ec_str);
 
 		do_indent ();
-		out_dec ("yy_is_jam = (yy_current_state == %d);\n",
+		out_dec ("yy_is_jam = (YY_G(yy_current_state) == %d);\n",
 			 jamstate);
 
 		if (reject) {
@@ -995,7 +995,7 @@ void gen_NUL_trans (void)
 			indent_puts ("if ( ! yy_is_jam )");
 			++indent_level;
 			indent_puts
-				("*YY_G(yy_state_ptr)++ = yy_current_state;");
+				("*YY_G(yy_state_ptr)++ = YY_G(yy_current_state);");
 			--indent_level;
 		}
 	}
@@ -1023,18 +1023,18 @@ void gen_start_state (void)
 	if (fullspd) {
 		if (bol_needed) {
 			indent_puts
-				("yy_current_state = yy_start_state_list[YY_G(yy_start) + YY_AT_BOL()];");
+				("YY_G(yy_current_state) = yy_start_state_list[YY_G(yy_start) + YY_AT_BOL()];");
 		}
 		else
 			indent_puts
-				("yy_current_state = yy_start_state_list[YY_G(yy_start)];");
+				("YY_G(yy_current_state) = yy_start_state_list[YY_G(yy_start)];");
 	}
 
 	else {
-		indent_puts ("yy_current_state = YY_G(yy_start);");
+		indent_puts ("YY_G(yy_current_state) = YY_G(yy_start);");
 
 		if (bol_needed)
-			indent_puts ("yy_current_state += YY_AT_BOL();");
+			indent_puts ("YY_G(yy_current_state) += YY_AT_BOL();");
 
 		if (reject) {
 			/* Set up for storing up states. */
@@ -1042,7 +1042,7 @@ void gen_start_state (void)
 			indent_puts
 				("YY_G(yy_state_ptr) = YY_G(yy_state_buf);");
 			indent_puts
-				("*YY_G(yy_state_ptr)++ = yy_current_state;");
+				("*YY_G(yy_state_ptr)++ = YY_G(yy_current_state);");
 			outn ("]])");
 		}
 	}
@@ -1506,11 +1506,11 @@ void make_tables (void)
 	if (yymore_used && !yytext_is_array) {
 		indent_puts ("YY_G(yytext_ptr) -= YY_G(yy_more_len); \\");
 		indent_puts
-			("yyleng = (int) (yy_cp - YY_G(yytext_ptr)); \\");
+			("yyleng = (int) (YY_G(yy_cp) - YY_G(yytext_ptr)); \\");
 	}
 
 	else
-		indent_puts ("yyleng = (int) (yy_cp - yy_bp); \\");
+		indent_puts ("yyleng = (int) (YY_G(yy_cp) - YY_G(yy_bp)); \\");
 
 	/* Now also deal with copying yytext_ptr to yytext if needed. */
 	skelout ();		/* %% [3.0] - break point in skel */
@@ -1769,13 +1769,13 @@ void make_tables (void)
 
 		outn ("#define REJECT \\");
 		outn ("{ \\");
-		outn ("*yy_cp = YY_G(yy_hold_char); /* undo effects of setting up yytext */ \\");
-		outn ("yy_cp = YY_G(yy_full_match); /* restore poss. backed-over text */ \\");
+		outn ("*YY_G(yy_cp) = YY_G(yy_hold_char); /* undo effects of setting up yytext */ \\");
+		outn ("YY_G(yy_cp) = YY_G(yy_full_match); /* restore poss. backed-over text */ \\");
 
 		if (variable_trailing_context_rules) {
 			outn ("YY_G(yy_lp) = YY_G(yy_full_lp); /* restore orig. accepting pos. */ \\");
 			outn ("YY_G(yy_state_ptr) = YY_G(yy_full_state); /* restore orig. state */ \\");
-			outn ("yy_current_state = *YY_G(yy_state_ptr); /* restore curr. state */ \\");
+			outn ("YY_G(yy_current_state) = *YY_G(yy_state_ptr); /* restore curr. state */ \\");
 		}
 
 		outn ("++YY_G(yy_lp); \\");
@@ -2088,7 +2088,7 @@ void make_tables (void)
 	set_indent (4);
 
 	if (fullspd || fulltbl)
-		indent_puts ("yy_cp = YY_G(yy_c_buf_p);");
+		indent_puts ("YY_G(yy_cp) = YY_G(yy_c_buf_p);");
 
 	else {			/* compressed table */
 		if (!reject && !interactive) {
@@ -2096,9 +2096,9 @@ void make_tables (void)
 			 * out the match.
 			 */
 			indent_puts
-				("yy_cp = YY_G(yy_last_accepting_cpos);");
+				("YY_G(yy_cp) = YY_G(yy_last_accepting_cpos);");
 			indent_puts
-				("yy_current_state = YY_G(yy_last_accepting_state);");
+				("YY_G(yy_current_state) = YY_G(yy_last_accepting_state);");
 		}
 
 		else
@@ -2106,7 +2106,7 @@ void make_tables (void)
 			 * yy_current_state was set up by
 			 * yy_get_previous_state().
 			 */
-			indent_puts ("yy_cp = YY_G(yy_c_buf_p);");
+			indent_puts ("YY_G(yy_cp) = YY_G(yy_c_buf_p);");
 	}
 
 


### PR DESCRIPTION
Hi,

This is my very first (beta) proposal for adding "push lexer" functionality to flex.
The rationale is since bison has a push mode, adding this functionality allows the whole lexer/parser to yield instead of doing a blocking wait for more input data. This is useful for example in embedded systems, where micro controllers do not have threads, but could benefit for online protocol parsing.

### How it works:
some (most) local variables from YY_DECL have been transferred to the yy_guts structure.
YY_DECL can now return YY_STALLED if no data is available to complete the current lexeme.
This happens if yy_fill_buffer is equal to 2 (maybe this should be changed to a #define) and a YY_STALLED (preprocessor) symbol exists.
There is a new yy_append_bytes function that appends bytes to the current input buffer (it can increase its size, but does not replace it like yy_scan_bytes).

### Status:
All tests pass. The tests will be adapted so they run also in the push lexer configuration, where that makes sense.

Please give me some feedback on the design decisions I made, and what should be changed (for example usage of a % keyword).

Cheers,
Jérôme.