### PR TITLE
build: Use portable alternative to $'\r' in mkskel.sh

### DIFF
--- a/src/mkskel.sh
+++ b/src/mkskel.sh
@@ -32,6 +32,9 @@ VERSION=$4
 case $VERSION in
    *[!0-9.]*) echo 'Invalid version number' >&2; exit 1;;
 esac
+
+cr=`printf '\r'`
+
 IFS=.
 # we do want word splitting, so we won't put double quotes around it (see IFS above)
 # shellcheck disable=2086
@@ -46,4 +49,4 @@ sed '/^%#/d
 s/m4_/m4preproc_/g
 s/a4_/4_/g
 s/[\\"]/\\&/g
-s/[^'$'\r'']*/  "&",/'
+s/[^'"$cr"']*/  "&",/'


### PR DESCRIPTION
(This is a follow-up to #353 . I can't reopen the old PR, so I file another one to address my point.)

Replace the `$'\r'` quoting in commit
c674b5faa3419032a6c41cc150488866f3b3cff9 with a portable alternative `` cr=`printf '\r'` ``

Although `$' '` (dollar-single-quote) quoting is proposed for inclusion in POSIX, we have not seen it in a published standard yet, so it is best to avoid it for now.