### PR TITLE
build: Generate man page with fixed program name 

### DIFF
--- a/doc/Makefile.am
+++ b/doc/Makefile.am
@@ -14,7 +14,11 @@ MAINTAINERCLEANFILES = flex.1
 CLEANFILES = *.aux *.cp *.cps *.fn *.fns *.hk *.hks *.ky *.log \
 	*.op *.ops *.pg *.toc *.tp *.tps *.vr *.vrs
 
-flex.1: $(top_srcdir)/configure.ac $(top_srcdir)/src/cpp-flex.skl $(top_srcdir)/src/options.c $(top_srcdir)/src/options.h | $(FLEX)
+flex.1: $(top_srcdir)/configure.ac $(top_srcdir)/src/cpp-flex.skl $(top_srcdir)/src/options.c $(top_srcdir)/src/options.h
+	@( cd $(top_builddir)/src && \
+	  prog_name=`echo '$(FLEX)' | sed 's|^$(top_builddir)/src/||'` && \
+	  $(MAKE) $(AM_MAKEFLAGS) $$prog_name \
+	)
 	$(HELP2MAN) --name='$(PACKAGE_NAME)' --section=1 \
 	--source='The Flex Project' --manual='Programming' \
 	--output=$@ $(FLEX) \

--- a/doc/Makefile.am
+++ b/doc/Makefile.am
@@ -12,14 +12,20 @@ dist_man_MANS = flex.1
 MAINTAINERCLEANFILES = flex.1
 
 CLEANFILES = *.aux *.cp *.cps *.fn *.fns *.hk *.hks *.ky *.log \
-	*.op *.ops *.pg *.toc *.tp *.tps *.vr *.vrs
+	*.op *.ops *.pg *.toc *.tp *.tps *.vr *.vrs \
+	flex$(EXEEXT)
+
+# Use a fixed program name, without extension (such as ".exe"), for man
+# page generation. 'help2man' strips directory prefix ("./") from the
+# usage string, but not file extensions.
 
 flex.1: $(top_srcdir)/configure.ac $(top_srcdir)/src/cpp-flex.skl $(top_srcdir)/src/options.c $(top_srcdir)/src/options.h
 	@( cd $(top_builddir)/src && \
 	  prog_name=`echo '$(FLEX)' | sed 's|^$(top_builddir)/src/||'` && \
 	  $(MAKE) $(AM_MAKEFLAGS) $$prog_name \
 	)
+	cp $(FLEX) flex$(EXEEXT)
 	$(HELP2MAN) --name='$(PACKAGE_NAME)' --section=1 \
 	--source='The Flex Project' --manual='Programming' \
-	--output=$@ $(FLEX) \
+	--output=$@ ./flex \
 	|| rm -f $@


### PR DESCRIPTION
Two commits:
* Use a more portable expression for the 'flex.1' man page on flex program.
* Fix the program name for the man page generation.

See the commit descriptions for details.