### PR TITLE
Remove trailing whitespace

### DIFF
--- a/src/c99-flex.skl
+++ b/src/c99-flex.skl
@@ -239,14 +239,14 @@ const int YY_END_OF_BUFFER_CHAR = 0;
 
 /*
  * Amount of stuff to slurp up with each read.
- * We assume the stdio library has already 
- * chosen a fit size foe whatever platform 
+ * We assume the stdio library has already
+ * chosen a fit size foe whatever platform
  * we're running on.
  */
 const int YY_READ_BUF_SIZE = BUFSIZ;
 
 /* Size of default input buffer. We want to be able to fit two
- * OS-level reads, but efficiency gains as the buffer size 
+ * OS-level reads, but efficiency gains as the buffer size
  * increases fall off after that
  */
 const int YY_BUF_SIZE =  m4_ifdef([[M4_MODE_YY_BUFSIZE]], [[M4_MODE_YY_BUFSIZE]], [[2 * YY_READ_BUF_SIZE]]);
@@ -337,7 +337,7 @@ static const YY_CHAR yy_ec[M4_HOOK_ECSTABLE_SIZE] = { 0,
 M4_HOOK_ECSTABLE_BODY[[]]m4_dnl
 };
 ]])
- 
+
 m4_ifdef( [[M4_MODE_USEMECS]],[[m4_dnl
 /* Character meta-equivalence-class mappings */
 static const YY_CHAR yy_meta[M4_HOOK_MECSTABLE_SIZE] = { 0,
@@ -861,14 +861,14 @@ void yyrestart(FILE * input_file, yyscan_t yyscanner)
 
 	yy_init_buffer( yyscanner->yy_buffer_stack[yyscanner->yy_buffer_stack_top], input_file, yyscanner);
 	yy_load_buffer_state( yyscanner );
-	
-m4_ifdef( [[M4_MODE_USES_REJECT]], [[        
+
+m4_ifdef( [[M4_MODE_USES_REJECT]], [[
 	/* Ensure the reject state buffer is large enough.
 	 */
 	if ( yyscanner->yy_state_buf_max < (yy_current_buffer(yyscanner)->yy_buf_size + YY_STATE_BUF_EXTRA_SPACE) ) {
 		new_size = yy_current_buffer(yyscanner)->yy_buf_size + YY_STATE_BUF_EXTRA_SPACE;
 		new_state_buf = (yy_state_type*) yyrealloc( yyscanner->yy_state_buf, (new_size * sizeof(yy_state_type)), yyscanner );
-		
+
 		if ( new_state_buf == NULL ) {
 			yypanic( "out of dynamic memory in yylex()", yyscanner );
 		}
@@ -1598,7 +1598,7 @@ void yy_switch_to_buffer(yybuffer new_buffer, yyscan_t yyscanner)
 {
 	size_t new_size = 0;
 	yy_state_type *new_state_buf = 0;
-	
+
 	/* TODO. We should be able to replace this entire function body
 	 * with
 	 *		yypop_buffer_state();
@@ -1624,7 +1624,7 @@ m4_ifdef( [[M4_MODE_USES_REJECT]], [[
 	if ( yyscanner->yy_state_buf_max < (yy_current_buffer(yyscanner)->yy_buf_size + YY_STATE_BUF_EXTRA_SPACE) ) {
 		new_size = yy_current_buffer(yyscanner)->yy_buf_size + YY_STATE_BUF_EXTRA_SPACE;
 		new_state_buf = (yy_state_type *)yyrealloc( yyscanner->yy_state_buf, (new_size * sizeof(yy_state_type)), yyscanner );
-		
+
 		if ( new_state_buf == NULL ) {
 			yypanic( "out of dynamic memory in yylex()", yyscanner );
 		}
@@ -2034,7 +2034,7 @@ m4_ifdef( [[<M4_YY_BISON_LLOC>]],
 			yyscanner->yy_buffer_stack[yyscanner->yy_buffer_stack_top] =
 				yy_create_buffer( yyscanner->yyin_r, YY_BUF_SIZE, yyscanner);
 		}
-		
+
 m4_ifdef( [[M4_MODE_USES_REJECT]],
 [[
 		/* Create the reject buffer large enough to save one state per allowed character.
@@ -2135,7 +2135,7 @@ m4_ifdef([[M4_MODE_VARIABLE_TRAILING_CONTEXT_RULES]], [[
 							yy_act &= ~YY_TRAILING_HEAD_MASK;
 							break;
 						}
-					} else if (( yy_act & YY_TRAILING_MASK) != 0) { 
+					} else if (( yy_act & YY_TRAILING_MASK) != 0) {
 						yyscanner->yy_looking_for_trail_begin = yy_act & ~YY_TRAILING_MASK;
 						yyscanner->yy_looking_for_trail_begin |= YY_TRAILING_HEAD_MASK;
 m4_ifdef([[M4_MODE_REAL_REJECT]], [[

--- a/src/cpp-flex.skl
+++ b/src/cpp-flex.skl
@@ -87,7 +87,7 @@ m4_ifdef( [[M4_YY_IN_HEADER]], [[m4_dnl
 #define M4_MODE_PREFIX[[HEADER_H]]
 #define M4_MODE_PREFIX[[IN_HEADER]] 1
 
-]])				
+]])
 m4_ifdef( [[M4_YY_IN_HEADER]],,[[m4_dnl
 m4_ifdef([[M4_MODE_C_ONLY]], [[
 m4_ifdef([[M4_YY_NOT_REENTRANT]], [[
@@ -932,7 +932,7 @@ static const YY_CHAR * yy_ec = 0;
 ]])
 
 ]])
- 
+
 m4_ifdef( [[M4_MODE_USEMECS]],[[m4_dnl
 /* Character meta-equivalence-class mappings */
 m4_ifdef( [[M4_MODE_GENTABLES]],[[m4_dnl
@@ -1484,14 +1484,14 @@ m4_define( [[M4_YY_NO_TOP_STATE]])
 
 /*
  * Amount of stuff to slurp up with each read.
- * We assume the stdio library has already 
- * chosen a fit size foe whatever platform 
+ * We assume the stdio library has already
+ * chosen a fit size foe whatever platform
  * we're running on.
  */
 #define YY_READ_BUF_SIZE BUFSIZ
 
 /* Size of default input buffer. We want to be able to fit two
- * OS-level reads, but efficiency gains as the buffer size 
+ * OS-level reads, but efficiency gains as the buffer size
  * increases fall off after that
  */
 #ifndef YY_BUF_SIZE
@@ -1904,7 +1904,7 @@ m4_ifdef([[M4_MODE_CXX_ONLY]], [[
 			YY_CURRENT_BUFFER_LVALUE =
 				yy_create_buffer( yyin, YY_BUF_SIZE M4_YY_CALL_LAST_ARG);
 		}
-		
+
 m4_ifdef( [[M4_MODE_USES_REJECT]],
 [[
 		/* Create the reject buffer large enough to save one state per allowed character.
@@ -2009,7 +2009,7 @@ m4_ifdef([[M4_MODE_VARIABLE_TRAILING_CONTEXT_RULES]], [[
 							yy_act &= ~YY_TRAILING_HEAD_MASK;
 							break;
 						}
-					} else if (( yy_act & YY_TRAILING_MASK) != 0) { 
+					} else if (( yy_act & YY_TRAILING_MASK) != 0) {
 						YY_G(yy_looking_for_trail_begin) = yy_act & ~YY_TRAILING_MASK;
 						YY_G(yy_looking_for_trail_begin) |= YY_TRAILING_HEAD_MASK;
 m4_ifdef([[M4_MODE_REAL_REJECT]], [[
@@ -2843,14 +2843,14 @@ void yyFlexLexer::yyrestart( std::istream& input_file )
 
 	yy_init_buffer( YY_CURRENT_BUFFER_LVALUE, input_file M4_YY_CALL_LAST_ARG);
 	yy_load_buffer_state( M4_YY_CALL_ONLY_ARG );
-	
-m4_ifdef( [[M4_MODE_USES_REJECT]], [[        
+
+m4_ifdef( [[M4_MODE_USES_REJECT]], [[
 	/* Ensure the reject state buffer is large enough.
 	 */
 	if ( YY_G(yy_state_buf_max) < (yy_current_buffer()->yy_buf_size + YY_STATE_BUF_EXTRA_SPACE) ) {
 		new_size = yy_current_buffer()->yy_buf_size + YY_STATE_BUF_EXTRA_SPACE;
 		new_state_buf = (yy_state_type *)yyrealloc( YY_G(yy_state_buf), (new_size * sizeof(yy_state_type)) M4_YY_CALL_LAST_ARG );
-		
+
 		if ( new_state_buf == NULL ) {
 			YY_FATAL_ERROR( "out of dynamic memory in yylex()" );
 		}
@@ -2917,14 +2917,14 @@ void yyFlexLexer::yy_switch_to_buffer( yybuffer new_buffer )
 
 	YY_CURRENT_BUFFER_LVALUE = new_buffer;
 	yy_load_buffer_state( M4_YY_CALL_ONLY_ARG );
-	
+
 m4_ifdef( [[M4_MODE_USES_REJECT]], [[
 	/* Ensure the reject state buffer is large enough.
 	 */
 	if ( YY_G(yy_state_buf_max) < (YY_CURRENT_BUFFER_LVALUE->yy_buf_size + YY_STATE_BUF_EXTRA_SPACE) ) {
 		new_size = YY_CURRENT_BUFFER_LVALUE->yy_buf_size + YY_STATE_BUF_EXTRA_SPACE;
 		new_state_buf = (yy_state_type *)yyrealloc( YY_G(yy_state_buf), (new_size * sizeof(yy_state_type)) M4_YY_CALL_LAST_ARG );
-		
+
 		if ( new_state_buf == NULL ) {
 			YY_FATAL_ERROR( "out of dynamic memory in yylex()" );
 		}

--- a/src/go-flex.skl
+++ b/src/go-flex.skl
@@ -171,14 +171,14 @@ const int flexBufferSentinel = 0;
 
 /*
  * Amount of stuff to slurp up with each read.
- * We assume the stdio library has already 
- * chosen a fit size foe whatever platform 
+ * We assume the stdio library has already
+ * chosen a fit size foe whatever platform
  * we're running on.
  */
 const int flexReadBufferSize = BUFSIZ;
 
 /* Size of default input buffer. We want to be able to fit two
- * OS-level reads, but efficiency gains as the buffer size 
+ * OS-level reads, but efficiency gains as the buffer size
  * increases fall off after that
  */
 const int flexInputBufferSize =  m4_ifdef([[M4_MODE_YY_BUFSIZE]], [[M4_MODE_YY_BUFSIZE]], [[2 * flexReadBufferSize]]);
@@ -263,7 +263,7 @@ static const YY_CHAR yyEC[M4_HOOK_ECSTABLE_SIZE] = { 0,
 M4_HOOK_ECSTABLE_BODY[[]]m4_dnl
 };
 ]])
- 
+
 m4_ifdef([[M4_MODE_USEMECS]],[[m4_dnl
 /* Character meta-equivalence-class mappings */
 static const YY_CHAR yyMeta[M4_HOOK_MECSTABLE_SIZE] = { 0,
@@ -759,10 +759,10 @@ void yypop_buffer_state (FlexLexer *yyscanner)
  */
 void yyrestart(FILE * input_file, FlexLexer *yyscanner)
 {
-	
+
 	size_t newSize = 0;
 	yyStateType *newStateBuf = 0;
-	
+
 	if (yy_current_buffer(yyscanner) == NULL) {
 		yyensure_buffer_stack (yyscanner);
 		yyscanner->yyBufferStack[yyscanner->yyBufferStackTop] =
@@ -771,14 +771,14 @@ void yyrestart(FILE * input_file, FlexLexer *yyscanner)
 
 	yy_init_buffer(yyscanner->yyBufferStack[yyscanner->yyBufferStackTop], input_file, yyscanner);
 	yy_load_buffer_state(yyscanner);
-	
-m4_ifdef( [[M4_MODE_USES_REJECT]], [[        
+
+m4_ifdef( [[M4_MODE_USES_REJECT]], [[
 	/* Ensure the reject state buffer is large enough.
 	 */
 	if ( yyscanner->yyStateBufMax < (yy_current_buffer(yyscanner)->yyInputBufSize + YY_STATE_BUF_EXTRA_SPACE) ) {
 		newSize = yy_current_buffer(yyscanner)->yyInputBufSize + YY_STATE_BUF_EXTRA_SPACE;
 		newStateBuf = (yyStateType *)yyrealloc( yyscanner->yyStateBuf, (newSize * sizeof(yyStateType)), yyscanner );
-		
+
 		if ( newStateBuf == NULL ) {
 			yypanic( "out of dynamic memory in yylex()", yyscanner );
 		}
@@ -1468,14 +1468,14 @@ void yy_switch_to_buffer(yybuffer newBuffer, FlexLexer *yyscanner)
 
 	yyscanner->yyBufferStack[yyscanner->yyBufferStackTop] = newBuffer;
 	yy_load_buffer_state(yyscanner);
-	
+
 m4_ifdef( [[M4_MODE_USES_REJECT]], [[
 	/* Ensure the reject state buffer is large enough.
 	 */
 	if ( yyscanner->yyStateBufMax < (yy_current_buffer(yyscanner)->yyInputBufSize + YY_STATE_BUF_EXTRA_SPACE) ) {
 		newSize = yy_current_buffer(yyscanner)->yyInputBufSize + YY_STATE_BUF_EXTRA_SPACE;
 		newStateBuf = (yyStateType *)yyrealloc( yyscanner->yyStateBuf, (newSize * sizeof(yyStateType)), yyscanner );
-		
+
 		if ( newStateBuf == NULL ) {
 			yypanic( "out of dynamic memory in yylex()", yyscanner );
 		}
@@ -1986,7 +1986,7 @@ m4_ifdef([[M4_MODE_VARIABLE_TRAILING_CONTEXT_RULES]], [[
 							yyAct &= ~YY_TRAILING_HEAD_MASK;
 							break;
 						}
-					} else if ((yyAct & YY_TRAILING_MASK) != 0) { 
+					} else if ((yyAct & YY_TRAILING_MASK) != 0) {
 						yyscanner->yyLookingForTrailBegin = yyAct & ~YY_TRAILING_MASK;
 						yyscanner->yyLookingForTrailBegin |= YY_TRAILING_HEAD_MASK;
 m4_ifdef([[M4_MODE_REAL_REJECT]], [[


### PR DESCRIPTION
Many projects have pre-commit hooks that check for pedantic things like trailing whitespace. No harm in removing it to pacify them.