### PR TITLE
Call `input` rather than `yyinput` in src/scan.l:

### DIFF
--- a/src/scan.l
+++ b/src/scan.l
@@ -673,7 +673,10 @@ void context_member(char *, const char *);
                    */
                 &&  (cclval = ccllookup( nmstr )) != 0 )
 				{
-				if ( yyinput() != ']' )
+				/* Intentionally using the old API rather than `yyinput`, so that
+				 * we can bootstrap using flex 2.6.4 and older.
+				 */
+				if ( input() != ']' )
 					synerr( _( "bad character class" ) );
 
 				yylval = cclval;


### PR DESCRIPTION
This allows the stage1 build to succeed even when using a currently-released (2.6.4) version of Flex.

Open to suggestions of how this could be done better if calling the legacy name is undersirable.