### PR TITLE
build: Append $(WARNINGFLAGS) to AM_CFLAGS

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -1,5 +1,6 @@
 AM_YFLAGS = -d
 AM_CPPFLAGS = -DLOCALEDIR=\"$(localedir)\"
+AM_CFLAGS = $(WARNINGFLAGS)
 LIBS = @LIBS@
 pkgconfigdir = @pkgconfigdir@
 
@@ -59,8 +60,6 @@ nodist_flex_SOURCES += stage1scan.c
 else
 flex_SOURCES += scan.l
 endif
-
-flex_CFLAGS = $(AM_CFLAGS) $(WARNINGFLAGS)
 
 COMMON_SOURCES = \
 	buf.c \
@@ -172,17 +171,17 @@ dist-hook: scan.l flex$(EXEEXT)
 # not fail.
 
 stage1flex-skeletons.$(OBJEXT): $(SKELINCLUDES)
-flex-skeletons.$(OBJEXT): $(SKELINCLUDES)
+skeletons.$(OBJEXT): $(SKELINCLUDES)
 
 stage1flex-main.$(OBJEXT): parse.h
-flex-main.$(OBJEXT): parse.h
+main.$(OBJEXT): parse.h
 
 stage1flex-yylex.$(OBJEXT): parse.h
-flex-yylex.$(OBJEXT): parse.h
+yylex.$(OBJEXT): parse.h
 
 stage1flex-scan.$(OBJEXT): parse.h
-flex-stage1scan.$(OBJEXT): parse.h
-flex-scan.$(OBJEXT): parse.h
+stage1scan.$(OBJEXT): parse.h
+scan.$(OBJEXT): parse.h
 
 # Run GNU indent on sources. Don't run this unless all the sources compile cleanly.
 #


### PR DESCRIPTION
In src/Makefile.am, remove `flex_CFLAGS` variable, and append `$(WARNINGFLAGS)` to `AM_CFLAGS`. The use of `flex_CFLAGS` has forced Automake to rename flex's object files (.o) to have a 'flex-' prefix. By preventing the rename, the generated src/Makefile.in can be about 37 kB smaller.