### PR TITLE
build man page when cross compiling

### DIFF
--- a/doc/Makefile.am
+++ b/doc/Makefile.am
@@ -1,4 +1,8 @@
+if CROSS
+FLEX = $(top_builddir)/src/stage1flex
+else
 FLEX = $(top_builddir)/src/flex$(EXEEXT)
+endif
 TEXI2DVI = @TEXI2DVI@ -I $(srcdir)/../examples/manual/
 TEXI2PDF = @TEXI2PDF@ -I $(srcdir)/../examples/manual/
 


### PR DESCRIPTION
- .gitignore adjustments for WIN32
- typo
- remove hard-wired bison lookup, check for "GNU Bison" in $YACC's version output instead
- removed output-beautification of YACC and INDENT
- test(quotes): Add after action comment tests for m4quotes.
- Fix #539 crash on Apple M1 by casting 0 to (char *) explicitly
- Correctly refer to ctrl.traceline_template:
- remove unused DO_COMPARISON
- docs: Add CONTRIBUTING manual.
- docs(contrib): Add CONTRIBUTING.md to EXTRA_DIST.
- doc(contrib): Alphabetize commit types
- fix(build): build man page when cross compiling
