### PR TITLE
fix typos

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -110,7 +110,7 @@ flex NEWS
     when those platforms are not present.
 
 *** When running "make check", you can now pas V=0 to silence more of
-    the build. This is useful when you're less connncerned about the
+    the build. This is useful when you're less concerned about the
     details of building and linking the test programs themselves.
 
 * Noteworthy changes in release 2.6.3 (2016-12-30) [stable]
@@ -158,7 +158,7 @@ flex NEWS
 
 ** flex internals
 
-*** a segfalt involving yyrestart(NULL) has been fixed
+*** a segfault involving yyrestart(NULL) has been fixed
 
 *** flex should now handle quoting when mixed with m4 processing correctly
 
@@ -245,7 +245,7 @@ flex NEWS
 
 *** Removed deprecated 'register' storage class specifier
 
-*** Changeed output formats from octal to hexadecimal
+*** Changed output formats from octal to hexadecimal
 
 *** check limits before using array index cclp; resolves sf-166
 
@@ -402,7 +402,7 @@ distribution
 * version 2.5.31 released 2003-4-1
 
 ** remove --enable-maintainer-mode configure option; none of the
-   Makefiles were using it and it can be unduely confusing
+   Makefiles were using it and it can be unduly confusing
 
 * version 2.5.30 released 2003-4-1
 
@@ -451,7 +451,7 @@ distribution
 
 ** new es translation from the translation project
 
-** slight tweeks to the flex_int*_t types
+** slight tweaks to the flex_int*_t types
 
 ** flex now warns about pattern ranges that might be ambiguous when
    generating a case-insensitive scanner
@@ -605,7 +605,7 @@ formatting the manual in postscript and pdf in the distributed
 
 ** the test suite now respects the usual CFLAGS, etc. variables
 
-** removed some warnings which some tests trigggered with the -s option
+** removed some warnings which some tests triggered with the -s option
 
 ** the flex-generated header file now tries to be smarter about
    conditionally including start conditions

--- a/ONEWS
+++ b/ONEWS
@@ -929,7 +929,7 @@ Changes between 2.3 Patch #2 (02Aug90) and original 2.3 release:
 	  Reordered #ifdef maze in the scanner skeleton in the hope of
 	  getting the declarations right for cfront and g++, too.
 
-	- Note that this patch supercedes patch #1 for release 2.3,
+	- Note that this patch supersedes patch #1 for release 2.3,
 	  which was never announced but was available briefly for
 	  anonymous ftp.
 
@@ -987,7 +987,7 @@ Things which didn't used to be documented but now are:
 	- yy_switch_to_buffer() can be used in the yywrap() macro/routine.
 
 	- flex scanners do not use stdio for their input, and hence when
-	  writing an interactive scanner one must explictly call fflush()
+	  writing an interactive scanner one must explicitly call fflush()
 	  after writing out a prompt.
 
 	- flex scanner can be made reentrant (after a fashion) by using

--- a/autogen.sh
+++ b/autogen.sh
@@ -22,7 +22,7 @@
 #  PURPOSE.
 
 # If you see no configure script, then run ./autogen.sh to create it
-# and procede with the "normal" build procedures.
+# and proceed with the "normal" build procedures.
 
 # use LIBTOOLIZE, if set
 if test "x$LIBTOOLIZE" = "x"; then

--- a/doc/flex.texi
+++ b/doc/flex.texi
@@ -1199,7 +1199,7 @@ run-time error results.
 Also note that you cannot use @code{%array} with C++ scanner classes
 (@pxref{Cxx}).
 
-In target langages with automatic memory allocation and arrays, none
+In target languages with automatic memory allocation and arrays, none
 of this applies; you can expect @code{yytext} to dynamically resize
 itself, calls to the @code{yyunput()} will not destroy the present
 contents of @code{yytext}, and you will never get a run-time error
@@ -2481,7 +2481,7 @@ holds the length of the current token.
 @item  FILE *yyin
 is the file which by default @code{flex} reads from.
 In target languages other than C/C++, expect it to have
