### PR TITLE
fix(tests): tests/Makefile unnecessarily regenerates

### DIFF
--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -434,7 +434,7 @@ RULESETS = \
 	$(srcdir)/yymorearraybol.rules \
 	$(srcdir)/yyunput.rules
 
-$(srcdir)/ruleset.am: $(srcdir)/ruleset.sh $(RULESETS)
+$(srcdir)/ruleset.am: $(srcdir)/ruleset.sh
 	( cd $(srcdir) && $(SHELL) ruleset.sh nr r c99 go >ruleset.am )
 
 include $(srcdir)/ruleset.am


### PR DESCRIPTION
`tests/ruleset.am` should not depend on the modification dates of the `*.rules` files in the directory. `bmake` (NetBSD make; also available in some Linux distros), can occasionally treat `ruleset.am` as outdated and unnecessarily regenerates it, causing a chain of regeneraion of Makefiles or even dependency tracking error.

(This might look like a bug in bmake's side, but we should remove false dependencies in makefiles anyway. `ruleset.am` only depends on the names and existences of the `*.rules` files, not their contents or modification dates.)