### PR TITLE
docs: Clarify GNU tool dependencies.

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -72,6 +72,7 @@ built from scratch:
 * GNU bison;  to generate parse.c from parse.y
 * autoconf; for handling the build system
 * automake; for Makefile generation
+* libtool; often packaged with automake, but not always
 * make; for running the generated Makefiles
 * gettext; for i18n support
 * help2man; to generate the flex man page
@@ -84,6 +85,7 @@ built from scratch:
   manual are not built unless specifically requested, but the targets
   are included by automake.
 * GNU indent; for indenting the flex source the way we want it done
+* GNU sed; GNU extensions are used so other sed versions will not work
 
 In cases where the versions of the above tools matter, the file
 configure.ac will specify the minimum required versions.
@@ -100,3 +102,9 @@ steps as building flex from a release archive.
 Note that, in addition to `make check`, `make distcheck` builds a
 release archive and builds and tests flex from inside a directory
 containing only known distributed files.
+
+If you have trouble building flex from git sources on non-Debian systems,
+(e.g. MacOS) make sure that any required GNU tools have been added to
+your PATH before your system defaults. Also check that required GNU tools
+are aliased to their typical names - some package systems prefix them with
+"gnu-" which make them hard for configure to find.


### PR DESCRIPTION
Clarify and expand tool dependency info in INSTALL.md, particularly with respect to GNU tool variants. Describe minimal troubleshooting steps for failed builds on non-Debian systems.

Refs: #632