-whatever natine type is associated with I/O streams. It may be
+whatever native type is associated with I/O streams. It may be
 redefined but doing so only makes sense before scanning begins or after
 an EOF has been encountered.  Changing it in the midst of scanning will
 have unexpected results since @code{flex} buffers its input; use
@@ -2547,7 +2547,7 @@ is @code{TOK_NUMBER}, part of the scanner might look like:
 @end verbatim
 @end example
 
-Bison is also retargetable to langages other than C.  Outside the
+Bison is also retargetable to languages other than C.  Outside the
 C/C++ back end, it is likely that your Bison module will simply export
 module-level constants that will be made visible to your scanner by
 linkage or by explicit import statements.
@@ -2727,9 +2727,9 @@ Python, etc.
 Back ends other than the default C generator can't assume they have
 the C preprocessor available.  Therefore, Flex recognizes the
 following function calls - yyecho(), yyless(), yymore(), yyinput(),
-yystart(), yybegin(), yyunput(), yypanic() - and rewreites them adding a
+yystart(), yybegin(), yyunput(), yypanic() - and rewrites them adding a
 yyscanner final argument as though they were C macros. This optiion
-is set to false whrn you select or default to the C back end, and to
+is set to false when you select or default to the C back end, and to
 true otherwise.  You can turn it off (or on) explicitly after your
 emit option.
 
@@ -2755,7 +2755,7 @@ implementation.  Note that this does not mean @emph{full} compatibility.
 Use of this option costs a considerable amount of performance, and it
 cannot be used with the @samp{--c++}, @samp{--full}, @samp{--fast}, @samp{-Cf}, or
 @samp{-CF} options.  For details on the compatibilities it provides, see
