### PR TITLE
build: Correct program path in doc/Makefile.am

### DIFF
--- a/doc/Makefile.am
+++ b/doc/Makefile.am
@@ -48,4 +48,4 @@ flex.1: $(top_srcdir)/configure.ac $(top_srcdir)/src/cpp-flex.skl $(top_srcdir)/
 	--source='The Flex Project' \
 	--manual='Programming' \
 	--output=$@ \
-	flex
+	./flex


### PR DESCRIPTION
A build system regression from 3c70fb6932fdc61bddf8371400b6582c2fd5a0e9.

When `help2man` is invoked with a program path without the directory prefix (such as "./"), it might launch a program installed on the builder's system instead of the program just compiled in the working directory.

Reproducible on a CI server (example build log: https://github.com/Explorer09/flex/actions/runs/9018798317/job/24780203568)

1. Have an old version of flex installed on the builder's system ("`apt install flex`" or similar command from your package manager)
2. Hack src/main.c to alter some help text ([like this](https://github.com/Explorer09/flex/commit/ae0cc2f90775db55e8ec79f505ca075813d82878))
3. Build flex and the man page with `rm -f doc/flex.1 && ./configure && make`
4. `cat doc/flex.1` and see the man page isn't updated with altered text.