### PR TITLE
Issue 609: Fix wrong example regex for C- and C++-style comments

### DIFF
--- a/doc/flex.texi
+++ b/doc/flex.texi
@@ -8667,6 +8667,7 @@ addition of the @samp{$} character.
 
 @item C99 Comment
 @code{("/*"([^*]|"*"[^/])*"*/")|("/"(\\\n)*"/"[^\n]*)}
+@code(("/*"([^*]|"*"+[^*/])*"*"+"/")|("/"(\\\n)*"/"((\\\n)|[^\n])*))
 
 Note that in C99, a @samp{//}-style comment may be split across lines,  and, contrary to popular belief,
 does not include the trailing @samp{\n} character.

--- a/doc/flex.texi
+++ b/doc/flex.texi
@@ -8666,7 +8666,7 @@ addition of the @samp{$} character.
 @code{L?\"([^\"\\\n]|(\\['\"?\\abfnrtv])|(\\([0123456]@{1,3@}))|(\\x[[:xdigit:]]+)|(\\u([[:xdigit:]]@{4@}))|(\\U([[:xdigit:]]@{8@})))*\"}
 
 @item C99 Comment
-@code(("/*"([^*]|"*"+[^*/])*"*"+"/")|("/"(\\\n)*"/"((\\\n)|[^\n])*))
+@code{("/*"([^*]|"*"+[^*/])*"*"+"/")|("/"(\\\n)*"/"((\\\n)|[^\n])*)}
 
 Note that in C99, a @samp{//}-style comment may be split across lines,  and, contrary to popular belief,
 does not include the trailing @samp{\n} character.

--- a/doc/flex.texi
+++ b/doc/flex.texi
@@ -8666,7 +8666,6 @@ addition of the @samp{$} character.
 @code{L?\"([^\"\\\n]|(\\['\"?\\abfnrtv])|(\\([0123456]@{1,3@}))|(\\x[[:xdigit:]]+)|(\\u([[:xdigit:]]@{4@}))|(\\U([[:xdigit:]]@{8@})))*\"}
 
 @item C99 Comment
-@code{("/*"([^*]|"*"[^/])*"*/")|("/"(\\\n)*"/"[^\n]*)}
 @code(("/*"([^*]|"*"+[^*/])*"*"+"/")|("/"(\\\n)*"/"((\\\n)|[^\n])*))
 
 Note that in C99, a @samp{//}-style comment may be split across lines,  and, contrary to popular belief,


### PR DESCRIPTION
This fixes issue 609, https://github.com/westes/flex/issues/609

The regex example in section A.4.3 Quoted Constructs of the Flex manual is wrong for both C- and C++-style comments

```
("/*"([^*]|"*"[^/])*"*/")|("/"(\\\n)*"/"[^\n]*)}
```

The C portion of the regex fails to recognize valid C comments like `/* text ** more text */` and fails to reject invalid comments like `/* comment 1 **/ invalid missing comment start */`

Also the C++ portion of the regex fails to recognize valid C++ multiline comments containing escaped newlines after comment start like
```c++
// multiline \
comment 1
```

The correct regex for C and C++ comments is

```
("/*"([^*]|"*"[^*/])*"*"+"/")|("/"(\\\n)*"/"((\\\n)|[^\n])*)
```

or

```
(?x: ( "/*" ( [^*] | "*"+ [^*/] )* "*"+ "/" ) | ( "/" (\\ \n)* "/" ( (\\ \n) | [^\n] )* ) )
```
