### PR TITLE
build: Update AX_PROG_CC_FOR_BUILD to fix BUILD_EXEEXT problems

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -78,6 +78,15 @@ AC_PROG_LN_S
 AC_PROG_AWK
 AC_PROG_INSTALL
 
+AS_IF([test "x${BUILD_OBJEXT-}" = x],
+  [AS_IF([test "$cross_compiling" = no],
+    [BUILD_EXEEXT="$EXEEXT"
+    BUILD_OBJEXT="$OBJEXT"],
+    [BUILD_EXEEXT="${ac_cv_build_exeext-}"
+    BUILD_OBJEXT="${ac_cv_build_objext-}"])])
+AS_IF([test "x${BUILD_OBJEXT-}" = x && test "x${enable_bootstrap-yes}" = xyes],
+  [AC_MSG_ERROR([BUILD_OBJEXT is invalid; please regenerate 'configure' with a newer ax_prog_cc_for_build.m4 (serial 22 or later) or configure with '--disable-bootstrap'])])
+
 pkgconfigdir=${libdir}/pkgconfig
 AC_SUBST(pkgconfigdir)
 

--- a/m4/ax_prog_cc_for_build.m4
+++ b/m4/ax_prog_cc_for_build.m4
@@ -1,5 +1,5 @@
 # ===========================================================================
-#   http://www.gnu.org/software/autoconf-archive/ax_prog_cc_for_build.html
+#   https://www.gnu.org/software/autoconf-archive/ax_prog_cc_for_build.html
 # ===========================================================================
 #
 # SYNOPSIS
@@ -32,28 +32,34 @@
 #   and this notice are preserved. This file is offered as-is, without any
 #   warranty.
 
