### PR TITLE
Skip linenum increment for indented code blocks

### DIFF
--- a/src/scan.l
+++ b/src/scan.l
@@ -95,7 +95,7 @@ extern const char *escaped_qstart, *escaped_qend;
 #define START_CODEBLOCK(x) do { \
     /* Emit the needed line directive... */\
     if (indented_code == false) { \
-        linenum++; \
+        if (!x) linenum++; \
         line_directive_out(NULL, infilename, linenum);	\
     } \
     add_action(M4QSTART); \

--- a/tests/.gitignore
+++ b/tests/.gitignore
@@ -80,7 +80,7 @@ lexcompat*
 !lexcompat.rules
 !lexcompat.txt
 lineno*
-!lineno_generated.l
+!lineno_generated.l.in
 !lineno.rules
 !lineno.txt
 mem_nr

--- a/tests/.gitignore
+++ b/tests/.gitignore
@@ -80,6 +80,7 @@ lexcompat*
 !lexcompat.rules
 !lexcompat.txt
 lineno*
+!lineno_generated.l
 !lineno.rules
 !lineno.txt
 mem_nr

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -73,6 +73,7 @@ SPORADIC_TESTS = \
 	cxx_restart \
 	header_nr \
 	header_r \
+	lineno_generated \
 	mem_nr \
 	mem_r \
 	mem_c99 \
@@ -133,6 +134,7 @@ nodist_header_r_SOURCES = header_r_scanner.h
 include_by_buffer_direct_SOURCES = include_by_buffer.direct.l
 include_by_push_direct_SOURCES = include_by_push.direct.l
 include_by_reentrant_direct_SOURCES = include_by_reentrant.direct.l
+lineno_generated_SOURCES = lineno_generated.l
 mem_nr_SOURCES = mem_nr.l
 mem_r_SOURCES = mem_r.l
 mem_c99_SOURCES = mem_c99.l
@@ -196,6 +198,7 @@ CLEANFILES = \
 	include_by_buffer.direct.c \
 	include_by_push.direct.c \
 	include_by_reentrant.direct.c \
+	lineno_generated.c \
 	mem_nr.c \
 	mem_r.c \
 	mem_c99.c \
@@ -320,6 +323,10 @@ FLEX = $(top_builddir)/src/flex
 
 .ll.cc: $(FLEX)
 	$(AM_V_LEX)$(FLEX) $(TESTOPTS) -+ -o $@ $<
+
+#want line numbers, so override the default rule
+lineno_generated.c: lineno_generated.l
+	$(AM_V_LEX)$(FLEX) -o $@ $<
 
 bison_nr_main.$(OBJEXT): bison_nr_parser.h bison_nr_scanner.h
 bison_nr_scanner.$(OBJEXT): bison_nr_parser.h

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -201,6 +201,7 @@ CLEANFILES = \
 	include_by_push.direct.c \
 	include_by_reentrant.direct.c \
 	lineno_generated.c \
+	lineno_generated.l \
 	mem_nr.c \
 	mem_r.c \
 	mem_c99.c \
@@ -286,6 +287,7 @@ EXTRA_DIST = \
 	flexname.txt \
 	lexcompat.txt \
 	lineno.txt \
+	lineno_generated.l.in \
 	posix.txt \
 	posixlycorrect.txt \
 	preposix.txt \

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -135,6 +135,8 @@ include_by_buffer_direct_SOURCES = include_by_buffer.direct.l
 include_by_push_direct_SOURCES = include_by_push.direct.l
 include_by_reentrant_direct_SOURCES = include_by_reentrant.direct.l
 lineno_generated_SOURCES = lineno_generated.l
+lineno_generated.l: lineno_generated.l.in
+	grep -n '@LINE@' $^ | sed -e 's%^\([0-9]\+\):.*%\1s/@LINE@/\1/%' | sed -f - $^ > $@.t && mv $@.t $@
 mem_nr_SOURCES = mem_nr.l
 mem_r_SOURCES = mem_r.l
 mem_c99_SOURCES = mem_c99.l

