### PR TITLE
Fix Issue #539 crash on Apple M1 by casting 0 to (char *) explicitly

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -295,7 +295,7 @@ void initialize_output_filters(void)
 	if ( !(m4 = getenv("M4"))) {
 		m4 = M4;
 	}
-	filter_create_ext(output_chain, m4, "-P", 0);
+	filter_create_ext(output_chain, m4, "-P", (char *) 0);
 	filter_create_int(output_chain, filter_fix_linedirs, NULL);
 
 	/* For debugging, only run the requested number of filters. */


### PR DESCRIPTION
Currently, when the NULL-terminated variadic function `filter_create_ext()` is invoked, the value `0` is passed as the last argument to act as a terminator. However, this is an integer value, which is incompatible with the pointer data type expected by `filter_create_ext()`.

This is undefined behavior in C, correct operation is not guaranteed. In fact, it causes flex to crash on Apple M1 when GCC is used - the loop is not terminated when it should, instead, it keeps running, corrupting the argument list for invoking m4. As a result, it creates the following error:

> flex: fatal internal error, exec of gm4 failed

This commit fixes the problem by explicitly casting the value `0` to the correct pointer type `(char *)`. According to Rich Felker, the primary author of musl libc, [type casting from 0 is technically safer than using the value `NULL`](https://ewontfix.com/11/).