-@ref{Lex and Posix}. It will usuually be a no-op on back ends other
+@ref{Lex and Posix}. It will usually be a no-op on back ends other
 than C/C++.
 This option also results in the name
 @code{YY_FLEX_LEX_COMPAT} being @code{#define}'d in the generated scanner.
@@ -3138,8 +3138,8 @@ scanner, which simply calls @code{yylex()}.  This option implies
 @opindex yyterminate
 @hkindex yyterminate
 @item @code{%option yyterminate}
-This is a string-valuued option with which you can specify an expansion
-of the yyterminate() hook. whuch normally causes the generated
+This is a string-valued option with which you can specify an expansion
+of the yyterminate() hook. which normally causes the generated
 scanner to return 0 as an end-of-input indication.
 
 @anchor{option-nounistd}
@@ -3155,7 +3155,7 @@ to find them.
 
 This option is obsolete, as after Flex was originally written
 @file{unistd.h} became part of the Single Unix Specification and is
-consequently everywhere; thuas there is no reason to use this option
+consequently everywhere; thus there is no reason to use this option
 on modern systems.  It is included so as not to break compatibility
 with old build scripts, and will have no effect on backends other than
 the default C one.
@@ -4368,7 +4368,7 @@ to accomplish this. (See below).
 
 In the default C/C++ back end @code{yylex_init} and
 @code{yylex_destroy} must be called before and after @code{yylex},
-respectively.  This may not be true in other target langages,
+respectively.  This may not be true in other target languages,
 especially those with automatic memory management.
 
 @example
@@ -4533,7 +4533,7 @@ the scanner itself.
 
 In the default C/C++ back end, the extra field in your scanner state
 structure is defined as type @code{void *}; in other target languages
-it might be a generic type, or no such field might be genetated at
+it might be a generic type, or no such field might be generated at
 all.  In back ends which support this extra field, you may redefine
 the type using @code{%option extra-type="your_type"} in the scanner:
 
@@ -8761,7 +8761,7 @@ definitions Flex ships is that the bodies of initializers for arrays
 of integers consist of decimal numeric literals separated by commas
 (and optional whitespace).
 
-Otherwise, knowledge of each target langage's syntax lives in a
+Otherwise, knowledge of each target language's syntax lives in a
 language-specific skeleton file that is digested into a data structure
 inside Flex when Flex is compiled.  The skeleton files are part of the
 Flex source distribution; they are not required by the Flex
@@ -8792,7 +8792,7 @@ This file you are looking at is processed through GNU m4 during the
 pre-compilation stage of Flex. At this time only macros starting with
 `m4preproc_' are processed, and quoting is normal (that is, the quote
 opener is a back-tick (ASCII 96) and the quote closer is a tick or
-single quote (ASCII 39) @footnote{See chapter 3.2 of the m4 mamual,
+single quote (ASCII 39) @footnote{See chapter 3.2 of the m4 manual,
 ``Quoting input to m4'', for more information.}.  The main purpose of
 this expansion phase is to set Flex version symbols.
 
@@ -8861,14 +8861,14 @@ is pointed at by the skel nember of your language back end.
 
 @item
 The interesting part: mutate your new back end and skeleton so they
-produce code in your desired target langage.
+produce code in your desired target language.
 
 @item
 Add a test suite for your back end.  You should be able to clone
 one of the existing sets of test loads to get good coverage.  Note
 that is highly unlikely your back end will be accepted into the
 flex distribution without a test suite.  Fortunately, adapting
-the existing tests should not be difficult.  There is some guisdance
+the existing tests should not be difficult.  There is some guidance
 in the @file{tests/README} file of the source distrbution.
 @end enumerate
 
@@ -9031,7 +9031,7 @@ call the special action @code{YY_NEW_FILE}.  This is no longer
 necessary.
 
 @item
-FLEX_SCANNER: Not neaningful outside of the C back end, and not defined.
+FLEX_SCANNER: Not meaningful outside of the C back end, and not defined.
 
 @item
 FLEX_DEBUG: Outside the default C back end, this is a constant of type
@@ -9046,7 +9046,7 @@ YY_BUF_SIZE: replaced by @code{%option bufsize}.
 
 @item:
 yyterminate(): Backends that don't use the C preprocessor cannot
-support redefinining this hook with #define.  Instead, set it with
+support redefining this hook with #define.  Instead, set it with
 the @code{yyterminate} option. 
 
 @end itemize
@@ -9062,7 +9062,7 @@ This is also why the functions @code{yy_current_buffer()},
 @code{yy_flush_current_buffer()}, and @code{yy_set_interactive()}
 do not have rewrite rules (see @xref{option-rewrite}); simply
 removing the underscores would have produced names that are
-unncomfortably long and hard on the eyeballs.  We leave
+uncomfortably long and hard on the eyeballs.  We leave
 it to the API binding for each individual target language to
 choose whether they should be left as is, camel-cased, or
 otherwise adapted to local conventions.
@@ -9127,7 +9127,7 @@ to specific locations in the generated scanner, and may be used to insert arbitr
 @c endf
 @c nnoremap <F5>  1G/@node\s\+unnamed-faq-\d\+<cr>mfww"wy5ezt:call Faq2()<cr>
 
-@c Remaining problem points for the multilangage interface
+@c Remaining problem points for the multilanguage interface
 @c YY_NUM_RULES
 @c YY_FLEX_MAJOR_VERSION
 @c YY_FLEX_MINOR_VERSION

--- a/examples/README
+++ b/examples/README
@@ -2,7 +2,7 @@ This directory contains some examples of what you can do with
 flex. These files are not tested regularly so you might have to tinker
 a bit before they work for you. Updates, new files and patches are welcome.
 
-	- debflex.awk, an awk script for anotating flex debug output.
+	- debflex.awk, an awk script for annotating flex debug output.
 	  It presently only works with gawk and mawk, not with "old"
 	  or "new" awk.
 

--- a/examples/manual/j2t.lex
+++ b/examples/manual/j2t.lex
@@ -149,7 +149,7 @@ void write_block_header(char *type)
                       */
 ^[^\n:]+\n[*]+\n      write_block_header(CHAPTER); 
 
-^"= "[A-Z]" ="\n"="*  { /* we create a seciton for each category */
+^"= "[A-Z]" ="\n"="*  { /* we create a section for each category */
                         if(need_closing == TRUE){
                           printf("@end table\n\n\n");
                         }
@@ -214,7 +214,7 @@ void write_block_header(char *type)
                     }
 
  /*
-  * repoduce @enumerate lists
+  * reproduce @enumerate lists
   */
 
 ":"\n+[ \t]*[0-9]+"."   {

--- a/src/c99-flex.skl
+++ b/src/c99-flex.skl
@@ -221,7 +221,7 @@ m4_ifdef( [[M4_YY_ALWAYS_INTERACTIVE]], ,
 #include <stdlib.h>
 #include <stdbool.h>
 #include <stdint.h>
-#include <unistd.h>	/* requred for isatty() */
+#include <unistd.h>	/* required for isatty() */
 
 #if defined(__GNUC__) && __GNUC__ >= 3
 #define yynoreturn __attribute__((__noreturn__))
@@ -259,9 +259,9 @@ const int YY_NULL = 0;
  */
 m4_define([[YY_SC_TO_UI]], [[((YY_CHAR)($1))]])
 
-/* In the ancestal C back end this was a void pointer, meant to be
+/* In the ancestral C back end this was a void pointer, meant to be
  * opaque pointer.  That indirection has been removed here as it
- * wouldn't easily port to other langages.
+ * wouldn't easily port to other languages.
  */
 typedef struct yyguts_t *yyscan_t;
 
@@ -968,7 +968,7 @@ m4_ifdef( [[M4_MODE_YYLINENO]],
 }
 ]])
 
-%# yymore has a magic rewute rule. It's declared here, rather than with the other
+%# yymore has a magic rewrite rule. It's declared here, rather than with the other
 %# magic functions, so yy_get_next_buffer() won't need a forward declaration.
 m4_ifdef([[M4_MODE_YYMORE_USED]], [[
 m4_ifdef( [[M4_MODE_YYTEXT_IS_ARRAY]], [[
@@ -2056,7 +2056,7 @@ m4_ifdef( [[M4_MODE_USES_REJECT]],
 		yy_load_buffer_state( yyscanner );
 	}
 
-	/* open scope of user declarationns */
+	/* open scope of user declarations */
 	{
 %% [4.0] user's declarations go here
 

--- a/src/ccl.c
+++ b/src/ccl.c
@@ -135,7 +135,7 @@ ccl_set_diff (int a, int b)
     d = cclinit();
 
     /* In order to handle negation, we spin through all possible chars,
-     * addding each char in a that is not in b.
+     * adding each char in a that is not in b.
      * (This could be O(n^2), but n is small and bounded.)
      */
 	for ( ch = 0; ch < ctrl.csize; ++ch )

--- a/src/cpp-flex.skl
+++ b/src/cpp-flex.skl
@@ -4186,7 +4186,7 @@ static int yytbl_data_load YYFARGS2(struct yytbl_dmap *, dmap, struct yytbl_read
 				p = (struct yy_trans_info **) p + 1;
 			}
 			else {
-				/* t32 is a plain int. copy data, then incrememnt p. */
+				/* t32 is a plain int. copy data, then increment p. */
 				switch (dmap->dm_sz) {
 				case sizeof (flex_int32_t):
 					if(M4_YY_TABLES_VERIFY ) {

--- a/src/flexdef.h
+++ b/src/flexdef.h
@@ -305,7 +305,7 @@ typedef enum trit_t {
  * If it's in this structure, it has a corresponding m4 symbol.
  */
 struct ctrl_bundle_t {
-	bool always_interactive;// always use cheacter-by-character input
+	bool always_interactive;// always use character-by-character input
 	FILE *backing_up_file;	// file to summarize backing-up states to 
 	bool bison_bridge_lval;	// (--bison-bridge), bison pure calling convention. 
 	bool bison_bridge_lloc;	// (--bison-locations), bison yylloc.
@@ -341,7 +341,7 @@ struct ctrl_bundle_t {
 	bool use_read;		// (-f, -F, or -Cr) use read() for scanner input 
        				// otherwise, use fread(). 
 	char *yyclass;		// yyFlexLexer subclass to use for YY_DECL
-	char *yydecl;		// user-specfied prototype for yylex.
+	char *yydecl;		// user-specified prototype for yylex.
 	int yylmax;		// Maximum buffer length if %array
 	trit yymore_really_used;// Force geberation of support code for yymore
 	bool yytext_is_array;	// if true (i.e., %array directive), then declare
@@ -918,7 +918,7 @@ extern void mark_defs1(void);
 /* Mark the current position in the action array as the end of the prolog. */
 extern void mark_prolog(void);
 
-/* Generate a data statment for a two-dimensional array. */
+/* Generate a data statement for a two-dimensional array. */
 extern void mk2data(int);
 
 extern void mkdata(int);	/* generate a data statement */
@@ -1032,7 +1032,7 @@ extern void set_input_file(char *);
 
 /* from file skeletons.c */
 
-/* return the correct file suffix for the selrcted back end */
+/* return the correct file suffix for the selected back end */
 const char *suffix (void);
 
 /* Mine a text-valued property out of the skeleton file */

--- a/src/go-flex.skl
+++ b/src/go-flex.skl
@@ -153,7 +153,7 @@ m4_ifdef([[M4_YY_ALWAYS_INTERACTIVE]], ,
 #include <stdlib.h>
 #include <stdbool.h>
 #include <stdint.h>
-#include <unistd.h>	/* requred for isatty() */
+#include <unistd.h>	/* required for isatty() */
 
 #if defined(__GNUC__) && __GNUC__ >= 3
 #define yynoreturn __attribute__((__noreturn__))
@@ -925,7 +925,7 @@ m4_ifdef([[M4_MODE_NO_CPP_USE_READ]], [[
 }
 ]])
 
-%# yymore has a magic rewute rule. It's declared here, rather than with the other
+%# yymore has a magic rewrite rule. It's declared here, rather than with the other
 %# magic functions, so yy_get_next_buffer() won't need a forward declaration.
 m4_ifdef([[M4_MODE_YYMORE_USED]], [[
 m4_ifdef([[M4_MODE_YYTEXT_IS_ARRAY]], [[

--- a/src/main.c
+++ b/src/main.c
@@ -1284,7 +1284,7 @@ void readin (void)
 		out_str ("M4_HOOK_SET_POSTACTION(%s)\n", ctrl.postaction);
 	}
 
-	/* This has to be a stright textual substitution rather
+	/* This has to be a straight textual substitution rather
 	 * than a constant declaration because in C a const is
 	 * not const enough to be a static array bound.
 	 */
@@ -1294,7 +1294,7 @@ void readin (void)
 	if (userdef_buf.elts)
 		outn ((char *) (userdef_buf.elts));
 
-	/* If the user explicitly requested posix compatibility by specifing the
+	/* If the user explicitly requested posix compatibility by specifying the
 	 * posix-compat option, then we check for conflicting options. However, if
 	 * the POSIXLY_CORRECT variable is set, then we quietly make flex as
 	 * posix-compatible as possible.  This is the recommended behavior

--- a/src/misc.c
+++ b/src/misc.c
@@ -474,7 +474,7 @@ unsigned char myesc (unsigned char array[])
 }
 
 
-/* out - various flavors of outputing a (possibly formatted) string for the
+/* out - various flavors of outputting a (possibly formatted) string for the
  *	 generated scanner, keeping track of the line count.
  */
 

--- a/src/tblcmp.c
+++ b/src/tblcmp.c
@@ -489,7 +489,7 @@ void    mkdeftbl (void)
  * (i.e., jam entries) into the table.  It is assumed that by linking to
  * "JAMSTATE" they will be taken care of.  In any case, entries in "state"
  * marking transitions to "SAME_TRANS" are treated as though they will be
- * taken care of by whereever "deflink" points.  "totaltrans" is the total
+ * taken care of by wherever "deflink" points.  "totaltrans" is the total
  * number of transitions out of the state.  If it is below a certain threshold,
  * the tables are searched for an interior spot that will accommodate the
  * state array.

--- a/tests/README
+++ b/tests/README
@@ -87,17 +87,17 @@ rules file. The assumption is that the test binary should consume the
 data following ### in the rules file, exercising some set of Flex
 features and not returning a nonzero status.
 
-If you can express your test as a ruleset within in this orotocol,
+If you can express your test as a ruleset within in this protocol,
 please do so.  Those tests are easy to port to new back ends, as that
-whole job can be done by enhabcing testmaker.m4.
+whole job can be done by enhancing testmaker.m4.
 
 * WHY SOME TESTS ARE MISSING
 
 The "top" test is backend-independent; what it's really testing
 is Flex's ability to accumulate and ship preamble code sections.
 
-The "quotes" test is also backend-indepedent; it's testing that
-m4 expansion doesn't leak through the genertated scanner.
+The "quotes" test is also backend-independent; it's testing that
+m4 expansion doesn't leak through the generated scanner.
 
 The C99 backend is missing tests for the Bison bridge, header
 generation, and loadable tables because it omits those features in

--- a/tests/flexname.rules
+++ b/tests/flexname.rules
@@ -24,7 +24,7 @@
 /*
  * Test Lex incompatibility.  This is the compatibility exanmple from
  * the documentation; with !lex-compat it *should* match the string "foo".
- * For the complementery test, see lexcompat.rules.
+ * For the complementary test, see lexcompat.rules.
  */
 %option nounput nomain noyywrap noinput
 %option warn nolex-compat

--- a/tests/lineno.rules
+++ b/tests/lineno.rules
@@ -30,7 +30,7 @@
  * If "--yylineno" in the action is "yylineno--", the pattern
  * is not recognized and the magic rewrite rule for yylineo
  * does not fire.  Only an issue for non-default back ends that
- * do magic rewrites rather than rtelying on the C preprocessor.
+ * do magic rewrites rather than relying on the C preprocessor.
  */
 %option 8bit
 %option nounput nomain noyywrap noinput yylineno

--- a/tests/ruleset.sh
+++ b/tests/ruleset.sh
@@ -66,7 +66,7 @@ EOF
     done
 done
 
-# posixlycorrect is a special case becaae we need to set POSIXLY_CORRECT
+# posixlycorrect is a special case because we need to set POSIXLY_CORRECT
 # in Flex's environment while these .l files are being processed.
 for backend in "$@" ; do
     case $backend in

--- a/tests/testmaker.sh
+++ b/tests/testmaker.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 #
-# testmaker.sh - asssemble tests from backend-independent rulesets and
+# testmaker.sh - assemble tests from backend-independent rulesets and
 # backend-dependent boilerplate.  Generates both a Flex source file
 # and an input text for it.
 #

--- a/tests/yyless.rules
+++ b/tests/yyless.rules
@@ -21,7 +21,7 @@
  * PURPOSE.
  */
  /*
-  * Test yyless.  What should haooen is:
+  * Test yyless.  What should happen is:
   * 1. "foobar" is matched by the first rule.
   * 2. "bar" is pushed back by yyless(3)
   * 3. "bar" is matched by the second rule


### PR DESCRIPTION
NEWS
ONEWS
autogen.sh
doc/flex.texi
examples/README
examples/manual/j2t.lex
src/c99-flex.skl
src/ccl.c
src/cpp-flex.skl
src/flexdef.h
src/go-flex.skl
src/main.c
src/misc.c
src/tblcmp.c
tests/README
tests/flexname.rules
tests/lineno.rules
tests/ruleset.sh
tests/testmaker.sh
tests/yyless.rules