### PR TITLE
Add error messages to unreachable ends of switch statements

### DIFF
--- a/src/c99-flex.skl
+++ b/src/c99-flex.skl
@@ -1214,6 +1214,8 @@ int yyinput (yyscan_t yyscanner)
 			case EOB_ACT_CONTINUE_SCAN:
 				yyscanner->yy_c_buf_p = yyscanner->yytext_ptr + offset;
 				break;
+			default:
+				yypanic("unexpected return value from yy_get_next_buffer()", yyscanner);
 			}
 		}
 	}
@@ -2363,6 +2365,8 @@ m4_ifdef([[M4_MODE_FIND_ACTION_REJECT_OR_INTERACTIVE]], [[
 						yy_cp = yyscanner->yy_c_buf_p;
 						yy_bp = yyscanner->yytext_ptr + YY_MORE_ADJ;
 						goto yy_find_action;
+					default:
+						yypanic("unexpected return value from yy_get_next_buffer()", yyscanner);
 					} /* end EOB inner switch */
 				} /* end if */
 				break;

--- a/src/cpp-flex.skl
+++ b/src/cpp-flex.skl
@@ -2269,6 +2269,8 @@ m4_ifdef([[M4_MODE_FIND_ACTION_REJECT_OR_INTERACTIVE]], [[
 						yy_cp = YY_G(yy_c_buf_p);
 						yy_bp = YY_G(yytext_ptr) + YY_MORE_ADJ;
 						goto yy_find_action;
+					default:
+						YY_FATAL_ERROR("unexpected return value from yy_get_next_buffer()");
 					} /* end EOB inner switch */
 				} /* end if */
 				break;
@@ -2789,6 +2791,8 @@ int yyFlexLexer::yyinput()
 			case EOB_ACT_CONTINUE_SCAN:
 				YY_G(yy_c_buf_p) = YY_G(yytext_ptr) + offset;
 				break;
+			default:
+				YY_FATAL_ERROR("unexpected return value from yy_get_next_buffer()");
 			}
 		}
 	}

--- a/src/go-flex.skl
+++ b/src/go-flex.skl
@@ -1123,6 +1123,8 @@ int yyinput(FlexLexer *yyscanner)
 			case EOB_ACT_CONTINUE_SCAN:
 				yyscanner->yyCBufP = yyscanner->yytext_ptr + offset;
 				break;
+			default:
+				yypanic("unexpected return value from yy_get_next_buffer()", yyscanner);
 			}
 		}
 	}
@@ -2213,6 +2215,8 @@ m4_ifdef([[M4_MODE_FIND_ACTION_REJECT_OR_INTERACTIVE]], [[
 						yyCp = yyscanner->yyCBufP;
 						yyBp = yyscanner->yytext_ptr + YY_MORE_ADJ;
 						goto yyFindActionLabel;
+					default:
+						yypanic("unexpected return value from yy_get_next_buffer()", yyscanner);
 					} /* end EOB inner switch */
 				} /* end if */
 				break;


### PR DESCRIPTION
This PR fixes #103 by adding error messages (either `yypanic()` or `YY_FATAL_ERROR`) as a default case in switch statements that check against the return value of `yy_get_next_buffer()`.

Since `yy_get_next_buffer()` is defined to return only one of three values, and all these switch statements have cases for all of these values, it would be an error if execution fell through to the default case. Additionally, adding these statements helps future-proof the codebase if `yy_get_next_buffer()` is ever modified. 