### PR TITLE
remove unused DO_COMPARISON

### DIFF
--- a/tests/testwrapper.sh
+++ b/tests/testwrapper.sh
@@ -11,7 +11,6 @@ INPUT_DIRECTORY=""
 INPUT_NAME=""
 INPUT_COUNT=0
 USE_REDIRECT=0
-DO_COMPARISON=0
 
 while getopts d:i:r OPTION ; do
     case $OPTION in


### PR DESCRIPTION
that was used in older versions of the script, but now seems to be only set to zero here and not used anywhere