### PR TITLE
fix compile warning originating in cpp skeleton

### DIFF
--- a/src/cpp-flex.skl
+++ b/src/cpp-flex.skl
@@ -2390,7 +2390,7 @@ int yyFlexLexer::LexerInput( char* buf, int max_size )
 	if ( yyin.bad() ) {
 		return -1;
 	} else {
-		return yyin.gcount();
+		return (int)yyin.gcount();
 	}
 #endif
 }


### PR DESCRIPTION
`gcount()` is of type `streamsize` which has a system-dependent size with at least `int`. Because of the `int max_size` limit no bigger value will be returned, the explicit cast fixes warnings from compilers/static analyzers.

As an alternative `LexerInput` may be changed to have a return and parameter of type `streamsize`, but this would need more changes and likely create more warnings in other places.

This issue originates from https://github.com/lexxmark/winflexbison/issues/73 where more details can be found (this is not a MSVC only issue).