### PR TITLE
Enable yylineno increment on default rule match 

### DIFF
--- a/src/parse.y
+++ b/src/parse.y
@@ -130,6 +130,8 @@ goal		:  initlex sect1 sect1end sect2 initforrule
 			 */
 			default_rule = num_rules;
 
+			rule_has_nl[default_rule] = true;
+
 			finish_rule( def_rule, false, 0, 0, 0);
 
 			for ( i = 1; i <= lastsc; ++i )


### PR DESCRIPTION
This PR fixes #397 by setting the default rule as having a newline within the `rule_has_nl` array. This in turn allows the `yylineno` parsing code to execute when the default action is taken.