### PR TITLE
build: Makefile improvements with skeleton sources

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -141,14 +141,17 @@ dist-hook: scan.l flex$(EXEEXT)
 
 SKELINCLUDES := $(subst skl,h,$(wildcard *.skl))
 
-stage1flex-main.$(OBJEXT): parse.h $(SKELINCLUDES)
-flex-main.$(OBJEXT): parse.h $(SKELINCLUDES)
+stage1flex-skeletons.$(OBJEXT): $(SKELINCLUDES)
+flex-skeletons.$(OBJEXT): $(SKELINCLUDES)
 
-stage1flex-yylex.$(OBJEXT): parse.h $(SKELINCLUDES)
-flex-yylex.$(OBJEXT): parse.h $(SKELINCLUDES)
+stage1flex-main.$(OBJEXT): parse.h
+flex-main.$(OBJEXT): parse.h
 
-stage1flex-scan.$(OBJEXT): parse.h $(SKELINCLUDES)
-flex-stage1scan.$(OBJEXT): parse.h $(SKELINCLUDES)
+stage1flex-yylex.$(OBJEXT): parse.h
+flex-yylex.$(OBJEXT): parse.h
+
+stage1flex-scan.$(OBJEXT): parse.h
+flex-stage1scan.$(OBJEXT): parse.h
 
 # Run GNU indent on sources. Don't run this unless all the sources compile cleanly.
 #

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -101,6 +101,7 @@ EXTRA_DIST = \
 	chkskel.sh
 
 MOSTLYCLEANFILES = \
+	$(SKELINCLUDES) \
 	stage1scan.c
 
 CLEANFILES = stage1flex$(EXEEXT)
@@ -109,9 +110,6 @@ SKELINCLUDES = \
 	cpp-flex.h \
 	c99-flex.h \
 	go-flex.h
-
-clean-local:
-	rm -f $(SKELINCLUDES)
 
 cpp-flex.h: cpp-flex.skl mkskel.sh flexint_shared.h tables_shared.h tables_shared.c
 	$(SHELL) $(srcdir)/mkskel.sh cpp $(srcdir) $(m4) $(VERSION) > $@.tmp

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -45,8 +45,9 @@ endif
 flex_SOURCES = \
 	$(COMMON_SOURCES)
 
-nodist_flex_SOURCES = \
-	stage1scan.c
+nodist_flex_SOURCES =
+
+nodist_flex_SOURCES += stage1scan.c
 
 flex_CFLAGS = $(AM_CFLAGS) $(WARNINGFLAGS)
 
@@ -95,7 +96,8 @@ EXTRA_DIST = \
 	gettext.h \
 	chkskel.sh
 
-MOSTLYCLEANFILES = stage1scan.c
+MOSTLYCLEANFILES = \
+	stage1scan.c
 
 CLEANFILES = stage1flex$(EXEEXT)
 

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -23,6 +23,9 @@ stage1flex_SOURCES = \
 	scan.l \
 	$(COMMON_SOURCES)
 
+nodist_stage1flex_SOURCES = \
+	$(SKELINCLUDES)
+
 if CROSS
 stage1flex_LDADD =
 stage1flex_SOURCES += \
@@ -45,7 +48,8 @@ endif
 flex_SOURCES = \
 	$(COMMON_SOURCES)
 
-nodist_flex_SOURCES =
+nodist_flex_SOURCES = \
+	$(SKELINCLUDES)
 
 nodist_flex_SOURCES += stage1scan.c
 
@@ -101,13 +105,13 @@ MOSTLYCLEANFILES = \
 
 CLEANFILES = stage1flex$(EXEEXT)
 
-BUILT_SOURCES = \
+SKELINCLUDES = \
 	cpp-flex.h \
 	c99-flex.h \
 	go-flex.h
 
 clean-local:
-	rm -f $(BUILT_SOURCES)
+	rm -f $(SKELINCLUDES)
 
 cpp-flex.h: cpp-flex.skl mkskel.sh flexint_shared.h tables_shared.h tables_shared.c
 	$(SHELL) $(srcdir)/mkskel.sh cpp $(srcdir) $(m4) $(VERSION) > $@.tmp
@@ -140,8 +144,6 @@ dist-hook: scan.l flex$(EXEEXT)
 
 # make needs to be told to make inclusions so that parallelized runs will
 # not fail.
-
-SKELINCLUDES := $(subst skl,h,$(wildcard *.skl))
 
 stage1flex-skeletons.$(OBJEXT): $(SKELINCLUDES)
 flex-skeletons.$(OBJEXT): $(SKELINCLUDES)


### PR DESCRIPTION
1. Correct skeleton headers dependencies
2. Don't use BUILT_SOURCES for skeleton files 
3. Let "make mostlyclean" delete "*-flex.h"