### PR TITLE
Correctly refer to ctrl.traceline_template

### DIFF
--- a/src/filter.c
+++ b/src/filter.c
@@ -328,7 +328,7 @@ static bool is_blank_line (const char *str)
 int filter_fix_linedirs (struct filter *chain)
 {
 	char   buf[4096];
-	const char *traceline_template, *cp;
+	const char *cp;
 	const size_t readsz = sizeof buf;
 	int     lineno = 1;
 	bool    in_gen = true;	/* in generated code */
@@ -381,7 +381,7 @@ int filter_fix_linedirs (struct filter *chain)
 
 				/* Adjust the line directives. */
 				in_gen = true;
-				snprintf (buf, readsz, traceline_template,
+				snprintf (buf, readsz, ctrl.traceline_template,
 					  lineno + 1, filename);
 				strncat(buf, "\n", sizeof(buf)-1);
 			}


### PR DESCRIPTION
This was refactored in 0e32cd, but left a dangling reference to the previous location here. This was causing the `filter_fix_linedirs` filter to crash during building of `src/stage1scan.c`, resulting in a file truncated to (100+4)kB and an exit status of 1.