--- a/tests/lineno_generated.l
+++ b/tests/lineno_generated.l
@@ -1,0 +1,72 @@
+/*
+ * This file is part of flex.
+ * 
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 
+ * Neither the name of the University nor the names of its contributors
+ * may be used to endorse or promote products derived from this software
+ * without specific prior written permission.
+ * 
+ * THIS SOFTWARE IS PROVIDED ``AS IS'' AND WITHOUT ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, WITHOUT LIMITATION, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE.
+ */
+
+%{
+/* Test generated line numbers. Be careful editing this file
+   as it's all about ensuring flex generates correct line
+   directives.
+*/
+#include <stdio.h>
+#include "config.h"
+
+static int defs_percent_expect = 32, defs_percent_got = __LINE__;
+static int error_count = 0;
+
+static void test_line (const char *desc, int expect, int got);
+
+%}
+
+    static int defs_indent_expect = 39, defs_indent_got = __LINE__;
+
+%option nounput noyywrap noinput
+%option warn
+
+%%
+        test_line ("prolog indent", 45, __LINE__);
+%{
+        test_line ("prolog percent", 47, __LINE__);
+%}
+\n      { test_line ("rules braced", 49, __LINE__); }
+.       test_line ("rules bare", 50, __LINE__);
+
+%%
+
+static void
+test_line (const char *desc, int expect, int got)
+{
+    printf ("%s: expect: %d got: %d\n", desc, expect, got);
+	error_count += expect != got;
+}
+
+int
+main (void)
+{
+    yybuffer buffer = yy_scan_string ("a\na\n");
+    yylex ();
+    yy_delete_buffer (buffer);
+    test_line ("defs percent", defs_percent_expect, defs_percent_got);
+    test_line ("defs indent", defs_indent_expect, defs_indent_got);
+    test_line ("user code", 69, __LINE__);
+
+    return error_count != 0;
+}

--- a/tests/lineno_generated.l.in
+++ b/tests/lineno_generated.l.in
@@ -24,30 +24,31 @@
 %{
 /* Test generated line numbers. Be careful editing this file
    as it's all about ensuring flex generates correct line
-   directives.
+   directives, so the @LINE@ markers must be on the same line as a
+   their corresponding __LINE__ macros.
 */
 #include <stdio.h>
 #include "config.h"
 
-static int defs_percent_expect = 32, defs_percent_got = __LINE__;
+static int defs_percent_expect = @LINE@, defs_percent_got = __LINE__;
 static int error_count = 0;
 
 static void test_line (const char *desc, int expect, int got);
 
 %}
 
-    static int defs_indent_expect = 39, defs_indent_got = __LINE__;
+    static int defs_indent_expect = @LINE@, defs_indent_got = __LINE__;
 
 %option nounput noyywrap noinput
 %option warn
 
 %%
-        test_line ("prolog indent", 45, __LINE__);
+        test_line ("prolog indent", @LINE@, __LINE__);
 %{
-        test_line ("prolog percent", 47, __LINE__);
+        test_line ("prolog percent", @LINE@, __LINE__);
 %}
-\n      { test_line ("rules braced", 49, __LINE__); }
-.       test_line ("rules bare", 50, __LINE__);
+\n      { test_line ("rules braced", @LINE@, __LINE__); }
+.       test_line ("rules bare", @LINE@, __LINE__);
 
 %%
 
@@ -66,7 +67,7 @@ main (void)
     yy_delete_buffer (buffer);
     test_line ("defs percent", defs_percent_expect, defs_percent_got);
     test_line ("defs indent", defs_indent_expect, defs_indent_got);
-    test_line ("user code", 69, __LINE__);
+    test_line ("user code", @LINE@, __LINE__);
 
     return error_count != 0;
 }


### PR DESCRIPTION
An indented code block would cause the subsequent all subsequent code block line numbers (including its own) to be out by one.

For example, the following would cause the line number for the `BEGIN` code block to have the line number for the `warning` code block. This would also affect the code in the final section after the second `%%`.

    %%
                yyflexdebug = 0;
                grab_frame = GRAB_FRAME;
                grab_other = GRAB_OTHER;
                grab_write = GRAB_WRITE;
                yylval->pointer = 0;// ensure pointer vals are null

    "/*"        { BEGIN (COMMENT); }
    <COMMENT>"/*" { warning (0, "nested /* in comment"); }