### PR TITLE
 ci: Add read-only permissions to workflows

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,6 +8,8 @@ on:
   pull_request:
     branches: [ master ]
 
+permissions: read-all
+
 jobs:
   build:
 

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -20,13 +20,13 @@ on:
   schedule:
     - cron: '31 22 * * 4'
 
+permissions: read-all
+
 jobs:
   analyze:
     name: Analyze
     runs-on: ubuntu-latest
     permissions:
-      actions: read
-      contents: read
       security-events: write
 
     strategy:


### PR DESCRIPTION
Fixes #562.

As described in the issue, this PR adds read-only permissions to flex's workflows. This reduces the risk of supply-chain attacks via the project's CI/CD infrastructure.