-#serial 8
+#serial 21
+# With patches not yet merged upstream
+# <https://savannah.gnu.org/patch/index.php?10452>
 
 AU_ALIAS([AC_PROG_CC_FOR_BUILD], [AX_PROG_CC_FOR_BUILD])
 AC_DEFUN([AX_PROG_CC_FOR_BUILD], [dnl
 AC_REQUIRE([AC_PROG_CC])dnl
 AC_REQUIRE([AC_PROG_CPP])dnl
-AC_REQUIRE([AC_EXEEXT])dnl
-AC_REQUIRE([AC_CANONICAL_HOST])dnl
+AC_REQUIRE([AC_CANONICAL_BUILD])dnl
 
 dnl Use the standard macros, but make them use other variable names
 dnl
 pushdef([ac_cv_prog_CPP], ac_cv_build_prog_CPP)dnl
 pushdef([ac_cv_prog_gcc], ac_cv_build_prog_gcc)dnl
+pushdef([ac_cv_prog_cc_c89], ac_cv_build_prog_cc_c89)dnl
+pushdef([ac_cv_prog_cc_c99], ac_cv_build_prog_cc_c99)dnl
+pushdef([ac_cv_prog_cc_c11], ac_cv_build_prog_cc_c11)dnl
+pushdef([ac_cv_prog_cc_c23], ac_cv_build_prog_cc_c23)dnl
+pushdef([ac_cv_prog_cc_stdc], ac_cv_build_prog_cc_stdc)dnl
 pushdef([ac_cv_prog_cc_works], ac_cv_build_prog_cc_works)dnl
 pushdef([ac_cv_prog_cc_cross], ac_cv_build_prog_cc_cross)dnl
 pushdef([ac_cv_prog_cc_g], ac_cv_build_prog_cc_g)dnl
-pushdef([ac_cv_exeext], ac_cv_build_exeext)dnl
-pushdef([ac_cv_objext], ac_cv_build_objext)dnl
+pushdef([ac_prog_cc_stdc], ac_build_prog_cc_stdc)dnl
 pushdef([ac_exeext], ac_build_exeext)dnl
 pushdef([ac_objext], ac_build_objext)dnl
 pushdef([CC], CC_FOR_BUILD)dnl
 pushdef([CPP], CPP_FOR_BUILD)dnl
+pushdef([GCC], GCC_FOR_BUILD)dnl
 pushdef([CFLAGS], CFLAGS_FOR_BUILD)dnl
 pushdef([CPPFLAGS], CPPFLAGS_FOR_BUILD)dnl
 pushdef([LDFLAGS], LDFLAGS_FOR_BUILD)dnl
@@ -67,27 +73,58 @@ pushdef([ac_cv_host_alias], ac_cv_build_alias)dnl
 pushdef([ac_cv_host_cpu], ac_cv_build_cpu)dnl
 pushdef([ac_cv_host_vendor], ac_cv_build_vendor)dnl
 pushdef([ac_cv_host_os], ac_cv_build_os)dnl
-pushdef([ac_cpp], ac_build_cpp)dnl
-pushdef([ac_compile], ac_build_compile)dnl
-pushdef([ac_link], ac_build_link)dnl
+pushdef([ac_tool_prefix], ac_build_tool_prefix)dnl
+pushdef([am_cv_CC_dependencies_compiler_type], am_cv_build_CC_dependencies_compiler_type)dnl
+pushdef([am_cv_prog_cc_c_o], am_cv_build_prog_cc_c_o)dnl
+pushdef([cross_compiling], cross_compiling_build)dnl
+dnl
+dnl These variables are problematic to rename by M4 macros, so we save
+dnl their values in alternative names, and restore the values later.
+dnl
+dnl _AC_COMPILER_EXEEXT and _AC_COMPILER_OBJEXT internally call
+dnl AC_SUBST which prevents the renaming of EXEEXT and OBJEXT
+dnl variables. It's not a good idea to rename ac_cv_exeext and
+dnl ac_cv_objext either as they're related.
+dnl Renaming ac_exeext and ac_objext is safe though.
+dnl
+ac_cv_host_exeext=$ac_cv_exeext
+AS_VAR_SET_IF([ac_cv_build_exeext],
+  [ac_cv_exeext=$ac_cv_build_exeext],
+  [AS_UNSET([ac_cv_exeext])])
+ac_cv_host_objext=$ac_cv_objext
+AS_VAR_SET_IF([ac_cv_build_objext],
+  [ac_cv_objext=$ac_cv_build_objext],
+  [AS_UNSET([ac_cv_objext])])
+dnl
+dnl ac_cv_c_compiler_gnu is used in _AC_LANG_COMPILER_GNU (called by
+dnl AC_PROG_CC) indirectly.
+dnl
+ac_cv_host_c_compiler_gnu=$ac_cv_c_compiler_gnu
+AS_VAR_SET_IF([ac_cv_build_c_compiler_gnu],
+  [ac_cv_c_compiler_gnu=$ac_cv_build_c_compiler_gnu],
+  [AS_UNSET([ac_cv_c_compiler_gnu])])
 
-save_cross_compiling=$cross_compiling
-save_ac_tool_prefix=$ac_tool_prefix
-cross_compiling=no
-ac_tool_prefix=
+cross_compiling_build=no
 
+ac_build_tool_prefix=
+AS_IF([test -n "$build"],      [ac_build_tool_prefix="$build-"],
+      [test -n "$build_alias"],[ac_build_tool_prefix="$build_alias-"])
+
+AC_LANG_PUSH([C])
 AC_PROG_CC
+_AC_COMPILER_EXEEXT
+_AC_COMPILER_OBJEXT
 AC_PROG_CPP
-AC_EXEEXT
 
-ac_tool_prefix=$save_ac_tool_prefix
-cross_compiling=$save_cross_compiling
+BUILD_EXEEXT=$ac_cv_exeext
+BUILD_OBJEXT=$ac_cv_objext
 
 dnl Restore the old definitions
 dnl
-popdef([ac_link])dnl
-popdef([ac_compile])dnl
-popdef([ac_cpp])dnl
+popdef([cross_compiling])dnl
+popdef([am_cv_prog_cc_c_o])dnl
+popdef([am_cv_CC_dependencies_compiler_type])dnl
+popdef([ac_tool_prefix])dnl
 popdef([ac_cv_host_os])dnl
 popdef([ac_cv_host_vendor])dnl
 popdef([ac_cv_host_cpu])dnl
@@ -101,24 +138,39 @@ popdef([host])dnl
 popdef([LDFLAGS])dnl
 popdef([CPPFLAGS])dnl
 popdef([CFLAGS])dnl
+popdef([GCC])dnl
 popdef([CPP])dnl
 popdef([CC])dnl
 popdef([ac_objext])dnl
 popdef([ac_exeext])dnl
-popdef([ac_cv_objext])dnl
-popdef([ac_cv_exeext])dnl
+popdef([ac_prog_cc_stdc])dnl
 popdef([ac_cv_prog_cc_g])dnl
 popdef([ac_cv_prog_cc_cross])dnl
 popdef([ac_cv_prog_cc_works])dnl
+popdef([ac_cv_prog_cc_stdc])dnl
+popdef([ac_cv_prog_cc_c23])dnl
+popdef([ac_cv_prog_cc_c11])dnl
+popdef([ac_cv_prog_cc_c99])dnl
+popdef([ac_cv_prog_cc_c89])dnl
 popdef([ac_cv_prog_gcc])dnl
 popdef([ac_cv_prog_CPP])dnl
+dnl
+ac_cv_exeext=$ac_cv_host_exeext
+EXEEXT=$ac_cv_host_exeext
+ac_cv_objext=$ac_cv_host_objext
+OBJEXT=$ac_cv_host_objext
+ac_cv_c_compiler_gnu=$ac_cv_host_c_compiler_gnu
+ac_compiler_gnu=$ac_cv_host_c_compiler_gnu
+
+dnl restore global variables ac_ext, ac_cpp, ac_compile,
+dnl ac_link, ac_compiler_gnu (dependant on the current
+dnl language after popping):
+AC_LANG_POP([C])
 
 dnl Finally, set Makefile variables
 dnl
-BUILD_EXEEXT=$ac_build_exeext
-BUILD_OBJEXT=$ac_build_objext
-AC_SUBST(BUILD_EXEEXT)dnl
-AC_SUBST(BUILD_OBJEXT)dnl
+AC_SUBST([BUILD_EXEEXT])dnl
+AC_SUBST([BUILD_OBJEXT])dnl
 AC_SUBST([CFLAGS_FOR_BUILD])dnl
 AC_SUBST([CPPFLAGS_FOR_BUILD])dnl
 AC_SUBST([LDFLAGS_FOR_BUILD])dnl


### PR DESCRIPTION
The BUILD_EXEEXT and BUILD_OBJEXT variables in `configure` was broken.
The ax_prog_cc_for_build.m4 from autoconf-archive upstream contains some fixes to BUILD_EXEEXT and BUILD_OBJEXT, but they were broken again with Autoconf 2.70.

In this PR, I updated the ax_prog_cc_for_build.m4 module while added my own fixes to make BUILD_EXEEXT and BUILD_OBJEXT work in Autoconf 2.70.

(I also submitted the patches upstream, but they are not merged yet:
https://savannah.gnu.org/patch/index.php?10452
https://github.com/autoconf-archive/autoconf-archive/pull/296)