### PR TITLE
gitignore doc/flex and doc/flex.exe

### DIFF
--- a/doc/.gitignore
+++ b/doc/.gitignore
@@ -25,3 +25,6 @@ flex.ps
 version.texi
 flex.html
 flex.t2p
+
+flex
+flex.exe


### PR DESCRIPTION
Following commit 7e53fea7dc086dec34522e73f442705879773a9d, 'flex' executable program might now reside in doc directory. Add the file names to gitignore list.