### PR TITLE
Making flex re-entrant and releasing all acquired resources at the end

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -228,4 +228,7 @@ indent: $(top_srcdir)/.indent.pro
 		echo $$f FAILED to indent; \
 	done;
 
-.PHONY: indent
+fix-parse: parse.c
+	sed -i -E -e 's/(yy[^,]+,[^,]+), gv\)/\1, yyscanner, gv)/' parse.c
+
+.PHONY: indent fix-parse

--- a/src/buf.c
+++ b/src/buf.c
@@ -46,8 +46,8 @@
  */
 
 /* global buffers. */
-struct Buf userdef_buf;		/**< for user #definitions triggered by cmd-line. */
-struct Buf top_buf;             /**< contains %top code. String buffer. */
+//struct Buf userdef_buf;		/**< for user #definitions triggered by cmd-line. */
+//struct Buf top_buf;             /**< contains %top code. String buffer. */
 
 /* Append a "%s" formatted string to a string buffer */
 struct Buf *buf_prints (struct Buf *buf, const char *fmt, const char *s)

--- a/src/buf.c
+++ b/src/buf.c
@@ -50,7 +50,7 @@
 //struct Buf top_buf;             /**< contains %top code. String buffer. */
 
 /* Append a "%s" formatted string to a string buffer */
-struct Buf *buf_prints (struct Buf *buf, const char *fmt, const char *s)
+struct Buf *buf_prints (FlexState* gv, struct Buf *buf, const char *fmt, const char *s)
 {
 	char   *t;
 	size_t tsz;
@@ -58,17 +58,17 @@ struct Buf *buf_prints (struct Buf *buf, const char *fmt, const char *s)
 	tsz = strlen(fmt) + strlen(s) + 1;
 	t = malloc(tsz);
 	if (!t)
-	    flexfatal (_("Allocation of buffer to print string failed"));
+	    flexfatal (gv, _("Allocation of buffer to print string failed"));
 	snprintf (t, tsz, fmt, s);
-	buf = buf_strappend (buf, t);
+	buf = buf_strappend (gv, buf, t);
 	free(t);
 	return buf;
 }
 
 /* Appends n characters in str to buf. */
-struct Buf *buf_strnappend (struct Buf *buf, const char *str, int n)
+struct Buf *buf_strnappend (FlexState* gv, struct Buf *buf, const char *str, int n)
 {
-	buf_append (buf, str, n + 1);
+	buf_append (gv, buf, str, n + 1);
 
 	/* "undo" the '\0' character that buf_append() already copied. */
 	buf->nelts--;
@@ -77,9 +77,9 @@ struct Buf *buf_strnappend (struct Buf *buf, const char *str, int n)
 }
 
 /* Appends characters in str to buf. */
-struct Buf *buf_strappend (struct Buf *buf, const char *str)
+struct Buf *buf_strappend (FlexState* gv, struct Buf *buf, const char *str)
 {
-	return buf_strnappend (buf, str, (int) strlen (str));
+	return buf_strnappend (gv, buf, str, (int) strlen (str));
 }
 
 /* create buf with 0 elements, each of size elem_size. */
@@ -107,7 +107,7 @@ void buf_destroy (struct Buf *buf)
  * We grow by mod(512) boundaries.
  */
 
-struct Buf *buf_append (struct Buf *buf, const void *ptr, int n_elem)
+struct Buf *buf_append (FlexState* gv, struct Buf *buf, const void *ptr, int n_elem)
 {
 	int     n_alloc = 0;
 
@@ -130,10 +130,10 @@ struct Buf *buf_append (struct Buf *buf, const void *ptr, int n_elem)
 
 		if (!buf->elts)
 			buf->elts =
-				allocate_array ((int) n_alloc, buf->elt_size);
+				allocate_array (gv, (int) n_alloc, buf->elt_size);
 		else
 			buf->elts =
-				reallocate_array (buf->elts, (int) n_alloc,
+				reallocate_array (gv, buf->elts, (int) n_alloc,
 						  buf->elt_size);
 
 		buf->nmax = n_alloc;

--- a/src/dfa.c
+++ b/src/dfa.c
@@ -52,22 +52,22 @@ static int  symfollowset(int[], int, int, int[]);
 
 static void check_for_backing_up(int ds, int state[])
 {
-	if ((reject && !dfaacc[ds].dfaacc_set) || (!reject && !dfaacc[ds].dfaacc_state)) {	/* state is non-accepting */
-		++num_backing_up;
+	if ((gv->reject && !gv->dfaacc[ds].dfaacc_set) || (!gv->reject && !gv->dfaacc[ds].dfaacc_state)) {	/* state is non-accepting */
+		++gv->num_backing_up;
 
-		if (env.backing_up_report) {
-			fprintf (ctrl.backing_up_file,
+		if (gv->env.backing_up_report) {
+			fprintf (gv->ctrl.backing_up_file,
 				 _("State #%d is non-accepting -\n"), ds);
 
 			/* identify the state */
-			dump_associated_rules (ctrl.backing_up_file, ds);
+			dump_associated_rules (gv->ctrl.backing_up_file, ds);
 
 			/* Now identify it further using the out- and
 			 * jam-transitions.
 			 */
-			dump_transitions (ctrl.backing_up_file, state);
+			dump_transitions (gv->ctrl.backing_up_file, state);
 
-			putc ('\n', ctrl.backing_up_file);
+			putc ('\n', gv->ctrl.backing_up_file);
 		}
 	}
 }
@@ -101,10 +101,10 @@ static void check_trailing_context(int *nfa_states, int num_states, int *accset,
 
 	for (i = 1; i <= num_states; ++i) {
 		int     ns = nfa_states[i];
-		int type = state_type[ns];
-		int ar = assoc_rule[ns];
+		int type = gv->state_type[ns];
+		int ar = gv->assoc_rule[ns];
 
-		if (type == STATE_NORMAL || rule_type[ar] != RULE_VARIABLE) {	/* do nothing */
+		if (type == STATE_NORMAL || gv->rule_type[ar] != RULE_VARIABLE) {	/* do nothing */
 		}
 
 		else if (type == STATE_TRAILING_CONTEXT) {
@@ -118,7 +118,7 @@ static void check_trailing_context(int *nfa_states, int num_states, int *accset,
 				if (accset[j] & YY_TRAILING_HEAD_MASK) {
 					line_warning (_
 						      ("dangerous trailing context"),
-						      rule_linenum[ar]);
+						      gv->rule_linenum[ar]);
 					return;
 				}
 		}
@@ -138,11 +138,11 @@ static void dump_associated_rules(FILE *file, int ds)
 	int i, j;
 	int num_associated_rules = 0;
 	int rule_set[MAX_ASSOC_RULES + 1];
-	int *dset = dss[ds];
-	int size = dfasiz[ds];
+	int *dset = gv->dss[ds];
+	int size = gv->dfasiz[ds];
 
 	for (i = 1; i <= size; ++i) {
-		int rule_num = rule_linenum[assoc_rule[dset[i]]];
+		int rule_num = gv->rule_linenum[gv->assoc_rule[dset[i]]];
 
 		for (j = 1; j <= num_associated_rules; ++j)
 			if (rule_num == rule_set[j])
@@ -186,8 +186,8 @@ static void dump_transitions(FILE *file, int state[])
 	int i, ec;
 	int out_char_set[CSIZE];
 
-	for (i = 0; i < ctrl.csize; ++i) {
-		ec = ABS (ecgroup[i]);
+	for (i = 0; i < gv->ctrl.csize; ++i) {
+		ec = ABS (gv->ecgroup[i]);
 		out_char_set[i] = state[ec];
 	}
 
@@ -196,7 +196,7 @@ static void dump_transitions(FILE *file, int state[])
 	list_character_set (file, out_char_set);
 
 	/* now invert the members of the set to get the jam transitions */
-	for (i = 0; i < ctrl.csize; ++i)
+	for (i = 0; i < gv->ctrl.csize; ++i)
 		out_char_set[i] = !out_char_set[i];
 
 	fprintf (file, _("\n jam-transitions: EOF "));
@@ -232,42 +232,42 @@ static int *epsclosure(int *t, int *ns_addr, int accset[], int *nacc_addr, int *
 	int     stkpos, ns, tsp;
 	int     numstates = *ns_addr, nacc, hashval, transsym, nfaccnum;
 	int     stkend, nstate;
-	static int did_stk_init = false, *stk;
+	//static int did_stk_init = false, *stk;
 
 #define MARK_STATE(state) \
-do{ trans1[state] = trans1[state] - MARKER_DIFFERENCE;} while(0)
+do{ gv->trans1[state] = gv->trans1[state] - MARKER_DIFFERENCE;} while(0)
 
-#define IS_MARKED(state) (trans1[state] < 0)
+#define IS_MARKED(state) (gv->trans1[state] < 0)
 
 #define UNMARK_STATE(state) \
-do{ trans1[state] = trans1[state] + MARKER_DIFFERENCE;} while(0)
+do{ gv->trans1[state] = gv->trans1[state] + MARKER_DIFFERENCE;} while(0)
 
 #define CHECK_ACCEPT(state) \
 do{ \
-nfaccnum = accptnum[state]; \
+nfaccnum = gv->accptnum[state]; \
 if ( nfaccnum != NIL ) \
 accset[++nacc] = nfaccnum; \
 }while(0)
 
 #define DO_REALLOCATION() \
 do { \
-current_max_dfa_size += MAX_DFA_SIZE_INCREMENT; \
-++num_reallocs; \
-t = reallocate_integer_array( t, current_max_dfa_size ); \
-stk = reallocate_integer_array( stk, current_max_dfa_size ); \
+gv->current_max_dfa_size += MAX_DFA_SIZE_INCREMENT; \
+++gv->num_reallocs; \
+t = reallocate_integer_array( t, gv->current_max_dfa_size ); \
+gv->stk = reallocate_integer_array( gv->stk, gv->current_max_dfa_size ); \
 }while(0) \
 
 #define PUT_ON_STACK(state) \
 do { \
-if ( ++stkend >= current_max_dfa_size ) \
+if ( ++stkend >= gv->current_max_dfa_size ) \
 DO_REALLOCATION(); \
-stk[stkend] = state; \
+gv->stk[stkend] = state; \
 MARK_STATE(state); \
 }while(0)
 
 #define ADD_STATE(state) \
 do { \
-if ( ++numstates >= current_max_dfa_size ) \
+if ( ++numstates >= gv->current_max_dfa_size ) \
 DO_REALLOCATION(); \
 t[numstates] = state; \
 hashval += state; \
@@ -277,14 +277,14 @@ hashval += state; \
 do { \
 PUT_ON_STACK(state); \
 CHECK_ACCEPT(state); \
-if ( nfaccnum != NIL || transchar[state] != SYM_EPSILON ) \
+if ( nfaccnum != NIL || gv->transchar[state] != SYM_EPSILON ) \
 ADD_STATE(state); \
 }while(0)
 
 
-	if (!did_stk_init) {
-		stk = allocate_integer_array (current_max_dfa_size);
-		did_stk_init = true;
+	if (!gv->did_stk_init) {
+		gv->stk = allocate_integer_array (gv->current_max_dfa_size);
+		gv->did_stk_init = true;
 	}
 
 	nacc = stkend = hashval = 0;
@@ -303,17 +303,17 @@ ADD_STATE(state); \
 	}
 
 	for (stkpos = 1; stkpos <= stkend; ++stkpos) {
-		ns = stk[stkpos];
-		transsym = transchar[ns];
+		ns = gv->stk[stkpos];
+		transsym = gv->transchar[ns];
 
 		if (transsym == SYM_EPSILON) {
-			tsp = trans1[ns] + MARKER_DIFFERENCE;
+			tsp = gv->trans1[ns] + MARKER_DIFFERENCE;
 
 			if (tsp != NO_TRANSITION) {
 				if (!IS_MARKED (tsp))
 					STACK_STATE (tsp);
 
-				tsp = trans2[ns];
+				tsp = gv->trans2[ns];
 
 				if (tsp != NO_TRANSITION
 				    && !IS_MARKED (tsp))
@@ -325,8 +325,8 @@ ADD_STATE(state); \
 	/* Clear out "visit" markers. */
 
 	for (stkpos = 1; stkpos <= stkend; ++stkpos) {
-		if (IS_MARKED (stk[stkpos]))
-			UNMARK_STATE (stk[stkpos]);
+		if (IS_MARKED (gv->stk[stkpos]))
+			UNMARK_STATE (gv->stk[stkpos]);
 		else
 			flexfatal (_
 				   ("consistency check failed in epsclosure()"));
@@ -344,23 +344,23 @@ ADD_STATE(state); \
 
 void increase_max_dfas (void)
 {
-	current_max_dfas += MAX_DFAS_INCREMENT;
+	gv->current_max_dfas += MAX_DFAS_INCREMENT;
 
-	++num_reallocs;
+	++gv->num_reallocs;
 
-	base = reallocate_integer_array (base, current_max_dfas);
-	def = reallocate_integer_array (def, current_max_dfas);
-	dfasiz = reallocate_integer_array (dfasiz, current_max_dfas);
-	accsiz = reallocate_integer_array (accsiz, current_max_dfas);
-	dhash = reallocate_integer_array (dhash, current_max_dfas);
-	dss = reallocate_int_ptr_array (dss, current_max_dfas);
-	dfaacc = reallocate_array(dfaacc, current_max_dfas,
+	gv->base = reallocate_integer_array (gv->base, gv->current_max_dfas);
+	gv->def = reallocate_integer_array (gv->def, gv->current_max_dfas);
+	gv->dfasiz = reallocate_integer_array (gv->dfasiz, gv->current_max_dfas);
+	gv->accsiz = reallocate_integer_array (gv->accsiz, gv->current_max_dfas);
+	gv->dhash = reallocate_integer_array (gv->dhash, gv->current_max_dfas);
+	gv->dss = reallocate_int_ptr_array (gv->dss, gv->current_max_dfas);
+	gv->dfaacc = reallocate_array(gv->dfaacc, gv->current_max_dfas,
 		sizeof(union dfaacc_union));
 
-	if (nultrans)
-		nultrans =
-			reallocate_integer_array (nultrans,
-						  current_max_dfas);
+	if (gv->nultrans)
+		gv->nultrans =
+			reallocate_integer_array (gv->nultrans,
+						  gv->current_max_dfas);
 }
 
 
@@ -400,8 +400,8 @@ size_t ntod (void)
 	/* accset needs to be large enough to hold all of the rules present
 	 * in the input, *plus* their YY_TRAILING_HEAD_MASK variants.
 	 */
-	accset = allocate_integer_array ((num_rules + 1) * 2);
-	nset = allocate_integer_array (current_max_dfa_size);
+	accset = allocate_integer_array ((gv->num_rules + 1) * 2);
+	nset = allocate_integer_array (gv->current_max_dfa_size);
 
 	/* The "todo" queue is represented by the head, which is the DFA
 	 * state currently being processed, and the "next", which is the
@@ -411,16 +411,16 @@ size_t ntod (void)
 	 */
 	todo_head = todo_next = 0;
 
-	for (i = 0; i <= ctrl.csize; ++i) {
+	for (i = 0; i <= gv->ctrl.csize; ++i) {
 		duplist[i] = NIL;
 		symlist[i] = false;
 	}
 
-	for (i = 0; i <= num_rules; ++i)
+	for (i = 0; i <= gv->num_rules; ++i)
 		accset[i] = NIL;
 
-	if (env.trace) {
-		dumpnfa (scset[1]);
+	if (gv->env.trace) {
+		dumpnfa (gv->scset[1]);
 		fputs (_("\n\nDFA Dump:\n\n"), stderr);
 	}
 
@@ -461,30 +461,30 @@ size_t ntod (void)
 	 * New way: we will only use NUL table for fulltbl, because the
 	 * scanner will use an integer instead of YY_CHAR as noted above
 	 */
-	if (ctrl.fulltbl && ecgroup[0] == numecs && is_power_of_2(numecs))
-		nultrans = allocate_integer_array (current_max_dfas);
+	if (gv->ctrl.fulltbl && gv->ecgroup[0] == gv->numecs && is_power_of_2(gv->numecs))
+		gv->nultrans = allocate_integer_array (gv->current_max_dfas);
 
-	if (ctrl.fullspd) {
-		for (i = 0; i <= numecs; ++i)
+	if (gv->ctrl.fullspd) {
+		for (i = 0; i <= gv->numecs; ++i)
 			state[i] = 0;
 
 		place_state (state, 0, 0);
-		dfaacc[0].dfaacc_state = 0;
+		gv->dfaacc[0].dfaacc_state = 0;
 	}
 
-	else if (ctrl.fulltbl) {
-		if (nultrans)
+	else if (gv->ctrl.fulltbl) {
+		if (gv->nultrans)
 			/* We won't be including NUL's transitions in the
 			 * table, so build it for entries from 0 .. numecs - 1.
 			 */
-			num_full_table_rows = numecs;
+			num_full_table_rows = gv->numecs;
 
 		else
 			/* Take into account the fact that we'll be including
 			 * the NUL entries in the transition table.  Build it
 			 * from 0 .. numecs.
 			 */
-			num_full_table_rows = numecs + 1;
+			num_full_table_rows = gv->numecs + 1;
 
 		/* Begin generating yy_nxt[][]
 		 * This spans the entire LONG function.
@@ -493,7 +493,7 @@ size_t ntod (void)
 		 * we'll wait until we can calculate yynxt_tbl->td_hilen.
 		 */
 		yynxt_tbl = calloc(1, sizeof (struct yytbl_data));
-     
+
 		yytbl_data_init (yynxt_tbl, YYTD_ID_NXT);
 		yynxt_tbl->td_hilen = 1;
 		yynxt_tbl->td_lolen = (flex_uint32_t) num_full_table_rows;
@@ -509,7 +509,7 @@ size_t ntod (void)
 		out_dec ("m4_define([[M4_HOOK_NXT_ROWS]], [[%d]])", num_full_table_rows);
 		outn ("m4_define([[M4_HOOK_NXT_BODY]], [[m4_dnl");
 		outn ("M4_HOOK_TABLE_OPENER");
-		if (gentables)
+		if (gv->gentables)
 			outn ("M4_HOOK_TABLE_OPENER");
 
 		/* Generate 0 entries for state #0. */
@@ -518,7 +518,7 @@ size_t ntod (void)
 			yynxt_data[yynxt_curr++] = 0;
 		}
 
-		if (gentables) {
+		if (gv->gentables) {
 			dataflush ();
 			outn ("M4_HOOK_TABLE_CONTINUE");
 		}
@@ -526,7 +526,7 @@ size_t ntod (void)
 
 	/* Create the first states. */
 
-	num_start_states = lastsc * 2;
+	num_start_states = gv->lastsc * 2;
 
 	for (i = 1; i <= num_start_states; ++i) {
 		numstates = 1;
@@ -536,31 +536,31 @@ size_t ntod (void)
 		 * one for the case when we're not.
 		 */
 		if (i % 2 == 1)
-			nset[numstates] = scset[(i / 2) + 1];
+			nset[numstates] = gv->scset[(i / 2) + 1];
 		else
 			nset[numstates] =
-				mkbranch (scbol[i / 2], scset[i / 2]);
+				mkbranch (gv->scbol[i / 2], gv->scset[i / 2]);
 
 		nset = epsclosure (nset, &numstates, accset, &nacc,
 				   &hashval);
 
 		if (snstods (nset, numstates, accset, nacc, hashval, &ds)) {
-			numas += nacc;
-			totnst += numstates;
+			gv->numas += nacc;
+			gv->totnst += numstates;
 			++todo_next;
 
-			if (variable_trailing_context_rules && nacc > 0)
+			if (gv->variable_trailing_context_rules && nacc > 0)
 				check_trailing_context (nset, numstates,
 							accset, nacc);
 		}
 	}
 
-	if (!ctrl.fullspd) {
-		if (!snstods (nset, 0, accset, 0, 0, &end_of_buffer_state))
+	if (!gv->ctrl.fullspd) {
+		if (!snstods (nset, 0, accset, 0, 0, &gv->end_of_buffer_state))
 			flexfatal (_
 				   ("could not create unique end-of-buffer state"));
 
-		++numas;
+		++gv->numas;
 		++num_start_states;
 		++todo_next;
 	}
@@ -570,20 +570,20 @@ size_t ntod (void)
 		targptr = 0;
 		totaltrans = 0;
 
-		for (i = 1; i <= numecs; ++i)
+		for (i = 1; i <= gv->numecs; ++i)
 			state[i] = 0;
 
 		ds = ++todo_head;
 
-		dset = dss[ds];
-		dsize = dfasiz[ds];
+		dset = gv->dss[ds];
+		dsize = gv->dfasiz[ds];
 
-		if (env.trace)
+		if (gv->env.trace)
 			fprintf (stderr, _("state # %d:\n"), ds);
 
 		sympartition (dset, dsize, symlist, duplist);
 
-		for (sym = 1; sym <= numecs; ++sym) {
+		for (sym = 1; sym <= gv->numecs; ++sym) {
 			if (symlist[sym]) {
 				symlist[sym] = 0;
 
@@ -600,12 +600,12 @@ size_t ntod (void)
 					if (snstods
 					    (nset, numstates, accset, nacc,
 					     hashval, &newds)) {
-						totnst = totnst +
+						gv->totnst = gv->totnst +
 							numstates;
 						++todo_next;
-						numas += nacc;
+						gv->numas += nacc;
 
-						if (variable_trailing_context_rules && nacc > 0)
+						if (gv->variable_trailing_context_rules && nacc > 0)
 							check_trailing_context
 								(nset,
 								 numstates,
@@ -615,14 +615,14 @@ size_t ntod (void)
 
 					state[sym] = newds;
 
-					if (env.trace)
+					if (gv->env.trace)
 						fprintf (stderr,
 							 "\t%d\t%d\n", sym,
 							 newds);
 
 					targfreq[++targptr] = 1;
 					targstate[targptr] = newds;
-					++numuniq;
+					++gv->numuniq;
 				}
 
 				else {
@@ -633,7 +633,7 @@ size_t ntod (void)
 					targ = state[duplist[sym]];
 					state[sym] = targ;
 
-					if (env.trace)
+					if (gv->env.trace)
 						fprintf (stderr,
 							 "\t%d\t%d\n", sym,
 							 targ);
@@ -646,7 +646,7 @@ size_t ntod (void)
 					while (targstate[++i] != targ) ;
 
 					++targfreq[i];
-					++numdup;
+					++gv->numdup;
 				}
 
 				++totaltrans;
@@ -655,17 +655,17 @@ size_t ntod (void)
 		}
 
 
-		numsnpairs += totaltrans;
+		gv->numsnpairs += totaltrans;
 
 		if (ds > num_start_states)
 			check_for_backing_up (ds, state);
 
-		if (nultrans) {
-			nultrans[ds] = state[NUL_ec];
-			state[NUL_ec] = 0;	/* remove transition */
+		if (gv->nultrans) {
+			gv->nultrans[ds] = state[gv->NUL_ec];
+			state[gv->NUL_ec] = 0;	/* remove transition */
 		}
 
-		if (ctrl.fulltbl) {
+		if (gv->ctrl.fulltbl) {
 
 			/* Each time we hit here, it's another td_hilen, so we realloc. */
 			yynxt_tbl->td_hilen++;
@@ -674,19 +674,19 @@ size_t ntod (void)
 						     yynxt_tbl->td_hilen *
 						     yynxt_tbl->td_lolen *
 						     sizeof (flex_int32_t));
-			if (gentables)
+			if (gv->gentables)
 				outn ("M4_HOOK_TABLE_OPENER");
 
 			/* Supply array's 0-element. */
-			if (ds == end_of_buffer_state) {
-				mk2data (-end_of_buffer_state);
+			if (ds == gv->end_of_buffer_state) {
+				mk2data (-gv->end_of_buffer_state);
 				yynxt_data[yynxt_curr++] =
-					-end_of_buffer_state;
+					-gv->end_of_buffer_state;
 			}
 			else {
-				mk2data (end_of_buffer_state);
+				mk2data (gv->end_of_buffer_state);
 				yynxt_data[yynxt_curr++] =
-					end_of_buffer_state;
+					gv->end_of_buffer_state;
 			}
 
 			for (i = 1; i < num_full_table_rows; ++i) {
@@ -698,16 +698,16 @@ size_t ntod (void)
 					state[i] ? state[i] : -ds;
 			}
 
-			if (gentables) {
+			if (gv->gentables) {
 				dataflush ();
 				outn ("M4_HOOK_TABLE_CONTINUE");
 			}
 		}
 
-		else if (ctrl.fullspd)
+		else if (gv->ctrl.fullspd)
 			place_state (state, ds, totaltrans);
 
-		else if (ds == end_of_buffer_state)
+		else if (ds == gv->end_of_buffer_state)
 			/* Special case this state to make sure it does what
 			 * it's supposed to, i.e., jam on end-of-buffer.
 			 */
@@ -732,12 +732,12 @@ size_t ntod (void)
 		}
 	}
 
-	if (ctrl.fulltbl) {
+	if (gv->ctrl.fulltbl) {
 		dataend ("M4_HOOK_TABLE_CLOSER");
 		outn("/* body */]])");
-		if (tablesext) {
+		if (gv->tablesext) {
 			yytbl_data_compress (yynxt_tbl);
-			if (yytbl_data_fwrite (&tableswr, yynxt_tbl) < 0)
+			if (yytbl_data_fwrite (&gv->tableswr, yynxt_tbl) < 0)
 				flexerror (_
 					   ("Could not write yynxt_tbl[][]"));
 		}
@@ -747,16 +747,16 @@ size_t ntod (void)
 		}
 	}
 
-	else if (!ctrl.fullspd) {
+	else if (!gv->ctrl.fullspd) {
 		cmptmps ();	/* create compressed template entries */
 
 		/* Create tables for all the states with only one
 		 * out-transition.
 		 */
-		while (onesp > 0) {
-			mk1tbl (onestate[onesp], onesym[onesp],
-				onenext[onesp], onedef[onesp]);
-			--onesp;
+		while (gv->onesp > 0) {
+			mk1tbl (gv->onestate[gv->onesp], gv->onesym[gv->onesp],
+				gv->onenext[gv->onesp], gv->onedef[gv->onesp]);
+			--gv->onesp;
 		}
 
 		mkdeftbl ();
@@ -786,10 +786,10 @@ static int snstods(int sns[], int numstates, int accset[], int nacc, int hashval
 	int i, j;
 	int newds, *oldsns;
 
-	for (i = 1; i <= lastdfa; ++i)
-		if (hashval == dhash[i]) {
-			if (numstates == dfasiz[i]) {
-				oldsns = dss[i];
+	for (i = 1; i <= gv->lastdfa; ++i)
+		if (hashval == gv->dhash[i]) {
+			if (numstates == gv->dfasiz[i]) {
+				oldsns = gv->dss[i];
 
 				if (!didsort) {
 					/* We sort the states in sns so we
@@ -804,26 +804,26 @@ static int snstods(int sns[], int numstates, int accset[], int nacc, int hashval
 						break;
 
 				if (j > numstates) {
-					++dfaeql;
+					++gv->dfaeql;
 					*newds_addr = i;
 					return 0;
 				}
 
-				++hshcol;
+				++gv->hshcol;
 			}
 
 			else
-				++hshsave;
+				++gv->hshsave;
 		}
 
 	/* Make a new dfa. */
 
-	if (++lastdfa >= current_max_dfas)
+	if (++gv->lastdfa >= gv->current_max_dfas)
 		increase_max_dfas ();
 
-	newds = lastdfa;
+	newds = gv->lastdfa;
 
-	dss[newds] = allocate_integer_array (numstates + 1);
+	gv->dss[newds] = allocate_integer_array (numstates + 1);
 
 	/* If we haven't already sorted the states in sns, we do so now,
 	 * so that future comparisons with it can be made quickly.
@@ -833,21 +833,21 @@ static int snstods(int sns[], int numstates, int accset[], int nacc, int hashval
           	qsort (&sns [1], (size_t) numstates, sizeof (sns [1]), intcmp);
 
 	for (i = 1; i <= numstates; ++i)
-		dss[newds][i] = sns[i];
+		gv->dss[newds][i] = sns[i];
 
-	dfasiz[newds] = numstates;
-	dhash[newds] = hashval;
+	gv->dfasiz[newds] = numstates;
+	gv->dhash[newds] = hashval;
 
 	if (nacc == 0) {
-		if (reject)
-			dfaacc[newds].dfaacc_set = NULL;
+		if (gv->reject)
+			gv->dfaacc[newds].dfaacc_set = NULL;
 		else
-			dfaacc[newds].dfaacc_state = 0;
+			gv->dfaacc[newds].dfaacc_state = 0;
 
-		accsiz[newds] = 0;
+		gv->accsiz[newds] = 0;
 	}
 
-	else if (reject) {
+	else if (gv->reject) {
 		/* We sort the accepting set in increasing order so the
 		 * disambiguating rule that the first rule listed is considered
 		 * match in the event of ties will work.
@@ -855,37 +855,37 @@ static int snstods(int sns[], int numstates, int accset[], int nacc, int hashval
 
 		qsort (&accset [1], (size_t) nacc, sizeof (accset [1]), intcmp);
 
-		dfaacc[newds].dfaacc_set =
+		gv->dfaacc[newds].dfaacc_set =
 			allocate_integer_array (nacc + 1);
 
 		/* Save the accepting set for later */
 		for (i = 1; i <= nacc; ++i) {
-			dfaacc[newds].dfaacc_set[i] = accset[i];
+			gv->dfaacc[newds].dfaacc_set[i] = accset[i];
 
-			if (accset[i] <= num_rules)
+			if (accset[i] <= gv->num_rules)
 				/* Who knows, perhaps a REJECT can yield
 				 * this rule.
 				 */
-				rule_useful[accset[i]] = true;
+				gv->rule_useful[accset[i]] = true;
 		}
 
-		accsiz[newds] = nacc;
+		gv->accsiz[newds] = nacc;
 	}
 
 	else {
 		/* Find lowest numbered rule so the disambiguating rule
 		 * will work.
 		 */
-		j = num_rules + 1;
+		j = gv->num_rules + 1;
 
 		for (i = 1; i <= nacc; ++i)
 			if (accset[i] < j)
 				j = accset[i];
 
-		dfaacc[newds].dfaacc_state = j;
+		gv->dfaacc[newds].dfaacc_state = j;
 
-		if (j <= num_rules)
-			rule_useful[j] = true;
+		if (j <= gv->num_rules)
+			gv->rule_useful[j] = true;
 	}
 
 	*newds_addr = newds;
@@ -909,23 +909,23 @@ static int symfollowset(int ds[], int dsize, int transsym, int nset[])
 
 	for (i = 1; i <= dsize; ++i) {	/* for each nfa state ns in the state set of ds */
 		ns = ds[i];
-		sym = transchar[ns];
-		tsp = trans1[ns];
+		sym = gv->transchar[ns];
+		tsp = gv->trans1[ns];
 
 		if (sym < 0) {	/* it's a character class */
 			sym = -sym;
-			ccllist = cclmap[sym];
-			lenccl = ccllen[sym];
+			ccllist = gv->cclmap[sym];
+			lenccl = gv->ccllen[sym];
 
-			if (cclng[sym]) {
+			if (gv->cclng[sym]) {
 				for (j = 0; j < lenccl; ++j) {
 					/* Loop through negated character
 					 * class.
 					 */
-					ch = ccltbl[ccllist + j];
+					ch = gv->ccltbl[ccllist + j];
 
 					if (ch == 0)
-						ch = NUL_ec;
+						ch = gv->NUL_ec;
 
 					if (ch > transsym)
 						/* Transsym isn't in negated
@@ -944,10 +944,10 @@ static int symfollowset(int ds[], int dsize, int transsym, int nset[])
 
 			else
 				for (j = 0; j < lenccl; ++j) {
-					ch = ccltbl[ccllist + j];
+					ch = gv->ccltbl[ccllist + j];
 
 					if (ch == 0)
-						ch = NUL_ec;
+						ch = gv->NUL_ec;
 
 					if (ch > transsym)
 						break;
@@ -961,7 +961,7 @@ static int symfollowset(int ds[], int dsize, int transsym, int nset[])
 		else if (sym == SYM_EPSILON) {	/* do nothing */
 		}
 
-		else if (ABS (ecgroup[sym]) == transsym)
+		else if (ABS (gv->ecgroup[sym]) == transsym)
 			nset[++numstates] = tsp;
 
 	      bottom:;
@@ -987,26 +987,26 @@ static void sympartition(int ds[], int numstates, int symlist[], int duplist[])
 	 * we are really creating equivalence classes of equivalence classes.
 	 */
 
-	for (i = 1; i <= numecs; ++i) {	/* initialize equivalence class list */
+	for (i = 1; i <= gv->numecs; ++i) {	/* initialize equivalence class list */
 		duplist[i] = i - 1;
 		dupfwd[i] = i + 1;
 	}
 
 	duplist[1] = NIL;
-	dupfwd[numecs] = NIL;
+	dupfwd[gv->numecs] = NIL;
 
 	for (i = 1; i <= numstates; ++i) {
 		ns = ds[i];
-		tch = transchar[ns];
+		tch = gv->transchar[ns];
 
 		if (tch != SYM_EPSILON) {
-			if (tch < -lastccl || tch >= ctrl.csize) {
+			if (tch < -gv->lastccl || tch >= gv->ctrl.csize) {
 				flexfatal (_
 					   ("bad transition character detected in sympartition()"));
 			}
 
 			if (tch >= 0) {	/* character transition */
-				int     ec = ecgroup[tch];
+				int     ec = gv->ecgroup[tch];
 
 				mkechar (ec, dupfwd, duplist);
 				symlist[ec] = 1;
@@ -1015,34 +1015,34 @@ static void sympartition(int ds[], int numstates, int symlist[], int duplist[])
 			else {	/* character class */
 				tch = -tch;
 
-				lenccl = ccllen[tch];
-				cclp = cclmap[tch];
-				mkeccl (ccltbl + cclp, lenccl, dupfwd,
-					duplist, numecs, NUL_ec);
+				lenccl = gv->ccllen[tch];
+				cclp = gv->cclmap[tch];
+				mkeccl (gv->ccltbl + cclp, lenccl, dupfwd,
+					duplist, gv->numecs, gv->NUL_ec);
 
-				if (cclng[tch]) {
+				if (gv->cclng[tch]) {
 					j = 0;
 
 					for (k = 0; k < lenccl; ++k) {
-						ich = ccltbl[cclp + k];
+						ich = gv->ccltbl[cclp + k];
 
 						if (ich == 0)
-							ich = NUL_ec;
+							ich = gv->NUL_ec;
 
 						for (++j; j < ich; ++j)
 							symlist[j] = 1;
 					}
 
-					for (++j; j <= numecs; ++j)
+					for (++j; j <= gv->numecs; ++j)
 						symlist[j] = 1;
 				}
 
 				else
 					for (k = 0; k < lenccl; ++k) {
-						ich = ccltbl[cclp + k];
+						ich = gv->ccltbl[cclp + k];
 
 						if (ich == 0)
-							ich = NUL_ec;
+							ich = gv->NUL_ec;
 
 						symlist[ich] = 1;
 					}

--- a/src/ecs.c
+++ b/src/ecs.c
@@ -40,7 +40,7 @@ void    ccl2ecl (void)
 {
 	int     i, ich, newlen, cclp, ccls, cclmec;
 
-	for (i = 1; i <= lastccl; ++i) {
+	for (i = 1; i <= gv->lastccl; ++i) {
 		/* We loop through each character class, and for each character
 		 * in the class, add the character's equivalence class to the
 		 * new "character" class we are creating.  Thus when we are all
@@ -49,20 +49,20 @@ void    ccl2ecl (void)
 		 */
 
 		newlen = 0;
-		cclp = cclmap[i];
+		cclp = gv->cclmap[i];
 
-		for (ccls = 0; ccls < ccllen[i]; ++ccls) {
-			ich = ccltbl[cclp + ccls];
-			cclmec = ecgroup[ich];
+		for (ccls = 0; ccls < gv->ccllen[i]; ++ccls) {
+			ich = gv->ccltbl[cclp + ccls];
+			cclmec = gv->ecgroup[ich];
 
 			if (cclmec > 0) {
 				/* Note: range 1..256 is mapped to 1..255,0 */
-				ccltbl[cclp + newlen] = (unsigned char) cclmec;
+				gv->ccltbl[cclp + newlen] = (unsigned char) cclmec;
 				++newlen;
 			}
 		}
 
-		ccllen[i] = newlen;
+		gv->ccllen[i] = newlen;
 	}
 }
 
@@ -116,7 +116,7 @@ void    mkeccl (unsigned char ccls[], int lenccl, int fwd[], int bck[], int llsi
 {
 	int     cclp, oldec, newec;
 	int     cclm, i, j;
-	static unsigned char cclflags[CSIZE];	/* initialized to all '\0' */
+	//static unsigned char cclflags[CSIZE];	/* initialized to all '\0' */
 
 	/* Note that it doesn't matter whether or not the character class is
 	 * negated.  The same results will be obtained in either case.
@@ -147,7 +147,7 @@ void    mkeccl (unsigned char ccls[], int lenccl, int fwd[], int bck[], int llsi
 				if (ccl_char > i)
 					break;
 
-				if (ccl_char == i && !cclflags[j]) {
+				if (ccl_char == i && !gv->cclflags[j]) {
 					/* We found an old companion of cclm
 					 * in the ccl.  Link it into the new
 					 * equivalence class and flag it as
@@ -158,7 +158,7 @@ void    mkeccl (unsigned char ccls[], int lenccl, int fwd[], int bck[], int llsi
 					fwd[newec] = i;
 					newec = i;
 					/* Set flag so we don't reprocess. */
-					cclflags[j] = 1;
+					gv->cclflags[j] = 1;
 
 					/* Get next equivalence class member. */
 					/* continue 2 */
@@ -189,9 +189,9 @@ void    mkeccl (unsigned char ccls[], int lenccl, int fwd[], int bck[], int llsi
 
 		/* Find next ccl member to process. */
 
-		for (++cclp; cclp < lenccl && cclflags[cclp]; ++cclp) {
+		for (++cclp; cclp < lenccl && gv->cclflags[cclp]; ++cclp) {
 			/* Reset "doesn't need processing" flag. */
-			cclflags[cclp] = 0;
+			gv->cclflags[cclp] = 0;
 		}
 	}
 }

--- a/src/ecs.c
+++ b/src/ecs.c
@@ -36,7 +36,7 @@
 
 /* ccl2ecl - convert character classes to set of equivalence classes */
 
-void    ccl2ecl (void)
+void    ccl2ecl (FlexState* gv)
 {
 	int     i, ich, newlen, cclp, ccls, cclmec;
 
@@ -112,7 +112,7 @@ int     cre8ecs (int fwd[], int bck[], int num)
  * NUL_mapping is the value which NUL (0) should be mapped to.
  */
 
-void    mkeccl (unsigned char ccls[], int lenccl, int fwd[], int bck[], int llsiz, int NUL_mapping)
+void    mkeccl (FlexState* gv, unsigned char ccls[], int lenccl, int fwd[], int bck[], int llsiz, int NUL_mapping)
 {
 	int     cclp, oldec, newec;
 	int     cclm, i, j;

--- a/src/filter.c
+++ b/src/filter.c
@@ -29,7 +29,7 @@ static const char * check_4_gnu_m4 =
 
 
 /** global chain. */
-struct filter *output_chain = NULL;
+//struct filter *output_chain = NULL;
 
 /* Allocate and initialize an external filter.
  * @param chain the current chain or NULL for new chain
@@ -264,7 +264,7 @@ int filter_tee_header (struct filter *chain)
 		fputs ("m4_define([[M4_YY_IN_HEADER]],[[]])m4_dnl\n", to_h);
 		fprintf (to_h,
 			 "m4_define( [[M4_YY_OUTFILE_NAME]],[[%s]])m4_dnl\n",
-			 env.headerfilename != NULL ? env.headerfilename : "<stdout>");
+			 gv->env.headerfilename != NULL ? gv->env.headerfilename : "<stdout>");
 	}
 
 	fputs (check_4_gnu_m4, to_c);
@@ -273,7 +273,7 @@ int filter_tee_header (struct filter *chain)
 	fputs ("m4_changequote([[,]])[[]]m4_dnl\n", to_c);
 	fputs ("m4_define([[M4_YY_NOOP]])[[]]m4_dnl\n", to_c);
 	fprintf (to_c, "m4_define( [[M4_YY_OUTFILE_NAME]],[[%s]])m4_dnl\n",
-		 env.outfilename != NULL ? env.outfilename : "<stdout>");
+		 gv->env.outfilename != NULL ? gv->env.outfilename : "<stdout>");
 
 	while (fgets (buf, sizeof buf, stdin)) {
 		fputs (buf, to_c);
@@ -285,7 +285,7 @@ int filter_tee_header (struct filter *chain)
 		fprintf (to_h, "\n");
 
 		/* write a fake line number. It will get fixed by the linedir filter. */
-		if (ctrl.gen_line_dirs)
+		if (gv->ctrl.gen_line_dirs)
 			line_directive_out (to_h, NULL, 4000);
 		fflush (to_h);
 		if (ferror (to_h))
@@ -300,11 +300,11 @@ int filter_tee_header (struct filter *chain)
 	fflush (to_c);
 	if (ferror (to_c))
 		lerr (_("error writing output file %s"),
-			env.outfilename != NULL ? env.outfilename : "<stdout>");
+			gv->env.outfilename != NULL ? gv->env.outfilename : "<stdout>");
 
 	else if (fclose (to_c))
 		lerr (_("error closing output file %s"),
-			env.outfilename != NULL ? env.outfilename : "<stdout>");
+			gv->env.outfilename != NULL ? gv->env.outfilename : "<stdout>");
 
 	while (wait (0) > 0) ;
 
@@ -344,9 +344,9 @@ int filter_fix_linedirs (struct filter *chain)
 		/* Check for directive. Note wired-in assumption:
 		 * field reference 1 is line number, 2 is filename.
 		 */
-		if (ctrl.traceline_re != NULL &&
-		    ctrl.traceline_template != NULL &&
-		    regexec (&regex_linedir, buf, 3, m, 0) == 0) {
+		if (gv->ctrl.traceline_re != NULL &&
+		    gv->ctrl.traceline_template != NULL &&
+		    regexec (&gv->regex_linedir, buf, 3, m, 0) == 0) {
 
 			char   *fname;
 
@@ -354,10 +354,10 @@ int filter_fix_linedirs (struct filter *chain)
 			fname = regmatch_dup (&m[2], buf);
 
 			if (strcmp (fname,
-				env.outfilename != NULL ? env.outfilename : "<stdout>")
+				gv->env.outfilename != NULL ? gv->env.outfilename : "<stdout>")
 					== 0
 			 || strcmp (fname,
-			 	env.headerfilename != NULL ? env.headerfilename : "<stdout>")
+			 	gv->env.headerfilename != NULL ? gv->env.headerfilename : "<stdout>")
 					== 0) {
 
 				char    *s1, *s2;
@@ -381,7 +381,7 @@ int filter_fix_linedirs (struct filter *chain)
 
 				/* Adjust the line directives. */
 				in_gen = true;
-				snprintf (buf, readsz, ctrl.traceline_template,
+				snprintf (buf, readsz, gv->ctrl.traceline_template,
 					  lineno + 1, filename);
 				strncat(buf, "\n", sizeof(buf)-1);
 			}
@@ -413,11 +413,11 @@ int filter_fix_linedirs (struct filter *chain)
 	fflush (stdout);
 	if (ferror (stdout))
 		lerr (_("error writing output file %s"),
-			env.outfilename != NULL ? env.outfilename : "<stdout>");
+			gv->env.outfilename != NULL ? gv->env.outfilename : "<stdout>");
 
 	else if (fclose (stdout))
 		lerr (_("error closing output file %s"),
-			env.outfilename != NULL ? env.outfilename : "<stdout>");
+			gv->env.outfilename != NULL ? gv->env.outfilename : "<stdout>");
 
 	return 0;
 }

--- a/src/flexdef.h
+++ b/src/flexdef.h
@@ -147,16 +147,16 @@
  * that can be used.  This definition is currently not used.
  */
 #define FREE_EPSILON(state) \
-	(transchar[state] == SYM_EPSILON && \
-	 trans2[state] == NO_TRANSITION && \
-	 finalst[state] != state)
+	(gv->transchar[state] == SYM_EPSILON && \
+	 gv->trans2[state] == NO_TRANSITION && \
+	 gv->finalst[state] != state)
 
 /* Returns true if an nfa state has an epsilon out-transition character
  * and both slots are free
  */
 #define SUPER_FREE_EPSILON(state) \
-	(transchar[state] == SYM_EPSILON && \
-	 trans1[state] == NO_TRANSITION) \
+	(gv->transchar[state] == SYM_EPSILON && \
+	 gv->trans1[state] == NO_TRANSITION) \
 
 /* Maximum number of NFA states that can comprise a DFA state.  It's real
  * big because if there's a lot of rules, the initial state will have a
@@ -221,7 +221,7 @@
 /* Enough so that if it's subtracted from an NFA state number, the result
  * is guaranteed to be negative.
  */
-#define MARKER_DIFFERENCE (maximum_mns+2)
+#define MARKER_DIFFERENCE (gv->maximum_mns+2)
 
 /* Maximum number of nxt/chk pairs for non-templates. */
 #define INITIAL_MAX_XPAIRS 2000
@@ -434,8 +434,8 @@ struct packtype_t {
 	size_t width;
 };
 
-extern struct ctrl_bundle_t ctrl;
-extern struct env_bundle_t env;
+//extern struct ctrl_bundle_t ctrl;
+//extern struct env_bundle_t env;
 
 /* Declarations for global variables. */
 
@@ -455,8 +455,8 @@ extern struct env_bundle_t env;
  * reject_really_used - same for REJECT
   */
 
-extern bool syntaxerror, eofseen;
-extern int yymore_used, reject, real_reject, continued_action, in_rule;
+//extern bool syntaxerror, eofseen;
+//extern int yymore_used, reject, real_reject, continued_action, in_rule;
 
 /* Variables used in the flex input routines:
  * datapos - characters on current output line
@@ -482,17 +482,17 @@ extern int yymore_used, reject, real_reject, continued_action, in_rule;
  * always_interactive - if true, generate an interactive scanner
  */
 
-extern int datapos, dataline, linenum;
-extern int skel_ind;
-extern char *infilename;
-extern char *extra_type;
-extern char **input_files;
-extern int num_input_files;
-extern char *program_name;
+//extern int datapos, dataline, linenum;
+//extern int skel_ind;
+//extern char *infilename;
+//extern char *extra_type;
+//extern char **input_files;
+//extern int num_input_files;
+//extern char *program_name;
 
-extern char *action_array;
-extern int action_size;
-extern int defs1_offset, prolog_offset, action_offset, action_index;
+//extern char *action_array;
+//extern int action_size;
+//extern int defs1_offset, prolog_offset, action_offset, action_index;
 
 
 /* Variables for stack of states having only one out-transition:
@@ -503,8 +503,8 @@ extern int defs1_offset, prolog_offset, action_offset, action_index;
  * onesp - stack pointer
  */
 
-extern int onestate[ONE_STACK_SIZE], onesym[ONE_STACK_SIZE];
-extern int onenext[ONE_STACK_SIZE], onedef[ONE_STACK_SIZE], onesp;
+//extern int onestate[ONE_STACK_SIZE], onesym[ONE_STACK_SIZE];
+//extern int onenext[ONE_STACK_SIZE], onedef[ONE_STACK_SIZE], onesp;
 
 
 /* Variables for nfa machine data:
@@ -541,16 +541,16 @@ extern int onenext[ONE_STACK_SIZE], onedef[ONE_STACK_SIZE], onesp;
  * footprint - total size of tables, in bytes.
  */
 
-extern int maximum_mns, current_mns, current_max_rules;
-extern int num_rules, num_eof_rules, default_rule, lastnfa;
-extern int *firstst, *lastst, *finalst, *transchar, *trans1, *trans2;
-extern int *accptnum, *assoc_rule, *state_type;
-extern int *rule_type, *rule_linenum;
+//extern int maximum_mns, current_mns, current_max_rules;
+//extern int num_rules, num_eof_rules, default_rule, lastnfa;
+//extern int *firstst, *lastst, *finalst, *transchar, *trans1, *trans2;
+//extern int *accptnum, *assoc_rule, *state_type;
+//extern int *rule_type, *rule_linenum;
 /* rule_useful[], rule_has_nl[] and ccl_has_nl[] are boolean arrays,
  * but allocated as char arrays for size. */
-extern char *rule_useful, *rule_has_nl, *ccl_has_nl;
-extern int nlch;
-extern size_t footprint;
+//extern char *rule_useful, *rule_has_nl, *ccl_has_nl;
+//extern int nlch;
+//extern size_t footprint;
 
 
 /* Different types of states; values are useful as masks, as well, for
@@ -561,7 +561,7 @@ extern size_t footprint;
 
 /* Global holding current type of state we're making. */
 
-extern int current_state_type;
+//extern int current_state_type;
 
 /* Different types of rules. */
 #define RULE_NORMAL 0
@@ -570,7 +570,7 @@ extern int current_state_type;
 /* True if the input rules include a rule with both variable-length head
  * and trailing context, false otherwise.
  */
-extern bool variable_trailing_context_rules;
+//extern bool variable_trailing_context_rules;
 
 
 /* Variables for protos:
@@ -585,8 +585,8 @@ extern bool variable_trailing_context_rules;
  * protsave contains the entire state array for protos
  */
 
-extern int numtemps, numprots, protprev[MSP], protnext[MSP], prottbl[MSP];
-extern int protcomst[MSP], firstprot, lastprot, protsave[PROT_SAVE_SIZE];
+//extern int numtemps, numprots, protprev[MSP], protnext[MSP], prottbl[MSP];
+//extern int protcomst[MSP], firstprot, lastprot, protsave[PROT_SAVE_SIZE];
 
 
 /* Variables for managing equivalence classes:
@@ -604,14 +604,14 @@ extern int protcomst[MSP], firstprot, lastprot, protsave[PROT_SAVE_SIZE];
  * for the NUL character.  Later we'll move this information into
  * the 0th element.
  */
-extern int numecs, nextecm[CSIZE + 1], ecgroup[CSIZE + 1], nummecs;
+//extern int numecs, nextecm[CSIZE + 1], ecgroup[CSIZE + 1], nummecs;
 
 /* Meta-equivalence classes are indexed starting at 1, so it's possible
  * that they will require positions from 1 .. CSIZE, i.e., CSIZE + 1
  * slots total (since the arrays are 0-based).  nextecm[] and ecgroup[]
  * don't require the extra position since they're indexed from 1 .. CSIZE - 1.
  */
-extern int tecfwd[CSIZE + 1], tecbck[CSIZE + 1];
+//extern int tecfwd[CSIZE + 1], tecbck[CSIZE + 1];
 
 
 /* Variables for start conditions:
@@ -624,12 +624,12 @@ extern int tecfwd[CSIZE + 1], tecbck[CSIZE + 1];
  * scname - start condition name
  */
 
-extern int lastsc, *scset, *scbol;
+//extern int lastsc, *scset, *scbol;
 /* scxclu[] and sceof[] are boolean arrays, but allocated as char
  * arrays for size. */
-extern char *scxclu, *sceof;
-extern int current_max_scs;
-extern const char **scname;
+//extern char *scxclu, *sceof;
+//extern int current_max_scs;
+//extern const char **scname;
 
 
 /* Variables for dfa machine data:
@@ -662,18 +662,18 @@ extern const char **scname;
  * end_of_buffer_state - end-of-buffer dfa state number
  */
 
-extern int current_max_dfa_size, current_max_xpairs;
-extern int current_max_template_xpairs, current_max_dfas;
-extern int lastdfa, *nxt, *chk, *tnxt;
-extern int *base, *def, *nultrans, NUL_ec, tblend, firstfree, **dss,
-	*dfasiz;
-extern union dfaacc_union {
-	int    *dfaacc_set;
-	int     dfaacc_state;
-}      *dfaacc;
-extern int *accsiz, *dhash, numas;
-extern int numsnpairs, jambase, jamstate;
-extern int end_of_buffer_state;
+//extern int current_max_dfa_size, current_max_xpairs;
+//extern int current_max_template_xpairs, current_max_dfas;
+//extern int lastdfa, *nxt, *chk, *tnxt;
+//extern int *base, *def, *nultrans, NUL_ec, tblend, firstfree, **dss,
+//	*dfasiz;
+//extern union dfaacc_union {
+//	int    *dfaacc_set;
+//	int     dfaacc_state;
+//};       *dfaacc;
+//extern int *accsiz, *dhash, numas;
+//extern int numsnpairs, jambase, jamstate;
+//extern int end_of_buffer_state;
 
 /* Variables for ccl information:
  * lastccl - ccl index of the last created ccl
@@ -687,9 +687,9 @@ extern int end_of_buffer_state;
  * ccltbl - holds the characters in each ccl - indexed by cclmap
  */
 
-extern int lastccl, *cclmap, *ccllen, *cclng, cclreuse;
-extern int current_maxccls, current_max_ccl_tbl_size;
-extern unsigned char *ccltbl;
+//extern int lastccl, *cclmap, *ccllen, *cclng, cclreuse;
+//extern int current_maxccls, current_max_ccl_tbl_size;
+//extern unsigned char *ccltbl;
 
 
 /* Variables for miscellaneous information:
@@ -713,10 +713,10 @@ extern unsigned char *ccltbl;
  * bol_needed - whether scanner needs beginning-of-line recognition
  */
 
-extern char nmstr[MAXLINE];
-extern int sectnum, nummt, hshcol, dfaeql, numeps, eps2, num_reallocs, nmval;
-extern int tmpuses, totnst, peakpairs, numuniq, numdup, hshsave;
-extern int num_backing_up, bol_needed;
+//extern char nmstr[MAXLINE];
+//extern int sectnum, nummt, hshcol, dfaeql, numeps, eps2, num_reallocs, nmval;
+//extern int tmpuses, totnst, peakpairs, numuniq, numdup, hshsave;
+//extern int num_backing_up, bol_needed;
 
 void   *allocate_array(int, size_t);
 void   *reallocate_array(void *, int, size_t);
@@ -858,7 +858,7 @@ extern void flexfatal(const char *);
     do{ \
         fprintf (stderr,\
                 _("%s: fatal internal error at %s:%d (%s): %s\n"),\
-                program_name, __FILE__, (int)__LINE__,\
+                gv->program_name, __FILE__, (int)__LINE__,\
                 __func__,msg);\
         FLEX_EXIT(1);\
     }while(0)
@@ -1094,17 +1094,17 @@ extern struct Buf *buf_strappend(struct Buf *, const char *str);
 extern struct Buf *buf_strnappend(struct Buf *, const char *str, int nchars);
 extern struct Buf *buf_prints(struct Buf *buf, const char *fmt, const char* s);
 
-extern struct Buf userdef_buf; /* a string buffer for #define's generated by user-options on cmd line. */
-extern struct Buf top_buf;     /* contains %top code. String buffer. */
+//extern struct Buf userdef_buf; /* a string buffer for #define's generated by user-options on cmd line. */
+//extern struct Buf top_buf;     /* contains %top code. String buffer. */
 
 /* For blocking out code from the header file. */
 #define OUT_BEGIN_CODE() outn("m4_ifdef( [[M4_YY_IN_HEADER]],,[[m4_dnl")
 #define OUT_END_CODE()   outn("]])")
 
 /* For setjmp/longjmp (instead of calling exit(2)). Linkage in main.c */
-extern jmp_buf flex_main_jmp_buf;
+//extern jmp_buf flex_main_jmp_buf;
 
-#define FLEX_EXIT(status) longjmp(flex_main_jmp_buf,(status)+1)
+#define FLEX_EXIT(status) longjmp(gv->flex_main_jmp_buf,(status)+1)
 
 /* Removes all \n and \r chars from tail of str. returns str. */
 extern char *chomp (char *str);
@@ -1150,7 +1150,7 @@ struct filter {
 };
 
 /* output filter chain */
-extern struct filter * output_chain;
+//extern struct filter * output_chain;
 extern struct filter *filter_create_ext (struct filter * chain, const char *cmd, ...);
 struct filter *filter_create_int(struct filter *chain,
 				  int (*filter_func) (struct filter *),
@@ -1165,7 +1165,7 @@ extern int filter_fix_linedirs(struct filter *chain);
  * From "regex.c"
  */
 
-extern regex_t regex_linedir;
+//extern regex_t regex_linedir;
 bool flex_init_regex(const char *);
 void flex_regcomp(regex_t *preg, const char *regex, int cflags);
 char   *regmatch_dup (regmatch_t * m, const char *src);
@@ -1176,12 +1176,12 @@ bool regmatch_empty (regmatch_t * m);
 
 /* From "scanflags.h" */
 typedef unsigned int scanflags_t;
-extern scanflags_t* _sf_stk;
-extern size_t _sf_top_ix, _sf_max; /**< stack of scanner flags. */
+//extern scanflags_t* _sf_stk;
+//extern size_t _sf_top_ix, _sf_max; /**< stack of scanner flags. */
 #define _SF_CASE_INS   ((scanflags_t) 0x0001)
 #define _SF_DOT_ALL    ((scanflags_t) 0x0002)
 #define _SF_SKIP_WS    ((scanflags_t) 0x0004)
-#define sf_top()           (_sf_stk[_sf_top_ix])
+#define sf_top()           (gv->_sf_stk[gv->_sf_top_ix])
 #define sf_case_ins()      (sf_top() & _SF_CASE_INS)
 #define sf_dot_all()       (sf_top() & _SF_DOT_ALL)
 #define sf_skip_ws()       (sf_top() & _SF_SKIP_WS)
@@ -1192,5 +1192,172 @@ extern void sf_init(void);
 extern void sf_push(void);
 extern void sf_pop(void);
 
+//From sym.c
+/* Variables for symbol tables:
+ * sctbl - start-condition symbol table
+ * ndtbl - name-definition symbol table
+ * ccltab - character class text symbol table
+ */
+
+struct hash_entry {
+	struct hash_entry *next;
+	char   *name;
+	char   *str_val;
+	int     int_val;
+};
+
+typedef struct hash_entry **hash_table;
+
+#define NAME_TABLE_HASH_SIZE 101
+#define START_COND_HASH_SIZE 101
+#define CCL_HASH_SIZE 101
+
+#include "tables.h"
+typedef struct {
+    /* these globals are all defined and commented in flexdef.h */
+    bool    syntaxerror, eofseen;
+    int     yymore_used, reject, real_reject, continued_action, in_rule;
+    int     datapos, dataline, linenum;
+    FILE   *skelfile;
+    int     skel_ind;
+    char   *action_array;
+    int     action_size, defs1_offset, prolog_offset, action_offset,
+            action_index;
+    char   *infilename;
+    char   *extra_type;
+    int     onestate[ONE_STACK_SIZE], onesym[ONE_STACK_SIZE];
+    int     onenext[ONE_STACK_SIZE], onedef[ONE_STACK_SIZE], onesp;
+    int     maximum_mns, current_mns, current_max_rules;
+    int     num_rules, num_eof_rules, default_rule, lastnfa;
+    int    *firstst, *lastst, *finalst, *transchar, *trans1, *trans2;
+    int    *accptnum, *assoc_rule, *state_type;
+    int    *rule_type, *rule_linenum;
+    int     current_state_type;
+    bool    variable_trailing_context_rules;
+    int     numtemps, numprots, protprev[MSP], protnext[MSP], prottbl[MSP];
+    int     protcomst[MSP], firstprot, lastprot, protsave[PROT_SAVE_SIZE];
+    int     numecs, nextecm[CSIZE + 1], ecgroup[CSIZE + 1], nummecs,
+            tecfwd[CSIZE + 1];
+    int     tecbck[CSIZE + 1];
+    int     lastsc, *scset, *scbol;
+    /* scxclu[] and sceof[] are boolean arrays, but allocated as char
+     * arrays for size. */
+    char   *scxclu, *sceof;
+    int     current_max_scs;
+    const char **scname;
+    int     current_max_dfa_size, current_max_xpairs;
+    int     current_max_template_xpairs, current_max_dfas;
+    int     lastdfa, *nxt, *chk, *tnxt;
+    int    *base, *def, *nultrans, NUL_ec, tblend, firstfree, **dss, *dfasiz;
+    union dfaacc_union {
+        int    *dfaacc_set;
+        int     dfaacc_state;
+    } *dfaacc;
+    int    *accsiz, *dhash, numas;
+    int     numsnpairs, jambase, jamstate;
+    int     lastccl, *cclmap, *ccllen, *cclng, cclreuse;
+    int     current_maxccls, current_max_ccl_tbl_size;
+    unsigned char   *ccltbl;
+    char    nmstr[MAXLINE];
+    int     sectnum, nummt, hshcol, dfaeql, numeps, eps2, num_reallocs, nmval;
+    int     tmpuses, totnst, peakpairs, numuniq, numdup, hshsave;
+    int     num_backing_up, bol_needed;
+    int     end_of_buffer_state;
+    char  **input_files;
+    int     num_input_files;
+    jmp_buf flex_main_jmp_buf;
+    /* rule_useful[], rule_has_nl[] and ccl_has_nl[] are boolean arrays,
+     * but allocated as char arrays for size. */
+    char   *rule_useful, *rule_has_nl, *ccl_has_nl;
+    int     nlch;
+
+    bool    tablesext, tablesverify, gentables;
+    char   *tablesfilename,*tablesname;
+    struct yytbl_writer tableswr;
+    size_t footprint;
+
+    struct ctrl_bundle_t ctrl;
+    struct env_bundle_t env;
+
+    /* Make sure program_name is initialized so we don't crash if writing
+     * out an error message before getting the program name from argv[0].
+     */
+    char   *program_name;
+
+    struct Buf userdef_buf; /* a string buffer for #define's generated by user-options on cmd line. */
+    struct Buf top_buf;     /* contains %top code. String buffer. */
+
+    struct filter * output_chain;
+
+    regex_t regex_linedir;
+
+    scanflags_t* _sf_stk;
+    size_t _sf_top_ix, _sf_max; /**< stack of scanner flags. */
+
+    /*static*/ struct hash_entry *ndtbl[NAME_TABLE_HASH_SIZE];
+    /*static*/ struct hash_entry *sctbl[START_COND_HASH_SIZE];
+    /*static*/ struct hash_entry *ccltab[CCL_HASH_SIZE];
+
+    //from scan.l
+    /*static*/ int bracelevel, didadef, indented_code;
+    /*static*/ bool doing_rule_action;
+    /*static*/ bool option_sense;
+
+    /*static*/ bool doing_codeblock;
+    int brace_depth, brace_start_line;
+    char nmdef[MAXLINE];
+
+    //from dfa.c
+    /*static*/ int did_stk_init, *stk;
+
+    //from ecs.c
+    /*static*/ unsigned char cclflags[CSIZE];	/* initialized to all '\0' */
+
+    //from sym.c
+    /*static*/ struct hash_entry empty_entry;
+
+    //from yylex.c
+    /*static*/ int beglin;
+
+    //from misc.c
+    /*static*/ char rform[20];
+
+    //from parse.y
+    int pat, scnum, eps, headcnt, trailcnt, lastchar, i_parse, rulelen;
+    /*static*/ int currccl;
+    bool trlcontxt;
+    /*static*/ bool sc_is_exclusive, cclsorted, varlength, variable_trail_rule;
+    int *scon_stk;
+    int scon_stk_ptr;
+
+    /*static*/ int madeany;  /* whether we've made the '.' character class */
+    /*static*/ int ccldot, cclany;
+    int previous_continued_action;	/* whether the previous rule's action was '|' */
+
+    //from skeletons.c
+    /*static*/ char sk_name[256], sk_value[256], *sk_np, *sk_vp;
+
+    //from gen.c
+    /*static*/ struct packtype_t pack_out;
+
+    //from main.c
+    /*static*/ int called_before;	/* prevent infinite recursion. */
+    /*static*/ const char *outfile_template; //[] = "lex.%s.%s";
+    /*static*/ const char *backing_name; // = "lex.backup";
+    /*static*/ const char *tablesfile_template; //[] = "lex.%s.tables";
+
+    /*static*/ char outfile_path[MAXLINE];
+    /*static*/ int outfile_created;
+    /*static*/ int _stdout_closed; /* flag to prevent double-fclose() on stdout. */
+    const char *escaped_qstart; // = "]]M4_YY_NOOP[M4_YY_NOOP[M4_YY_NOOP[[";
+    const char *escaped_qend; //   = "]]M4_YY_NOOP]M4_YY_NOOP]M4_YY_NOOP[[";
+
+    /* For debugging. The max number of filters to apply to skeleton. */
+    /*static*/ int preproc_level;
+
+} FlexState;
+
+extern FlexState *gv;
+void initFlexState(FlexState *fgv);
 
 #endif /* not defined FLEXDEF_H */

--- a/src/flexdef.h
+++ b/src/flexdef.h
@@ -1032,8 +1032,10 @@ const char *suffix (FlexState* gv);
 /* Mine a text-valued property out of the skeleton file */
 extern const char *skel_property(FlexState* gv, const char *);
 
+extern void init_default_backend(FlexState *gv);
+
 /* Is the default back end selected?*/
-extern bool is_default_backend(void);
+extern bool is_default_backend(FlexState* gv);
 
 /* Select a backend by name */
 extern void backend_by_name(FlexState* gv, const char *);
@@ -1215,6 +1217,15 @@ typedef struct hash_entry **hash_table;
 #define START_COND_HASH_SIZE 101
 #define CCL_HASH_SIZE 101
 
+/* Method table describing a language-specific back end.
+ * Even if this never gets a member other than the skel
+ * array, it prevents us from getting lost in a maze of
+ * twisty array reference levels, all different.
+ */
+struct flex_backend_t {
+	const char **skel;		// Digested skeleton file
+};
+
 #include "tables.h"
 typedef struct FlexState {
     /* these globals are all defined and commented in flexdef.h */
@@ -1365,6 +1376,9 @@ typedef struct FlexState {
     /*static*/ int preproc_level;
 
     yyscan_t scanner;
+
+    //from skeletons.c
+    /*static*/ struct flex_backend_t *backend;
 
 } FlexState;
 

--- a/src/flexdef.h
+++ b/src/flexdef.h
@@ -309,6 +309,8 @@
  */
 #define BAD_SUBSCRIPT -32767
 
+typedef struct FlexState FlexState;
+
 typedef enum trit_t {
 	trit_unspecified = -1,
 	trit_false = 0,
@@ -718,38 +720,38 @@ struct packtype_t {
 //extern int tmpuses, totnst, peakpairs, numuniq, numdup, hshsave;
 //extern int num_backing_up, bol_needed;
 
-void   *allocate_array(int, size_t);
-void   *reallocate_array(void *, int, size_t);
+void   *allocate_array(FlexState* gv, int, size_t);
+void   *reallocate_array(FlexState* gv, void *, int, size_t);
 
 #define allocate_integer_array(size) \
-	allocate_array(size, sizeof(int))
+	allocate_array(gv, size, sizeof(int))
 
 #define reallocate_integer_array(array,size) \
-	reallocate_array((void *) array, size, sizeof(int))
+	reallocate_array(gv, (void *) array, size, sizeof(int))
 
 #define allocate_int_ptr_array(size) \
-	allocate_array(size, sizeof(int *))
+	allocate_array(gv, size, sizeof(int *))
 
 #define allocate_char_ptr_array(size) \
-	allocate_array(size, sizeof(char *))
+	allocate_array(gv, size, sizeof(char *))
 
 #define reallocate_int_ptr_array(array,size) \
-	reallocate_array((void *) array, size, sizeof(int *))
+	reallocate_array(gv, (void *) array, size, sizeof(int *))
 
 #define reallocate_char_ptr_array(array,size) \
-	reallocate_array((void *) array, size, sizeof(char *))
+	reallocate_array(gv, (void *) array, size, sizeof(char *))
 
 #define allocate_character_array(size) \
-	allocate_array( size, sizeof(char))
+	allocate_array(gv, size, sizeof(char))
 
 #define reallocate_character_array(array,size) \
-	reallocate_array((void *) array, size, sizeof(char))
+	reallocate_array(gv, (void *) array, size, sizeof(char))
 
 #define allocate_Character_array(size) \
-	allocate_array(size, sizeof(unsigned char))
+	allocate_array(gv, size, sizeof(unsigned char))
 
 #define reallocate_Character_array(array,size) \
-	reallocate_array((void *) array, size, sizeof(unsigned char))
+	reallocate_array(gv, (void *) array, size, sizeof(unsigned char))
 
 
 /* External functions that are cross-referenced among the flex source files. */
@@ -757,34 +759,34 @@ void   *reallocate_array(void *, int, size_t);
 
 /* from file ccl.c */
 
-extern void ccladd(int, int);	/* add a single character to a ccl */
-extern int cclinit(void);	/* make an empty ccl */
-extern void cclnegate(int);	/* negate a ccl */
-extern int ccl_set_diff (int a, int b); /* set difference of two ccls. */
-extern int ccl_set_union (int a, int b); /* set union of two ccls. */
+extern void ccladd(FlexState* gv, int, int);	/* add a single character to a ccl */
+extern int cclinit(FlexState* gv);	/* make an empty ccl */
+extern void cclnegate(FlexState* gv, int);	/* negate a ccl */
+extern int ccl_set_diff (FlexState* gv, int a, int b); /* set difference of two ccls. */
+extern int ccl_set_union (FlexState* gv, int a, int b); /* set union of two ccls. */
 
 /* List the members of a set of characters in CCL form. */
-extern void list_character_set(FILE *, int[]);
+extern void list_character_set(FlexState* gv, FILE *, int[]);
 
 
 /* from file dfa.c */
 
 /* Increase the maximum number of dfas. */
-extern void increase_max_dfas(void);
+extern void increase_max_dfas(FlexState* gv);
 
-extern size_t ntod(void);	/* convert a ndfa to a dfa */
+extern size_t ntod(FlexState* gv);	/* convert a ndfa to a dfa */
 
 
 /* from file ecs.c */
 
 /* Convert character classes to set of equivalence classes. */
-extern void ccl2ecl(void);
+extern void ccl2ecl(FlexState* gv);
 
 /* Associate equivalence class numbers with class members. */
 extern int cre8ecs(int[], int[], int);
 
 /* Update equivalence classes based on character class transitions. */
-extern void mkeccl(unsigned char[], int, int[], int[], int, int);
+extern void mkeccl(FlexState* gv, unsigned char[], int, int[], int[], int, int);
 
 /* Create equivalence class for single character. */
 extern void mkechar(int, int[], int[]);
@@ -802,22 +804,22 @@ extern void visible_define_str (const char *, const char *);
 extern void visible_define_int (const char *, const int);
 
 /* generate transition tables */
-extern void make_tables(void);
+extern void make_tables(FlexState* gv);
 
 /* Select a type for optimal packing */
-struct packtype_t *optimize_pack(size_t);
+struct packtype_t *optimize_pack(FlexState* gv, size_t);
 
 /* from file main.c */
 
-extern void check_options(void);
-extern void flexend(int);
-extern void usage(void);
+extern void check_options(FlexState* gv);
+extern void flexend(FlexState* gv, int);
+extern void usage(FlexState* gv);
 
 
 /* from file misc.c */
 
 /* Add the given text to the stored actions. */
-extern void add_action(const char *new_text);
+extern void add_action(FlexState* gv, const char *new_text);
 
 /* True if a string is all lower case. */
 extern int all_lower(char *);
@@ -829,28 +831,28 @@ extern int all_upper(char *);
 extern int intcmp(const void *, const void *);
 
 /* Check a character to make sure it's in the expected range. */
-extern void check_char(int c);
+extern void check_char(FlexState* gv, int c);
 
 /* Replace upper-case letter to lower-case. */
 extern unsigned char clower(int);
 
 /* strdup() that fails fatally on allocation failures. */
-extern char *xstrdup(const char *);
+extern char *xstrdup(FlexState* gv, const char *);
 
 /* Compare two characters for use by qsort with '\0' sorting last. */
 extern int cclcmp(const void *, const void *);
 
 /* Finish up a block of data declarations. */
-extern void dataend(const char *);
+extern void dataend(FlexState* gv, const char *);
 
 /* Flush generated data statements. */
-extern void dataflush(void);
+extern void dataflush(FlexState* gv);
 
 /* Report an error message and terminate. */
-extern void flexerror(const char *);
+extern void flexerror(FlexState* gv, const char *);
 
 /* Report a fatal error message and terminate. */
-extern void flexfatal(const char *);
+extern void flexfatal(FlexState* gv, const char *);
 
 /* Report a fatal error with a pinpoint, and terminate */
 #ifdef HAVE_DECL___FUNC__
@@ -874,34 +876,34 @@ extern void flexfatal(const char *);
 #endif /* ! HAVE_DECL___func__ */
 
 /* Report an error message formatted  */
-extern void lerr(const char *, ...)
+extern void lerr(FlexState* gv, const char *, ...)
 #if defined(__GNUC__) && __GNUC__ >= 3
-    __attribute__((__format__(__printf__, 1, 2)))
+    __attribute__((__format__(__printf__, 2, 3)))
 #endif
 ;
 
 /* Like lerr, but also exit after displaying message. */
-extern void lerr_fatal(const char *, ...)
+extern void lerr_fatal(FlexState* gv, const char *, ...)
 #if defined(__GNUC__) && __GNUC__ >= 3
-    __attribute__((__format__(__printf__, 1, 2)))
+    __attribute__((__format__(__printf__, 2, 3)))
 #endif
 ;
 
 /* Spit out a "#line" statement. */
-extern void line_directive_out(FILE *, char *, int);
+extern void line_directive_out(FlexState* gv, FILE *, char *, int);
 
 /* Mark the current position in the action array as the end of the section 1
  * user defs.
  */
-extern void mark_defs1(void);
+extern void mark_defs1(FlexState* gv);
 
 /* Mark the current position in the action array as the end of the prolog. */
-extern void mark_prolog(void);
+extern void mark_prolog(FlexState* gv);
 
 /* Generate a data statement for a two-dimensional array. */
-extern void mk2data(int);
+extern void mk2data(FlexState* gv, int);
 
-extern void mkdata(int);	/* generate a data statement */
+extern void mkdata(FlexState* gv, int);	/* generate a data statement */
 
 /* Return the integer represented by a string of digits. */
 extern int myctoi(const char *);
@@ -923,81 +925,93 @@ extern void out_m4_define(const char* def, const char* val);
 /* Return a printable version of the given character, which might be
  * 8-bit.
  */
-extern char *readable_form(int);
+extern char *readable_form(FlexState* gv, int);
 
 /* Output a yy_trans_info structure. */
-extern void transition_struct_out(int, int);
+extern void transition_struct_out(FlexState* gv, int, int);
 
 /* Only needed when using certain broken versions of bison to build parse.c. */
-extern void *yy_flex_xmalloc(int);
+extern void *yy_flex_xmalloc(FlexState* gv, int);
 
 
 /* from file nfa.c */
 
 /* Add an accepting state to a machine. */
-extern void add_accept(int, int);
+extern void add_accept(FlexState* gv, int, int);
 
 /* Make a given number of copies of a singleton machine. */
-extern int copysingl(int, int);
+extern int copysingl(FlexState* gv, int, int);
 
 /* Debugging routine to write out an nfa. */
-extern void dumpnfa(int);
+extern void dumpnfa(FlexState* gv, int);
 
 /* Finish up the processing for a rule. */
-extern void finish_rule(int, bool, int, int, int);
+extern void finish_rule(FlexState* gv, int, bool, int, int, int);
 
 /* Connect two machines together. */
-extern int link_machines(int, int);
+extern int link_machines(FlexState* gv, int, int);
 
 /* Mark each "beginning" state in a machine as being a "normal" (i.e.,
  * not trailing context associated) state.
  */
-extern void mark_beginning_as_normal(int);
+extern void mark_beginning_as_normal(FlexState* gv, int);
 
 /* Make a machine that branches to two machines. */
-extern int mkbranch(int, int);
+extern int mkbranch(FlexState* gv, int, int);
 
-extern int mkclos(int);	/* convert a machine into a closure */
-extern int mkopt(int);	/* make a machine optional */
+extern int mkclos(FlexState* gv, int);	/* convert a machine into a closure */
+extern int mkopt(FlexState* gv, int);	/* make a machine optional */
 
 /* Make a machine that matches either one of two machines. */
-extern int mkor(int, int);
+extern int mkor(FlexState* gv, int, int);
 
 /* Convert a machine into a positive closure. */
-extern int mkposcl(int);
+extern int mkposcl(FlexState* gv, int);
 
-extern int mkrep(int, int, int);	/* make a replicated machine */
+extern int mkrep(FlexState* gv, int, int, int);	/* make a replicated machine */
 
 /* Create a state with a transition on a given symbol. */
-extern int mkstate(int);
+extern int mkstate(FlexState* gv, int);
 
-extern void new_rule(void);	/* initialize for a new rule */
+extern void new_rule(FlexState* gv);	/* initialize for a new rule */
 
 
 /* from file parse.y */
 
 /* Build the "<<EOF>>" action for the active start conditions. */
-extern void build_eof_action(void);
+extern void build_eof_action(FlexState* gv);
 
 /* Write out a message formatted with one string, pinpointing its location. */
-extern void format_pinpoint_message(const char *, const char *);
+extern void format_pinpoint_message(FlexState* gv, const char *, const char *);
 
 /* Write out a message, pinpointing its location. */
-extern void pinpoint_message(const char *);
+extern void pinpoint_message(FlexState* gv, const char *);
 
 /* Write out a warning, pinpointing it at the given line. */
-extern void line_warning(const char *, int);
+extern void line_warning(FlexState* gv, const char *, int);
 
 /* Write out a message, pinpointing it at the given line. */
-extern void line_pinpoint(const char *, int);
+extern void line_pinpoint(FlexState* gv, const char *, int);
+
+/* from file yylex.c */
+
+typedef void* yyscan_t;
+typedef int YYSTYPE;
+extern int yylex_init(yyscan_t *yyscanner);
+extern int yylex_destroy  (yyscan_t yyscanner);
+extern void yyset_out (FILE *  _out_str , yyscan_t yyscanner);
+extern char *yyget_text  (yyscan_t yyscanner);
+extern int yylex(YYSTYPE * yylval_param, yyscan_t yyscanner);
+extern void yyset_extra (FlexState* gv , yyscan_t yyscanner);
+extern FlexState* yyget_extra  (yyscan_t yyscanner);
 
 /* Report a formatted syntax error. */
-extern void format_synerr(const char *, const char *);
-extern void synerr(const char *);	/* report a syntax error */
-extern void format_warn(const char *, const char *);
-extern void lwarn(const char *);	/* report a warning */
-extern void yyerror(const char *);	/* report a parse error */
-extern int yyparse(void);		/* the YACC parser */
+extern void format_synerr(FlexState* gv, const char *, const char *);
+extern void synerr(FlexState* gv, const char *);	/* report a syntax error */
+extern void format_warn(FlexState* gv, const char *, const char *);
+extern void lwarn(FlexState* gv, const char *);	/* report a warning */
+extern void yyerror(yyscan_t yyscanner, const char *);	/* report a parse error */
+extern int yyparse(yyscan_t yyscanner, FlexState* gv);		/* the YACC parser */
 
 /* Ship a comment to the generated output */
 extern void comment(const char *);
@@ -1005,79 +1019,75 @@ extern void comment(const char *);
 /* from file scan.l */
 
 /* The Flex-generated scanner for flex. */
-extern int flexscan(void);
+extern int flexscan(YYSTYPE * yylval_param, yyscan_t yyscanner);
 
 /* Open the given file (if NULL, stdin) for scanning. */
-extern void set_input_file(char *);
+extern void set_input_file(yyscan_t yyscanner, char *);
 
 /* from file skeletons.c */
 
 /* return the correct file suffix for the selected back end */
-const char *suffix (void);
+const char *suffix (FlexState* gv);
 
 /* Mine a text-valued property out of the skeleton file */
-extern const char *skel_property(const char *);
+extern const char *skel_property(FlexState* gv, const char *);
 
 /* Is the default back end selected?*/
 extern bool is_default_backend(void);
 
 /* Select a backend by name */
-extern void backend_by_name(const char *);
+extern void backend_by_name(FlexState* gv, const char *);
 
 /* Write out one section of the skeleton file. */
-extern void skelout(bool);
+extern void skelout(FlexState* gv, bool);
 
 /* from file sym.c */
 
 /* Save the text of a character class. */
-extern void cclinstal(char[], int);
+extern void cclinstal(FlexState* gv, char[], int);
 
 /* Lookup the number associated with character class. */
-extern int ccllookup(char[]);
+extern int ccllookup(FlexState* gv, char[]);
 
-extern void ndinstal(const char *, char[]);	/* install a name definition */
-extern char *ndlookup(const char *);	/* lookup a name definition */
+extern void ndinstal(FlexState* gv, const char *, char[]);	/* install a name definition */
+extern char *ndlookup(FlexState* gv, const char *);	/* lookup a name definition */
 
 /* Increase maximum number of SC's. */
-extern void scextend(void);
-extern void scinstal(const char *, bool);	/* make a start condition */
+extern void scextend(FlexState* gv);
+extern void scinstal(FlexState* gv, const char *, bool);	/* make a start condition */
 
 /* Lookup the number associated with a start condition. */
-extern int sclookup(const char *);
+extern int sclookup(FlexState* gv, const char *);
 
 /* Supply context argument for a function if required */
-extern void context_call(char *);
+extern void context_call(FlexState* gv, char *);
 
 /* from file tblcmp.c */
 
 /* Build table entries for dfa state. */
-extern void bldtbl(int[], int, int, int, int);
+extern void bldtbl(FlexState* gv, int[], int, int, int, int);
 
-extern void cmptmps(void);	/* compress template table entries */
-extern void expand_nxt_chk(void);	/* increase nxt/chk arrays */
+extern void cmptmps(FlexState* gv);	/* compress template table entries */
+extern void expand_nxt_chk(FlexState* gv);	/* increase nxt/chk arrays */
 
 /* Finds a space in the table for a state to be placed. */
-extern int find_table_space(int *, int);
-extern void inittbl(void);	/* initialize transition tables */
+extern int find_table_space(FlexState* gv, int *, int);
+extern void inittbl(FlexState* gv);	/* initialize transition tables */
 
 /* Make the default, "jam" table entries. */
-extern void mkdeftbl(void);
+extern void mkdeftbl(FlexState* gv);
 
 /* Create table entries for a state (or state fragment) which has
  * only one out-transition.
  */
-extern void mk1tbl(int, int, int, int);
+extern void mk1tbl(FlexState* gv, int, int, int, int);
 
 /* Place a state into full speed transition table. */
-extern void place_state(int *, int, int);
+extern void place_state(FlexState* gv, int *, int, int);
 
 /* Save states with only one out-transition to be processed later. */
-extern void stack1(int, int, int, int);
+extern void stack1(FlexState* gv, int, int, int, int);
 
-
-/* from file yylex.c */
-
-extern int yylex(void);
 
 /* A growable array. See buf.c. */
 struct Buf {
@@ -1089,13 +1099,10 @@ struct Buf {
 
 extern void buf_init(struct Buf * buf, size_t elem_size);
 extern void buf_destroy(struct Buf * buf);
-extern struct Buf *buf_append(struct Buf * buf, const void *ptr, int n_elem);
-extern struct Buf *buf_strappend(struct Buf *, const char *str);
-extern struct Buf *buf_strnappend(struct Buf *, const char *str, int nchars);
-extern struct Buf *buf_prints(struct Buf *buf, const char *fmt, const char* s);
-
-//extern struct Buf userdef_buf; /* a string buffer for #define's generated by user-options on cmd line. */
-//extern struct Buf top_buf;     /* contains %top code. String buffer. */
+extern struct Buf *buf_append(FlexState* gv, struct Buf * buf, const void *ptr, int n_elem);
+extern struct Buf *buf_strappend(FlexState* gv, struct Buf *, const char *str);
+extern struct Buf *buf_strnappend(FlexState* gv, struct Buf *, const char *str, int nchars);
+extern struct Buf *buf_prints(FlexState* gv, struct Buf *buf, const char *fmt, const char* s);
 
 /* For blocking out code from the header file. */
 #define OUT_BEGIN_CODE() outn("m4_ifdef( [[M4_YY_IN_HEADER]],,[[m4_dnl")
@@ -1142,7 +1149,7 @@ bool range_covers_case (int c1, int c2);
  *  may be internal, as a function call.
  */
 struct filter {
-    int    (*filter_func)(struct filter*); /**< internal filter function */
+    int    (*filter_func)(FlexState* gv, struct filter*); /**< internal filter function */
     void * extra;         /**< extra data passed to filter_func */
 	int     argc;         /**< arg count */
 	const char ** argv;   /**< arg vector, \0-terminated */
@@ -1150,34 +1157,30 @@ struct filter {
 };
 
 /* output filter chain */
-//extern struct filter * output_chain;
-extern struct filter *filter_create_ext (struct filter * chain, const char *cmd, ...);
-struct filter *filter_create_int(struct filter *chain,
-				  int (*filter_func) (struct filter *),
+extern struct filter *filter_create_ext (FlexState* gv, struct filter * chain, const char *cmd, ...);
+struct filter *filter_create_int(FlexState* gv, struct filter *chain,
+				  int (*filter_func) (FlexState* gv, struct filter *),
                   void *extra);
-extern bool filter_apply_chain(struct filter * chain);
+extern bool filter_apply_chain(FlexState* gv, struct filter * chain);
 extern int filter_truncate(struct filter * chain, int max_len);
-extern int filter_tee_header(struct filter *chain);
-extern int filter_fix_linedirs(struct filter *chain);
+extern int filter_tee_header(FlexState* gv, struct filter *chain);
+extern int filter_fix_linedirs(FlexState* gv, struct filter *chain);
 
 
 /*
  * From "regex.c"
  */
 
-//extern regex_t regex_linedir;
-bool flex_init_regex(const char *);
-void flex_regcomp(regex_t *preg, const char *regex, int cflags);
-char   *regmatch_dup (regmatch_t * m, const char *src);
+bool flex_init_regex(FlexState* gv, const char *);
+void flex_regcomp(FlexState* gv, regex_t *preg, const char *regex, int cflags);
+char   *regmatch_dup (FlexState* gv, regmatch_t * m, const char *src);
 char   *regmatch_cpy (regmatch_t * m, char *dest, const char *src);
 int regmatch_len (regmatch_t * m);
-int regmatch_strtol (regmatch_t * m, const char *src, char **endptr, int base);
+int regmatch_strtol (FlexState* gv, regmatch_t * m, const char *src, char **endptr, int base);
 bool regmatch_empty (regmatch_t * m);
 
 /* From "scanflags.h" */
 typedef unsigned int scanflags_t;
-//extern scanflags_t* _sf_stk;
-//extern size_t _sf_top_ix, _sf_max; /**< stack of scanner flags. */
 #define _SF_CASE_INS   ((scanflags_t) 0x0001)
 #define _SF_DOT_ALL    ((scanflags_t) 0x0002)
 #define _SF_SKIP_WS    ((scanflags_t) 0x0004)
@@ -1188,9 +1191,9 @@ typedef unsigned int scanflags_t;
 #define sf_set_case_ins(X)      ((X) ? (sf_top() |= _SF_CASE_INS) : (sf_top() &= ~_SF_CASE_INS))
 #define sf_set_dot_all(X)       ((X) ? (sf_top() |= _SF_DOT_ALL)  : (sf_top() &= ~_SF_DOT_ALL))
 #define sf_set_skip_ws(X)       ((X) ? (sf_top() |= _SF_SKIP_WS)  : (sf_top() &= ~_SF_SKIP_WS))
-extern void sf_init(void);
-extern void sf_push(void);
-extern void sf_pop(void);
+extern void sf_init(FlexState* gv);
+extern void sf_push(FlexState* gv);
+extern void sf_pop(FlexState* gv);
 
 //From sym.c
 /* Variables for symbol tables:
@@ -1213,7 +1216,7 @@ typedef struct hash_entry **hash_table;
 #define CCL_HASH_SIZE 101
 
 #include "tables.h"
-typedef struct {
+typedef struct FlexState {
     /* these globals are all defined and commented in flexdef.h */
     bool    syntaxerror, eofseen;
     int     yymore_used, reject, real_reject, continued_action, in_rule;
@@ -1224,6 +1227,7 @@ typedef struct {
     int     action_size, defs1_offset, prolog_offset, action_offset,
             action_index;
     char   *infilename;
+    FILE   *fp_infilename;
     char   *extra_type;
     int     onestate[ONE_STACK_SIZE], onesym[ONE_STACK_SIZE];
     int     onenext[ONE_STACK_SIZE], onedef[ONE_STACK_SIZE], onesp;
@@ -1284,19 +1288,24 @@ typedef struct {
      */
     char   *program_name;
 
-    struct Buf userdef_buf; /* a string buffer for #define's generated by user-options on cmd line. */
-    struct Buf top_buf;     /* contains %top code. String buffer. */
-
-    struct filter * output_chain;
-
-    regex_t regex_linedir;
-
-    scanflags_t* _sf_stk;
-    size_t _sf_top_ix, _sf_max; /**< stack of scanner flags. */
-
     /*static*/ struct hash_entry *ndtbl[NAME_TABLE_HASH_SIZE];
     /*static*/ struct hash_entry *sctbl[START_COND_HASH_SIZE];
     /*static*/ struct hash_entry *ccltab[CCL_HASH_SIZE];
+
+    //from scanflags.c
+    scanflags_t* _sf_stk;
+    size_t _sf_top_ix, _sf_max; /**< stack of scanner flags. */
+
+    //from regex.c
+    regex_t regex_linedir;
+
+    //from filter.c
+    struct filter * output_chain;
+
+    //from buf.c
+    struct Buf userdef_buf; /* a string buffer for #define's generated by user-options on cmd line. */
+    struct Buf top_buf;     /* contains %top code. String buffer. */
+
 
     //from scan.l
     /*static*/ int bracelevel, didadef, indented_code;
@@ -1355,9 +1364,11 @@ typedef struct {
     /* For debugging. The max number of filters to apply to skeleton. */
     /*static*/ int preproc_level;
 
+    yyscan_t scanner;
+
 } FlexState;
 
-extern FlexState *gv;
+//extern FlexState *gv;
 void initFlexState(FlexState *fgv);
 
 #endif /* not defined FLEXDEF_H */

--- a/src/gen.c
+++ b/src/gen.c
@@ -48,15 +48,15 @@ static void genecs(void);
 struct packtype_t *optimize_pack(size_t sz)
 {
 	/* FIXME: There's a 32-bit assumption lurking here */
-	static struct packtype_t out;
+	//static struct packtype_t out;
 	if (sz == 0) {
-		out.name  = ctrl.long_align ? "M4_HOOK_INT32" : "M4_HOOK_INT16";
-		out.width = ctrl.long_align ? 32 : 16;
+		gv->pack_out.name  = gv->ctrl.long_align ? "M4_HOOK_INT32" : "M4_HOOK_INT16";
+		gv->pack_out.width = gv->ctrl.long_align ? 32 : 16;
 	} else {
-		out.name = (ctrl.long_align || sz >= INT16_MAX) ? "M4_HOOK_INT32" : "M4_HOOK_INT16";
-		out.width = (ctrl.long_align || sz >= INT16_MAX) ? 32 : 16;
+		gv->pack_out.name = (gv->ctrl.long_align || sz >= INT16_MAX) ? "M4_HOOK_INT32" : "M4_HOOK_INT16";
+		gv->pack_out.width = (gv->ctrl.long_align || sz >= INT16_MAX) ? 32 : 16;
 	}
-	return &out;
+	return &gv->pack_out;
 }
 
 /* Almost everything is done in terms of arrays starting at 1, so provide
@@ -77,12 +77,12 @@ static struct yytbl_data *mkeoltbl (void)
 	tbl = calloc(1, sizeof (struct yytbl_data));
 	yytbl_data_init (tbl, YYTD_ID_RULE_CAN_MATCH_EOL);
 	tbl->td_flags = YYTD_DATA8;
-	tbl->td_lolen = (flex_uint32_t) (num_rules + 1);
+	tbl->td_lolen = (flex_uint32_t) (gv->num_rules + 1);
 	tbl->td_data = tdata =
 		calloc(tbl->td_lolen, sizeof (flex_int8_t));
 
-	for (i = 1; i <= num_rules; i++)
-		tdata[i] = rule_has_nl[i] ? 1 : 0;
+	for (i = 1; i <= gv->num_rules; i++)
+		tdata[i] = gv->rule_has_nl[i] ? 1 : 0;
 
 	return tbl;
 }
@@ -91,22 +91,22 @@ static struct yytbl_data *mkeoltbl (void)
 static void geneoltbl (void)
 {
 	int     i;
-	struct packtype_t *ptype = optimize_pack(num_rules);
+	struct packtype_t *ptype = optimize_pack(gv->num_rules);
 
 	outn ("m4_ifdef( [[M4_MODE_YYLINENO]],[[");
 	out_str ("m4_define([[M4_HOOK_EOLTABLE_TYPE]], [[%s]])\n", ptype->name);
-	out_dec ("m4_define([[M4_HOOK_EOLTABLE_SIZE]], [[%d]])", num_rules + 1);
+	out_dec ("m4_define([[M4_HOOK_EOLTABLE_SIZE]], [[%d]])", gv->num_rules + 1);
 	outn ("m4_define([[M4_HOOK_EOLTABLE_BODY]], [[m4_dnl");
 
-	if (gentables) {
-		for (i = 1; i <= num_rules; i++) {
-			out_dec ("%d, ", rule_has_nl[i] ? 1 : 0);
+	if (gv->gentables) {
+		for (i = 1; i <= gv->num_rules; i++) {
+			out_dec ("%d, ", gv->rule_has_nl[i] ? 1 : 0);
 			/* format nicely, 20 numbers per line. */
 			if ((i % 20) == 19)
 				out ("\n    ");
 		}
 	}
-	footprint += num_rules * ptype->width;
+	gv->footprint += gv->num_rules * ptype->width;
 	outn ("]])");
 	outn ("]])");
 }
@@ -124,16 +124,16 @@ static struct yytbl_data *mkctbl (void)
 	int i;
 	struct yytbl_data *tbl = 0;
 	flex_int32_t *tdata = 0, curr = 0;
-	int     end_of_buffer_action = num_rules + 1;
+	int     end_of_buffer_action = gv->num_rules + 1;
 
-	struct packtype_t *ptype = optimize_pack(tblend + 2 + 1);
+	struct packtype_t *ptype = optimize_pack(gv->tblend + 2 + 1);
 	out_str ("m4_define([[M4_HOOK_MKCTBL_TYPE]], [[%s]])", ptype->name);
 
 	tbl = calloc(1, sizeof (struct yytbl_data));
 	yytbl_data_init (tbl, YYTD_ID_TRANSITION);
 	tbl->td_flags = YYTD_DATA32 | YYTD_STRUCT;
 	tbl->td_hilen = 0;
-	tbl->td_lolen = (flex_uint32_t) (tblend + 2 + 1);	/* number of structs */
+	tbl->td_lolen = (flex_uint32_t) (gv->tblend + 2 + 1);	/* number of structs */
 
 	tbl->td_data = tdata =
 		calloc(tbl->td_lolen * 2, sizeof (flex_int32_t));
@@ -156,60 +156,60 @@ static struct yytbl_data *mkctbl (void)
 	 * there's room for jam entries for other characters.
 	 */
 
-	while (tblend + 2 >= current_max_xpairs)
+	while (gv->tblend + 2 >= gv->current_max_xpairs)
 		expand_nxt_chk ();
 
-	while (lastdfa + 1 >= current_max_dfas)
+	while (gv->lastdfa + 1 >= gv->current_max_dfas)
 		increase_max_dfas ();
 
-	base[lastdfa + 1] = tblend + 2;
-	nxt[tblend + 1] = end_of_buffer_action;
-	chk[tblend + 1] = numecs + 1;
-	chk[tblend + 2] = 1;	/* anything but EOB */
+	gv->base[gv->lastdfa + 1] = gv->tblend + 2;
+	gv->nxt[gv->tblend + 1] = end_of_buffer_action;
+	gv->chk[gv->tblend + 1] = gv->numecs + 1;
+	gv->chk[gv->tblend + 2] = 1;	/* anything but EOB */
 
 	/* So that "make test" won't show arb. differences. */
-	nxt[tblend + 2] = 0;
+	gv->nxt[gv->tblend + 2] = 0;
 
 	/* Make sure every state has an end-of-buffer transition and an
 	 * action #.
 	 */
-	for (i = 0; i <= lastdfa; ++i) {
-		int     anum = dfaacc[i].dfaacc_state;
-		int     offset = base[i];
+	for (i = 0; i <= gv->lastdfa; ++i) {
+		int     anum = gv->dfaacc[i].dfaacc_state;
+		int     offset = gv->base[i];
 
-		chk[offset] = EOB_POSITION;
-		chk[offset - 1] = ACTION_POSITION;
-		nxt[offset - 1] = anum;	/* action number */
+		gv->chk[offset] = EOB_POSITION;
+		gv->chk[offset - 1] = ACTION_POSITION;
+		gv->nxt[offset - 1] = anum;	/* action number */
 	}
 
-	for (i = 0; i <= tblend; ++i) {
-		if (chk[i] == EOB_POSITION) {
+	for (i = 0; i <= gv->tblend; ++i) {
+		if (gv->chk[i] == EOB_POSITION) {
 			tdata[curr++] = 0;
-			tdata[curr++] = base[lastdfa + 1] - i;
+			tdata[curr++] = gv->base[gv->lastdfa + 1] - i;
 		}
 
-		else if (chk[i] == ACTION_POSITION) {
+		else if (gv->chk[i] == ACTION_POSITION) {
 			tdata[curr++] = 0;
-			tdata[curr++] = nxt[i];
+			tdata[curr++] = gv->nxt[i];
 		}
 
-		else if (chk[i] > numecs || chk[i] == 0) {
+		else if (gv->chk[i] > gv->numecs || gv->chk[i] == 0) {
 			tdata[curr++] = 0;
 			tdata[curr++] = 0;
 		}
 		else {		/* verify, transition */
 
-			tdata[curr++] = chk[i];
-			tdata[curr++] = base[nxt[i]] - (i - chk[i]);
+			tdata[curr++] = gv->chk[i];
+			tdata[curr++] = gv->base[gv->nxt[i]] - (i - gv->chk[i]);
 		}
 	}
 
 	/* Here's the final, end-of-buffer state. */
-	tdata[curr++] = chk[tblend + 1];
-	tdata[curr++] = nxt[tblend + 1];
+	tdata[curr++] = gv->chk[gv->tblend + 1];
+	tdata[curr++] = gv->nxt[gv->tblend + 1];
 
-	tdata[curr++] = chk[tblend + 2];
-	tdata[curr++] = nxt[tblend + 2];
+	tdata[curr++] = gv->chk[gv->tblend + 2];
+	tdata[curr++] = gv->nxt[gv->tblend + 2];
 
 	return tbl;
 }
@@ -228,13 +228,13 @@ static struct yytbl_data *mkssltbl (void)
 	yytbl_data_init (tbl, YYTD_ID_START_STATE_LIST);
 	tbl->td_flags = YYTD_DATA32 | YYTD_PTRANS;
 	tbl->td_hilen = 0;
-	tbl->td_lolen = (flex_uint32_t) (lastsc * 2 + 1);
+	tbl->td_lolen = (flex_uint32_t) (gv->lastsc * 2 + 1);
 
 	tbl->td_data = tdata =
 		calloc(tbl->td_lolen, sizeof (flex_int32_t));
 
-	for (i = 0; i <= lastsc * 2; ++i)
-		tdata[i] = base[i];
+	for (i = 0; i <= gv->lastsc * 2; ++i)
+		tdata[i] = gv->base[i];
 
 	return tbl;
 }
@@ -246,10 +246,10 @@ static struct yytbl_data *mkssltbl (void)
 static void genctbl(void)
 {
 	int i;
-	int     end_of_buffer_action = num_rules + 1;
+	int     end_of_buffer_action = gv->num_rules + 1;
 
 	/* Table of verify for transition and offset to next state. */
-	out_dec ("m4_define([[M4_HOOK_TRANSTABLE_SIZE]], [[%d]])", tblend + 2 + 1);
+	out_dec ("m4_define([[M4_HOOK_TRANSTABLE_SIZE]], [[%d]])", gv->tblend + 2 + 1);
 	outn ("m4_define([[M4_HOOK_TRANSTABLE_BODY]], [[m4_dnl");
 
 	/* We want the transition to be represented as the offset to the
@@ -270,68 +270,68 @@ static void genctbl(void)
 	 * there's room for jam entries for other characters.
 	 */
 
-	while (tblend + 2 >= current_max_xpairs)
+	while (gv->tblend + 2 >= gv->current_max_xpairs)
 		expand_nxt_chk ();
 
-	while (lastdfa + 1 >= current_max_dfas)
+	while (gv->lastdfa + 1 >= gv->current_max_dfas)
 		increase_max_dfas ();
 
-	base[lastdfa + 1] = tblend + 2;
-	nxt[tblend + 1] = end_of_buffer_action;
-	chk[tblend + 1] = numecs + 1;
-	chk[tblend + 2] = 1;	/* anything but EOB */
+	gv->base[gv->lastdfa + 1] = gv->tblend + 2;
+	gv->nxt[gv->tblend + 1] = end_of_buffer_action;
+	gv->chk[gv->tblend + 1] = gv->numecs + 1;
+	gv->chk[gv->tblend + 2] = 1;	/* anything but EOB */
 
 	/* So that "make test" won't show arb. differences. */
-	nxt[tblend + 2] = 0;
+	gv->nxt[gv->tblend + 2] = 0;
 
 	/* Make sure every state has an end-of-buffer transition and an
 	 * action #.
 	 */
-	for (i = 0; i <= lastdfa; ++i) {
-		int     anum = dfaacc[i].dfaacc_state;
-		int     offset = base[i];
+	for (i = 0; i <= gv->lastdfa; ++i) {
+		int     anum = gv->dfaacc[i].dfaacc_state;
+		int     offset = gv->base[i];
 
-		chk[offset] = EOB_POSITION;
-		chk[offset - 1] = ACTION_POSITION;
-		nxt[offset - 1] = anum;	/* action number */
+		gv->chk[offset] = EOB_POSITION;
+		gv->chk[offset - 1] = ACTION_POSITION;
+		gv->nxt[offset - 1] = anum;	/* action number */
 	}
 
-	for (i = 0; i <= tblend; ++i) {
-		if (chk[i] == EOB_POSITION)
-			transition_struct_out (0, base[lastdfa + 1] - i);
+	for (i = 0; i <= gv->tblend; ++i) {
+		if (gv->chk[i] == EOB_POSITION)
+			transition_struct_out (0, gv->base[gv->lastdfa + 1] - i);
 
-		else if (chk[i] == ACTION_POSITION)
-			transition_struct_out (0, nxt[i]);
+		else if (gv->chk[i] == ACTION_POSITION)
+			transition_struct_out (0, gv->nxt[i]);
 
-		else if (chk[i] > numecs || chk[i] == 0)
+		else if (gv->chk[i] > gv->numecs || gv->chk[i] == 0)
 			transition_struct_out (0, 0);	/* unused slot */
 
 		else		/* verify, transition */
-			transition_struct_out (chk[i],
-					       base[nxt[i]] - (i -
-							       chk[i]));
+			transition_struct_out (gv->chk[i],
+					       gv->base[gv->nxt[i]] - (i -
+							       gv->chk[i]));
 	}
 
 
 	/* Here's the final, end-of-buffer state. */
-	transition_struct_out (chk[tblend + 1], nxt[tblend + 1]);
-	transition_struct_out (chk[tblend + 2], nxt[tblend + 2]);
+	transition_struct_out (gv->chk[gv->tblend + 1], gv->nxt[gv->tblend + 1]);
+	transition_struct_out (gv->chk[gv->tblend + 2], gv->nxt[gv->tblend + 2]);
 
 	outn ("]])");
-	footprint += sizeof(struct yy_trans_info) * (tblend + 2 + 1);
+	gv->footprint += sizeof(struct yy_trans_info) * (gv->tblend + 2 + 1);
 
-	out_dec ("m4_define([[M4_HOOK_STARTTABLE_SIZE]], [[%d]])", lastsc * 2 + 1);
-	if (gentables) {
+	out_dec ("m4_define([[M4_HOOK_STARTTABLE_SIZE]], [[%d]])", gv->lastsc * 2 + 1);
+	if (gv->gentables) {
 		outn ("m4_define([[M4_HOOK_STARTTABLE_BODY]], [[m4_dnl");
-		for (i = 0; i <= lastsc * 2; ++i)
-			out_dec ("M4_HOOK_STATE_ENTRY_FORMAT(%d)", base[i]);
+		for (i = 0; i <= gv->lastsc * 2; ++i)
+			out_dec ("M4_HOOK_STATE_ENTRY_FORMAT(%d)", gv->base[i]);
 
 		dataend (NULL);
 		outn("]])");
-		footprint +=  sizeof(struct yy_trans_info *) * (lastsc * 2 + 1);
+		gv->footprint +=  sizeof(struct yy_trans_info *) * (gv->lastsc * 2 + 1);
 	}
 
-	if (ctrl.useecs)
+	if (gv->ctrl.useecs)
 		genecs ();
 }
 
@@ -348,14 +348,14 @@ static struct yytbl_data *mkecstbl (void)
 	yytbl_data_init (tbl, YYTD_ID_EC);
 	tbl->td_flags |= YYTD_DATA32;
 	tbl->td_hilen = 0;
-	tbl->td_lolen = (flex_uint32_t) ctrl.csize;
+	tbl->td_lolen = (flex_uint32_t) gv->ctrl.csize;
 
 	tbl->td_data = tdata =
 		calloc(tbl->td_lolen, sizeof (flex_int32_t));
 
-	for (i = 1; i < ctrl.csize; ++i) {
-		ecgroup[i] = ABS (ecgroup[i]);
-		tdata[i] = ecgroup[i];
+	for (i = 1; i < gv->ctrl.csize; ++i) {
+		gv->ecgroup[i] = ABS (gv->ecgroup[i]);
+		tdata[i] = gv->ecgroup[i];
 	}
 
 	return tbl;
@@ -368,28 +368,28 @@ static void genecs(void)
 	int ch, row;
 	int     numrows;
 
-	out_dec ("m4_define([[M4_HOOK_ECSTABLE_SIZE]], [[%d]])", ctrl.csize);
+	out_dec ("m4_define([[M4_HOOK_ECSTABLE_SIZE]], [[%d]])", gv->ctrl.csize);
 	outn ("m4_define([[M4_HOOK_ECSTABLE_BODY]], [[m4_dnl");
 
-	for (ch = 1; ch < ctrl.csize; ++ch) {
-		ecgroup[ch] = ABS (ecgroup[ch]);
-		mkdata (ecgroup[ch]);
+	for (ch = 1; ch < gv->ctrl.csize; ++ch) {
+		gv->ecgroup[ch] = ABS (gv->ecgroup[ch]);
+		mkdata (gv->ecgroup[ch]);
 	}
 
 	dataend (NULL);
 	outn("]])");
-	footprint += sizeof(YY_CHAR) * ctrl.csize;
+	gv->footprint += sizeof(YY_CHAR) * gv->ctrl.csize;
 
-	if (env.trace) {
+	if (gv->env.trace) {
 		fputs (_("\n\nEquivalence Classes:\n\n"), stderr);
 
 		/* Print in 8 columns */
-		numrows = ctrl.csize / 8;
+		numrows = gv->ctrl.csize / 8;
 
 		for (row = 0; row < numrows; ++row) {
-			for (ch = row; ch < ctrl.csize; ch += numrows) {
+			for (ch = row; ch < gv->ctrl.csize; ch += numrows) {
 				fprintf (stderr, "%4s = %-2d",
-					 readable_form (ch), ecgroup[ch]);
+					 readable_form (ch), gv->ecgroup[ch]);
 
 				putc (' ', stderr);
 			}
@@ -406,7 +406,7 @@ static void genecs(void)
 static struct yytbl_data *mkftbl(void)
 {
 	int i;
-	int     end_of_buffer_action = num_rules + 1;
+	int     end_of_buffer_action = gv->num_rules + 1;
 	struct yytbl_data *tbl;
 	flex_int32_t *tdata = 0;
 
@@ -414,19 +414,19 @@ static struct yytbl_data *mkftbl(void)
 	yytbl_data_init (tbl, YYTD_ID_ACCEPT);
 	tbl->td_flags |= YYTD_DATA32;
 	tbl->td_hilen = 0;	/* it's a one-dimensional array */
-	tbl->td_lolen = (flex_uint32_t) (lastdfa + 1);
+	tbl->td_lolen = (flex_uint32_t) (gv->lastdfa + 1);
 
 	tbl->td_data = tdata =
 		calloc(tbl->td_lolen, sizeof (flex_int32_t));
 
-	dfaacc[end_of_buffer_state].dfaacc_state = end_of_buffer_action;
+	gv->dfaacc[gv->end_of_buffer_state].dfaacc_state = end_of_buffer_action;
 
-	for (i = 1; i <= lastdfa; ++i) {
-		int anum = dfaacc[i].dfaacc_state;
+	for (i = 1; i <= gv->lastdfa; ++i) {
+		int anum = gv->dfaacc[i].dfaacc_state;
 
 		tdata[i] = anum;
 
-		if (env.trace && anum)
+		if (gv->env.trace && anum)
 			fprintf (stderr, _("state # %d accepts: [%d]\n"),
 				 i, anum);
 	}
@@ -440,31 +440,31 @@ static struct yytbl_data *mkftbl(void)
 static void genftbl(void)
 {
 	int i;
-	int     end_of_buffer_action = num_rules + 1;
-	struct packtype_t *ptype = optimize_pack(num_rules + 1);
+	int     end_of_buffer_action = gv->num_rules + 1;
+	struct packtype_t *ptype = optimize_pack(gv->num_rules + 1);
 
-	dfaacc[end_of_buffer_state].dfaacc_state = end_of_buffer_action;
+	gv->dfaacc[gv->end_of_buffer_state].dfaacc_state = end_of_buffer_action;
 
 	outn ("m4_define([[M4_HOOK_NEED_ACCEPT]], 1)");
 	out_str ("m4_define([[M4_HOOK_ACCEPT_TYPE]], [[%s]])", ptype->name);
-	out_dec ("m4_define([[M4_HOOK_ACCEPT_SIZE]], [[%d]])", lastdfa + 1);
+	out_dec ("m4_define([[M4_HOOK_ACCEPT_SIZE]], [[%d]])", gv->lastdfa + 1);
 	outn ("m4_define([[M4_HOOK_ACCEPT_BODY]], [[m4_dnl");
 
-	for (i = 1; i <= lastdfa; ++i) {
-		int anum = dfaacc[i].dfaacc_state;
+	for (i = 1; i <= gv->lastdfa; ++i) {
+		int anum = gv->dfaacc[i].dfaacc_state;
 
 		mkdata (anum);
 
-		if (env.trace && anum)
+		if (gv->env.trace && anum)
 			fprintf (stderr, _("state # %d accepts: [%d]\n"),
 				 i, anum);
 	}
 
 	dataend (NULL);
 	outn("]])");
-	footprint += (lastdfa + 1) * ptype->width;
+	gv->footprint += (gv->lastdfa + 1) * ptype->width;
 
-	if (ctrl.useecs)
+	if (gv->ctrl.useecs)
 		genecs ();
 
 	/* Don't have to dump the actual full table entries - they were
@@ -477,7 +477,7 @@ static void genftbl(void)
 static void gentabs(void)
 {
 	int     sz, i, j, k, *accset, nacc, *acc_array, total_states;
-	int     end_of_buffer_action = num_rules + 1;
+	int     end_of_buffer_action = gv->num_rules + 1;
 	struct yytbl_data *yyacc_tbl = 0, *yymeta_tbl = 0, *yybase_tbl = 0,
 	    *yydef_tbl = 0, *yynxt_tbl = 0, *yychk_tbl = 0, *yyacclist_tbl=0;
 	flex_int32_t *yyacc_data = 0, *yybase_data = 0, *yydef_data = 0,
@@ -485,17 +485,17 @@ static void gentabs(void)
 	flex_int32_t yybase_curr = 0, yyacclist_curr=0,yyacc_curr=0;
 	struct packtype_t *ptype;
 
-	acc_array = allocate_integer_array (current_max_dfas);
-	nummt = 0;
+	acc_array = allocate_integer_array (gv->current_max_dfas);
+	gv->nummt = 0;
 
 	/* The compressed table format jams by entering the "jam state",
 	 * losing information about the previous state in the process.
 	 * In order to recover the previous state, we effectively need
 	 * to keep backing-up information.
 	 */
-	++num_backing_up;
+	++gv->num_backing_up;
 
-	if (reject) {
+	if (gv->reject) {
 		/* Write out accepting list and pointer list.
 
 		 * First we generate the "yy_acclist" array.  In the process,
@@ -507,11 +507,11 @@ static void gentabs(void)
 		/* Set up accepting structures for the End Of Buffer state. */
 		EOB_accepting_list[0] = 0;
 		EOB_accepting_list[1] = end_of_buffer_action;
-		accsiz[end_of_buffer_state] = 1;
-		dfaacc[end_of_buffer_state].dfaacc_set =
+		gv->accsiz[gv->end_of_buffer_state] = 1;
+		gv->dfaacc[gv->end_of_buffer_state].dfaacc_set =
 		    EOB_accepting_list;
 
-		sz = MAX (numas, 1) + 1;
+		sz = MAX (gv->numas, 1) + 1;
 		ptype = optimize_pack(sz);
 		out_str ("m4_define([[M4_HOOK_ACCLIST_TYPE]], [[%s]])", ptype->name);
 		out_dec ("m4_define([[M4_HOOK_ACCLIST_SIZE]], [[%d]])", sz);
@@ -519,21 +519,21 @@ static void gentabs(void)
 
 		yyacclist_tbl = calloc(1,sizeof(struct yytbl_data));
 		yytbl_data_init (yyacclist_tbl, YYTD_ID_ACCLIST);
-		yyacclist_tbl->td_lolen  = (flex_uint32_t) (MAX(numas,1) + 1);
+		yyacclist_tbl->td_lolen  = (flex_uint32_t) (MAX(gv->numas,1) + 1);
 		yyacclist_tbl->td_data = yyacclist_data =
 		    calloc(yyacclist_tbl->td_lolen, sizeof (flex_int32_t));
 		yyacclist_curr = 1;
 
 		j = 1;		/* index into "yy_acclist" array */
 
-		for (i = 1; i <= lastdfa; ++i) {
+		for (i = 1; i <= gv->lastdfa; ++i) {
 			acc_array[i] = j;
 
-			if (accsiz[i] != 0) {
-				accset = dfaacc[i].dfaacc_set;
-				nacc = accsiz[i];
+			if (gv->accsiz[i] != 0) {
+				accset = gv->dfaacc[i].dfaacc_set;
+				nacc = gv->accsiz[i];
 
-				if (env.trace)
+				if (gv->env.trace)
 					fprintf (stderr,
 						 _("state # %d accepts: "),
 						 i);
@@ -543,12 +543,12 @@ static void gentabs(void)
 
 					++j;
 
-					if (variable_trailing_context_rules
+					if (gv->variable_trailing_context_rules
 					    && !(accnum &
 						 YY_TRAILING_HEAD_MASK)
 					    && accnum > 0
-					    && accnum <= num_rules
-					    && rule_type[accnum] ==
+					    && accnum <= gv->num_rules
+					    && gv->rule_type[accnum] ==
 					    RULE_VARIABLE) {
 						/* Special hack to flag
 						 * accepting number as part
@@ -560,7 +560,7 @@ static void gentabs(void)
 					mkdata (accnum);
 					yyacclist_data[yyacclist_curr++] = accnum;
 
-					if (env.trace) {
+					if (gv->env.trace) {
 						fprintf (stderr, "[%d]",
 							 accset[k]);
 
@@ -580,10 +580,10 @@ static void gentabs(void)
 
 		dataend (NULL);
 		outn("]])");
-		footprint += sz * ptype->width;
-		if (tablesext) {
+		gv->footprint += sz * ptype->width;
+		if (gv->tablesext) {
 			yytbl_data_compress (yyacclist_tbl);
-			if (yytbl_data_fwrite (&tableswr, yyacclist_tbl) < 0)
+			if (yytbl_data_fwrite (&gv->tableswr, yyacclist_tbl) < 0)
 				flexerror (_("Could not write yyacclist_tbl"));
 			yytbl_data_destroy (yyacclist_tbl);
 			yyacclist_tbl = NULL;
@@ -591,11 +591,11 @@ static void gentabs(void)
 	}
 
 	else {
-		dfaacc[end_of_buffer_state].dfaacc_state =
+		gv->dfaacc[gv->end_of_buffer_state].dfaacc_state =
 		    end_of_buffer_action;
 
-		for (i = 1; i <= lastdfa; ++i)
-			acc_array[i] = dfaacc[i].dfaacc_state;
+		for (i = 1; i <= gv->lastdfa; ++i)
+			acc_array[i] = gv->dfaacc[i].dfaacc_state;
 
 		/* add accepting number for jam state */
 		acc_array[i] = 0;
@@ -611,9 +611,9 @@ static void gentabs(void)
 	/* "lastdfa + 2" is the size of "yy_accept"; includes room for C arrays
 	 * beginning at 0 and for "jam" state.
 	 */
-	sz = lastdfa + 2;
+	sz = gv->lastdfa + 2;
 
-	if (reject)
+	if (gv->reject)
 		/* We put a "cap" on the table associating lists of accepting
 		 * numbers with state numbers.  This is needed because we tell
 		 * where the end of an accepting list is by looking at where
@@ -635,11 +635,11 @@ static void gentabs(void)
 	    calloc(yyacc_tbl->td_lolen, sizeof (flex_int32_t));
 	yyacc_curr=1;
 
-	for (i = 1; i <= lastdfa; ++i) {
+	for (i = 1; i <= gv->lastdfa; ++i) {
 		mkdata (acc_array[i]);
 		yyacc_data[yyacc_curr++] = acc_array[i];
 
-		if (!reject && env.trace && acc_array[i])
+		if (!gv->reject && gv->env.trace && acc_array[i])
 			fprintf (stderr, _("state # %d accepts: [%d]\n"),
 				 i, acc_array[i]);
 	}
@@ -648,7 +648,7 @@ static void gentabs(void)
 	mkdata (acc_array[i]);
 	yyacc_data[yyacc_curr++] = acc_array[i];
 
-	if (reject) {
+	if (gv->reject) {
 		/* Add "cap" for the list. */
 		mkdata (acc_array[i]);
 		yyacc_data[yyacc_curr++] = acc_array[i];
@@ -656,33 +656,33 @@ static void gentabs(void)
 
 	dataend (NULL);
 	outn ("]])");
-	footprint += sz * ptype->width;
+	gv->footprint += sz * ptype->width;
 
-	if (tablesext) {
+	if (gv->tablesext) {
 		yytbl_data_compress (yyacc_tbl);
-		if (yytbl_data_fwrite (&tableswr, yyacc_tbl) < 0)
+		if (yytbl_data_fwrite (&gv->tableswr, yyacc_tbl) < 0)
 			flexerror (_("Could not write yyacc_tbl"));
 	}
 	yytbl_data_destroy (yyacc_tbl);
 	yyacc_tbl = NULL;
 	/* End generating yy_accept */
 
-	if (ctrl.useecs) {
+	if (gv->ctrl.useecs) {
 
 		genecs ();
-		if (tablesext) {
+		if (gv->tablesext) {
 			struct yytbl_data *tbl;
 
 			tbl = mkecstbl ();
 			yytbl_data_compress (tbl);
-			if (yytbl_data_fwrite (&tableswr, tbl) < 0)
+			if (yytbl_data_fwrite (&gv->tableswr, tbl) < 0)
 				flexerror (_("Could not write ecstbl"));
 			yytbl_data_destroy (tbl);
 			tbl = 0;
 		}
 	}
 
-	if (ctrl.usemecs) {
+	if (gv->ctrl.usemecs) {
 		/* Begin generating yy_meta */
 		/* Write out meta-equivalence classes (used to index
 		 * templates with).
@@ -690,32 +690,32 @@ static void gentabs(void)
 		flex_int32_t *yymecs_data = 0;
 		yymeta_tbl = calloc(1, sizeof (struct yytbl_data));
 		yytbl_data_init (yymeta_tbl, YYTD_ID_META);
-		yymeta_tbl->td_lolen = (flex_uint32_t) (numecs + 1);
+		yymeta_tbl->td_lolen = (flex_uint32_t) (gv->numecs + 1);
 		yymeta_tbl->td_data = yymecs_data =
 		    calloc(yymeta_tbl->td_lolen,
 			   sizeof (flex_int32_t));
 
-		if (env.trace)
+		if (gv->env.trace)
 			fputs (_("\n\nMeta-Equivalence Classes:\n"),
 			       stderr);
-		out_dec ("m4_define([[M4_HOOK_MECSTABLE_SIZE]], [[%d]])", numecs+1);
+		out_dec ("m4_define([[M4_HOOK_MECSTABLE_SIZE]], [[%d]])", gv->numecs+1);
 		outn ("m4_define([[M4_HOOK_MECSTABLE_BODY]], [[m4_dnl");
  	
-		for (i = 1; i <= numecs; ++i) {
-			if (env.trace)
+		for (i = 1; i <= gv->numecs; ++i) {
+			if (gv->env.trace)
 				fprintf (stderr, "%d = %d\n",
-					 i, ABS (tecbck[i]));
+					 i, ABS (gv->tecbck[i]));
 
-			mkdata (ABS (tecbck[i]));
-			yymecs_data[i] = ABS (tecbck[i]);
+			mkdata (ABS (gv->tecbck[i]));
+			yymecs_data[i] = ABS (gv->tecbck[i]);
 		}
 
 		dataend (NULL);
 		outn ("]])");
-		footprint += sizeof(YY_CHAR) * (numecs + 1);
-		if (tablesext) {
+		gv->footprint += sizeof(YY_CHAR) * (gv->numecs + 1);
+		if (gv->tablesext) {
 			yytbl_data_compress (yymeta_tbl);
-			if (yytbl_data_fwrite (&tableswr, yymeta_tbl) < 0)
+			if (yytbl_data_fwrite (&gv->tableswr, yymeta_tbl) < 0)
 				flexerror (_("Could not write yymeta_tbl"));
 		}
 		yytbl_data_destroy (yymeta_tbl);
@@ -723,7 +723,7 @@ static void gentabs(void)
 		/* End generating yy_meta */
 	}
 
-	total_states = lastdfa + numtemps;
+	total_states = gv->lastdfa + gv->numtemps;
 
 	/* Begin generating yy_base */
 	sz = total_states + 1;
@@ -740,42 +740,42 @@ static void gentabs(void)
 		   sizeof (flex_int32_t));
 	yybase_curr = 1;
 
-	for (i = 1; i <= lastdfa; ++i) {
-		int d = def[i];
+	for (i = 1; i <= gv->lastdfa; ++i) {
+		int d = gv->def[i];
 
-		if (base[i] == JAMSTATE)
-			base[i] = jambase;
+		if (gv->base[i] == JAMSTATE)
+			gv->base[i] = gv->jambase;
 
 		if (d == JAMSTATE)
-			def[i] = jamstate;
+			gv->def[i] = gv->jamstate;
 
 		else if (d < 0) {
 			/* Template reference. */
-			++tmpuses;
-			def[i] = lastdfa - d + 1;
+			++gv->tmpuses;
+			gv->def[i] = gv->lastdfa - d + 1;
 		}
 
-		mkdata (base[i]);
-		yybase_data[yybase_curr++] = base[i];
+		mkdata (gv->base[i]);
+		yybase_data[yybase_curr++] = gv->base[i];
 	}
 
 	/* Generate jam state's base index. */
-	mkdata (base[i]);
-	yybase_data[yybase_curr++] = base[i];
+	mkdata (gv->base[i]);
+	yybase_data[yybase_curr++] = gv->base[i];
 
 	for (++i /* skip jam state */ ; i <= total_states; ++i) {
-		mkdata (base[i]);
-		yybase_data[yybase_curr++] = base[i];
-		def[i] = jamstate;
+		mkdata (gv->base[i]);
+		yybase_data[yybase_curr++] = gv->base[i];
+		gv->def[i] = gv->jamstate;
 	}
 
 	dataend (NULL);
 	outn ("]])");
-	footprint += sz * ptype->width;
+	gv->footprint += sz * ptype->width;
 
-	if (tablesext) {
+	if (gv->tablesext) {
 		yytbl_data_compress (yybase_tbl);
-		if (yytbl_data_fwrite (&tableswr, yybase_tbl) < 0)
+		if (yytbl_data_fwrite (&gv->tableswr, yybase_tbl) < 0)
 			flexerror (_("Could not write yybase_tbl"));
 	}
 	yytbl_data_destroy (yybase_tbl);
@@ -796,17 +796,17 @@ static void gentabs(void)
 	    calloc(yydef_tbl->td_lolen, sizeof (flex_int32_t));
 
 	for (i = 1; i <= total_states; ++i) {
-		mkdata (def[i]);
-		yydef_data[i] = def[i];
+		mkdata (gv->def[i]);
+		yydef_data[i] = gv->def[i];
 	}
 
 	dataend (NULL);
 	outn ("]])");
-	footprint += (total_states + 1) * ptype->width;
+	gv->footprint += (total_states + 1) * ptype->width;
 
-	if (tablesext) {
+	if (gv->tablesext) {
 		yytbl_data_compress (yydef_tbl);
-		if (yytbl_data_fwrite (&tableswr, yydef_tbl) < 0)
+		if (yytbl_data_fwrite (&gv->tableswr, yydef_tbl) < 0)
 			flexerror (_("Could not write yydef_tbl"));
 	}
 	yytbl_data_destroy (yydef_tbl);
@@ -814,38 +814,38 @@ static void gentabs(void)
 	/* End generating yy_def */
 
 
-	ptype = optimize_pack(tblend + 1);
+	ptype = optimize_pack(gv->tblend + 1);
 	/* Note: Used when !ctrl.fulltbl && !ctrl.fullspd).
 	 * (Alternately defined when ctrl.fullspd)
 	 */
 	out_str ("m4_define([[M4_HOOK_YYNXT_TYPE]], [[%s]])", ptype->name);
-	out_dec ("m4_define([[M4_HOOK_YYNXT_SIZE]], [[%d]])", tblend + 1);
+	out_dec ("m4_define([[M4_HOOK_YYNXT_SIZE]], [[%d]])", gv->tblend + 1);
 	outn ("m4_define([[M4_HOOK_YYNXT_BODY]], [[m4_dnl");
 
 	yynxt_tbl = calloc (1, sizeof (struct yytbl_data));
 	yytbl_data_init (yynxt_tbl, YYTD_ID_NXT);
-	yynxt_tbl->td_lolen = (flex_uint32_t) (tblend + 1);
+	yynxt_tbl->td_lolen = (flex_uint32_t) (gv->tblend + 1);
 	yynxt_tbl->td_data = yynxt_data =
 	    calloc (yynxt_tbl->td_lolen, sizeof (flex_int32_t));
 
-	for (i = 1; i <= tblend; ++i) {
+	for (i = 1; i <= gv->tblend; ++i) {
 		/* Note, the order of the following test is important.
 		 * If chk[i] is 0, then nxt[i] is undefined.
 		 */
-		if (chk[i] == 0 || nxt[i] == 0)
-			nxt[i] = jamstate;	/* new state is the JAM state */
+		if (gv->chk[i] == 0 || gv->nxt[i] == 0)
+			gv->nxt[i] = gv->jamstate;	/* new state is the JAM state */
 
-		mkdata (nxt[i]);
-		yynxt_data[i] = nxt[i];
+		mkdata (gv->nxt[i]);
+		yynxt_data[i] = gv->nxt[i];
 	}
 
 	dataend (NULL);
 	outn("]])");
-	footprint += ptype->width * (tblend + 1);
+	gv->footprint += ptype->width * (gv->tblend + 1);
 
-	if (tablesext) {
+	if (gv->tablesext) {
 		yytbl_data_compress (yynxt_tbl);
-		if (yytbl_data_fwrite (&tableswr, yynxt_tbl) < 0)
+		if (yytbl_data_fwrite (&gv->tableswr, yynxt_tbl) < 0)
 			flexerror (_("Could not write yynxt_tbl"));
 	}
 	yytbl_data_destroy (yynxt_tbl);
@@ -853,32 +853,32 @@ static void gentabs(void)
 	/* End generating yy_nxt */
 
 	/* Begin generating yy_chk */
-	ptype = optimize_pack(tblend + 1);
+	ptype = optimize_pack(gv->tblend + 1);
 	out_str ("m4_define([[M4_HOOK_CHK_TYPE]], [[%s]])", ptype->name);
-	out_dec ("m4_define([[M4_HOOK_CHK_SIZE]], [[%d]])", tblend + 1);
+	out_dec ("m4_define([[M4_HOOK_CHK_SIZE]], [[%d]])", gv->tblend + 1);
 	outn ("m4_define([[M4_HOOK_CHK_BODY]], [[m4_dnl");
 	
 	yychk_tbl = calloc (1, sizeof (struct yytbl_data));
 	yytbl_data_init (yychk_tbl, YYTD_ID_CHK);
-	yychk_tbl->td_lolen = (flex_uint32_t) (tblend + 1);
+	yychk_tbl->td_lolen = (flex_uint32_t) (gv->tblend + 1);
 	yychk_tbl->td_data = yychk_data =
 	    calloc(yychk_tbl->td_lolen, sizeof (flex_int32_t));
 
-	for (i = 1; i <= tblend; ++i) {
-		if (chk[i] == 0)
-			++nummt;
+	for (i = 1; i <= gv->tblend; ++i) {
+		if (gv->chk[i] == 0)
+			++gv->nummt;
 
-		mkdata (chk[i]);
-		yychk_data[i] = chk[i];
+		mkdata (gv->chk[i]);
+		yychk_data[i] = gv->chk[i];
 	}
 
 	dataend (NULL);
 	outn ("]])");
-	footprint += ptype->width * (tblend + 1);
+	gv->footprint += ptype->width * (gv->tblend + 1);
 
-	if (tablesext) {
+	if (gv->tablesext) {
 		yytbl_data_compress (yychk_tbl);
-		if (yytbl_data_fwrite (&tableswr, yychk_tbl) < 0)
+		if (yytbl_data_fwrite (&gv->tableswr, yychk_tbl) < 0)
 			flexerror (_("Could not write yychk_tbl"));
 	}
 	yytbl_data_destroy (yychk_tbl);
@@ -926,28 +926,28 @@ void make_tables (void)
 
 	/* This is where we REALLY begin generating the tables. */
 
-	if (ctrl.fullspd) {
+	if (gv->ctrl.fullspd) {
 		genctbl ();
-		if (tablesext) {
+		if (gv->tablesext) {
 			struct yytbl_data *tbl;
 
 			tbl = mkctbl ();
 			yytbl_data_compress (tbl);
-			if (yytbl_data_fwrite (&tableswr, tbl) < 0)
+			if (yytbl_data_fwrite (&gv->tableswr, tbl) < 0)
 				flexerror (_("Could not write ftbl"));
 			yytbl_data_destroy (tbl);
 
 			tbl = mkssltbl ();
 			yytbl_data_compress (tbl);
-			if (yytbl_data_fwrite (&tableswr, tbl) < 0)
+			if (yytbl_data_fwrite (&gv->tableswr, tbl) < 0)
 				flexerror (_("Could not write ssltbl"));
 			yytbl_data_destroy (tbl);
 			tbl = 0;
 
-			if (ctrl.useecs) {
+			if (gv->ctrl.useecs) {
 				tbl = mkecstbl ();
 				yytbl_data_compress (tbl);
-				if (yytbl_data_fwrite (&tableswr, tbl) < 0)
+				if (yytbl_data_fwrite (&gv->tableswr, tbl) < 0)
 					flexerror (_
 						   ("Could not write ecstbl"));
 				yytbl_data_destroy (tbl);
@@ -955,26 +955,26 @@ void make_tables (void)
 			}
 		}
 	}
-	else if (ctrl.fulltbl) {
+	else if (gv->ctrl.fulltbl) {
 		genftbl ();
-		if (tablesext) {
+		if (gv->tablesext) {
 			struct yytbl_data *tbl;
 
-			/* Alternately defined if !ctrl.ffullspd && !ctrl.fulltbl */
+			/* Alternately defined if !gv->ctrl.ffullspd && !gv->ctrl.fulltbl */
 			struct packtype_t *ptype;
 			tbl = mkftbl ();
 			yytbl_data_compress (tbl);
 			ptype = optimize_pack(tbl->td_lolen);
 			out_str ("m4_define([[M4_HOOK_ACCEPT_TYPE]], [[%s]])", ptype->name);
-			if (yytbl_data_fwrite (&tableswr, tbl) < 0)
+			if (yytbl_data_fwrite (&gv->tableswr, tbl) < 0)
 				flexerror (_("Could not write ftbl"));
 			yytbl_data_destroy (tbl);
 			tbl = 0;
 
-			if (ctrl.useecs) {
+			if (gv->ctrl.useecs) {
 				tbl = mkecstbl ();
 				yytbl_data_compress (tbl);
-				if (yytbl_data_fwrite (&tableswr, tbl) < 0)
+				if (yytbl_data_fwrite (&gv->tableswr, tbl) < 0)
 					flexerror (_
 						   ("Could not write ecstbl"));
 				yytbl_data_destroy (tbl);
@@ -986,15 +986,15 @@ void make_tables (void)
 		gentabs ();
 	}
 
-	snprintf(buf, sizeof(buf), "footprint: %ld bytes\n", footprint);
+	snprintf(buf, sizeof(buf), "footprint: %ld bytes\n", gv->footprint);
 	comment(buf);
-	snprintf(buf, sizeof(buf), "tblend: %d\n", tblend);
+	snprintf(buf, sizeof(buf), "tblend: %d\n", gv->tblend);
 	comment(buf);
-	snprintf(buf, sizeof(buf), "numecs: %d\n", numecs);
+	snprintf(buf, sizeof(buf), "numecs: %d\n", gv->numecs);
 	comment(buf);
-	snprintf(buf, sizeof(buf), "num_rules: %d\n", num_rules);
+	snprintf(buf, sizeof(buf), "num_rules: %d\n", gv->num_rules);
 	comment(buf);
-	snprintf(buf, sizeof(buf), "lastdfa: %d\n", lastdfa);
+	snprintf(buf, sizeof(buf), "lastdfa: %d\n", gv->lastdfa);
 	comment(buf);
 	outc ('\n');
 	
@@ -1003,73 +1003,73 @@ void make_tables (void)
 
 	comment("m4 controls begin\n");
 
-	if (num_backing_up > 0)
+	if (gv->num_backing_up > 0)
 		visible_define ( "M4_MODE_HAS_BACKING_UP");
 
 	// These are used for NUL transitions
-	if ((num_backing_up > 0 && !reject) && (!nultrans || ctrl.fullspd || ctrl.fulltbl))
+	if ((gv->num_backing_up > 0 && !gv->reject) && (!gv->nultrans || gv->ctrl.fullspd || gv->ctrl.fulltbl))
 		visible_define ( "M4_MODE_NEED_YY_CP");
-	if ((num_backing_up > 0 && !reject) && (ctrl.fullspd || ctrl.fulltbl))
+	if ((gv->num_backing_up > 0 && !gv->reject) && (gv->ctrl.fullspd || gv->ctrl.fulltbl))
 		visible_define ( "M4_MODE_NULTRANS_WRAP");
 
 	comment("m4 controls end\n");
 	out ("\n");
 
-	if (ctrl.do_yylineno) {
+	if (gv->ctrl.do_yylineno) {
 
 		geneoltbl ();
 
-		if (tablesext) {
+		if (gv->tablesext) {
 			struct yytbl_data *tbl;
 
 			tbl = mkeoltbl ();
 			yytbl_data_compress (tbl);
-			if (yytbl_data_fwrite (&tableswr, tbl) < 0)
+			if (yytbl_data_fwrite (&gv->tableswr, tbl) < 0)
 				flexerror (_("Could not write eoltbl"));
 			yytbl_data_destroy (tbl);
 			tbl = 0;
 		}
 	}
 
-	if (nultrans) {
+	if (gv->nultrans) {
 		flex_int32_t *yynultrans_data = 0;
 
 		/* Begin generating yy_NUL_trans */
-		out_str ("m4_define([[M4_HOOK_NULTRANS_TYPE]], [[%s]])", (ctrl.fullspd) ? "struct yy_trans_info*" : "M4_HOOK_INT32");
-		out_dec ("m4_define([[M4_HOOK_NULTRANS_SIZE]], [[%d]])", lastdfa + 1);
+		out_str ("m4_define([[M4_HOOK_NULTRANS_TYPE]], [[%s]])", (gv->ctrl.fullspd) ? "struct yy_trans_info*" : "M4_HOOK_INT32");
+		out_dec ("m4_define([[M4_HOOK_NULTRANS_SIZE]], [[%d]])", gv->lastdfa + 1);
 		outn ("m4_define([[M4_HOOK_NULTRANS_BODY]], [[m4_dnl");
 
 		yynultrans_tbl = calloc(1, sizeof (struct yytbl_data));
 		yytbl_data_init (yynultrans_tbl, YYTD_ID_NUL_TRANS);
 		// Performance kludge for C. Gives a small improvement
 		// in table loading time.
-		if (ctrl.fullspd && ctrl.have_state_entry_format)
+		if (gv->ctrl.fullspd && gv->ctrl.have_state_entry_format)
 			yynultrans_tbl->td_flags |= YYTD_PTRANS;
-		yynultrans_tbl->td_lolen = (flex_uint32_t) (lastdfa + 1);
+		yynultrans_tbl->td_lolen = (flex_uint32_t) (gv->lastdfa + 1);
 		yynultrans_tbl->td_data = yynultrans_data =
 		    calloc(yynultrans_tbl->td_lolen,
 			   sizeof (flex_int32_t));
 
-		for (i = 1; i <= lastdfa; ++i) {
+		for (i = 1; i <= gv->lastdfa; ++i) {
 			if ((yynultrans_tbl->td_flags & YYTD_PTRANS) != 0) {
 				// Only works in very C-like languages  
 				out_dec ("    &yy_transition[%d],\n",
-					 base[i]);
-				yynultrans_data[i] = base[i];
+					 gv->base[i]);
+				yynultrans_data[i] = gv->base[i];
 			}
 			else {
 				// This will work anywhere
-				mkdata (nultrans[i]);
-				yynultrans_data[i] = nultrans[i];
+				mkdata (gv->nultrans[i]);
+				yynultrans_data[i] = gv->nultrans[i];
 			}
 		}
 
 		dataend (NULL);
 		outn("]])");
-		footprint += (lastdfa + 1) * (ctrl.fullspd ? sizeof(struct yy_trans_info *) : sizeof(int32_t));
-		if (tablesext) {
+		gv->footprint += (gv->lastdfa + 1) * (gv->ctrl.fullspd ? sizeof(struct yy_trans_info *) : sizeof(int32_t));
+		if (gv->tablesext) {
 			yytbl_data_compress (yynultrans_tbl);
-			if (yytbl_data_fwrite (&tableswr, yynultrans_tbl) <
+			if (yytbl_data_fwrite (&gv->tableswr, yynultrans_tbl) <
 			    0)
 				flexerror (_
 					   ("Could not write yynultrans_tbl"));
@@ -1083,17 +1083,17 @@ void make_tables (void)
 		/* End generating yy_NUL_trans */
 	}
 
-	if (ctrl.ddebug) {		/* Spit out table mapping rules to line numbers. */
+	if (gv->ctrl.ddebug) {		/* Spit out table mapping rules to line numbers. */
 		/* Policy choice: we don't include this space
 		 * in the table metering.
 		 */
-		struct packtype_t *ptype = optimize_pack(num_rules);
+		struct packtype_t *ptype = optimize_pack(gv->num_rules);
 		out_str ("m4_define([[M4_HOOK_DEBUGTABLE_TYPE]], [[%s]])", ptype->name);
-		out_dec ("m4_define([[M4_HOOK_DEBUGTABLE_SIZE]], [[%d]])", num_rules);
+		out_dec ("m4_define([[M4_HOOK_DEBUGTABLE_SIZE]], [[%d]])", gv->num_rules);
 		outn ("m4_define([[M4_HOOK_DEBUGTABLE_BODY]], [[m4_dnl");
 
-		for (i = 1; i < num_rules; ++i)
-			mkdata (rule_linenum[i]);
+		for (i = 1; i < gv->num_rules; ++i)
+			mkdata (gv->rule_linenum[i]);
 		dataend (NULL);
 		outn("]])");
 	}

--- a/src/main.c
+++ b/src/main.c
@@ -128,6 +128,7 @@ FlexState* newFlexState(void)
     fgv->backing_name = "lex.backup";
     fgv->tablesfile_template = "lex.%s.tables";
     fgv->preproc_level = 1000;
+    init_default_backend(fgv);
     return fgv;
 }
 
@@ -1718,7 +1719,7 @@ void readin (FlexState* gv)
 	if (gv->ctrl.noyyread)
 		visible_define("M4_MODE_USER_YYREAD");
 
-	if (is_default_backend()) {
+	if (is_default_backend(gv)) {
 		if (gv->ctrl.C_plus_plus) {
 			visible_define ( "M4_MODE_CXX_ONLY");
 		} else {

--- a/src/main.c
+++ b/src/main.c
@@ -38,7 +38,7 @@
 #include "tables.h"
 #include "parse.h"
 
-static char flex_version[] = FLEX_VERSION;
+static const char flex_version[] = FLEX_VERSION;
 
 /* declare functions that have forward references */
 
@@ -46,88 +46,103 @@ void flexinit(int, char **);
 void readin(void);
 void set_up_initial_allocations(void);
 
-/* these globals are all defined and commented in flexdef.h */
-bool    syntaxerror, eofseen;
-int     yymore_used, reject, real_reject, continued_action, in_rule;
-int     datapos, dataline, linenum;
-FILE   *skelfile = NULL;
-int     skel_ind = 0;
-char   *action_array;
-int     action_size, defs1_offset, prolog_offset, action_offset,
-	action_index;
-char   *infilename = NULL;
-char   *extra_type = NULL;
-int     onestate[ONE_STACK_SIZE], onesym[ONE_STACK_SIZE];
-int     onenext[ONE_STACK_SIZE], onedef[ONE_STACK_SIZE], onesp;
-int     maximum_mns, current_mns, current_max_rules;
-int     num_rules, num_eof_rules, default_rule, lastnfa;
-int    *firstst, *lastst, *finalst, *transchar, *trans1, *trans2;
-int    *accptnum, *assoc_rule, *state_type;
-int    *rule_type, *rule_linenum;
-int     current_state_type;
-bool    variable_trailing_context_rules;
-int     numtemps, numprots, protprev[MSP], protnext[MSP], prottbl[MSP];
-int     protcomst[MSP], firstprot, lastprot, protsave[PROT_SAVE_SIZE];
-int     numecs, nextecm[CSIZE + 1], ecgroup[CSIZE + 1], nummecs,
-	tecfwd[CSIZE + 1];
-int     tecbck[CSIZE + 1];
-int     lastsc, *scset, *scbol;
-/* scxclu[] and sceof[] are boolean arrays, but allocated as char
- * arrays for size. */
-char   *scxclu, *sceof;
-int     current_max_scs;
-const char **scname;
-int     current_max_dfa_size, current_max_xpairs;
-int     current_max_template_xpairs, current_max_dfas;
-int     lastdfa, *nxt, *chk, *tnxt;
-int    *base, *def, *nultrans, NUL_ec, tblend, firstfree, **dss, *dfasiz;
-union dfaacc_union *dfaacc;
-int    *accsiz, *dhash, numas;
-int     numsnpairs, jambase, jamstate;
-int     lastccl, *cclmap, *ccllen, *cclng, cclreuse;
-int     current_maxccls, current_max_ccl_tbl_size;
-unsigned char   *ccltbl;
-char    nmstr[MAXLINE];
-int     sectnum, nummt, hshcol, dfaeql, numeps, eps2, num_reallocs, nmval;
-int     tmpuses, totnst, peakpairs, numuniq, numdup, hshsave;
-int     num_backing_up, bol_needed;
-int     end_of_buffer_state;
-char  **input_files;
-int     num_input_files;
-jmp_buf flex_main_jmp_buf;
-/* rule_useful[], rule_has_nl[] and ccl_has_nl[] are boolean arrays,
- * but allocated as char arrays for size. */
-char   *rule_useful, *rule_has_nl, *ccl_has_nl;
-int     nlch = '\n';
+///* these globals are all defined and commented in flexdef.h */
+//bool    syntaxerror, eofseen;
+//int     yymore_used, reject, real_reject, continued_action, in_rule;
+//int     datapos, dataline, linenum;
+//FILE   *skelfile = NULL;
+//int     skel_ind = 0;
+//char   *action_array;
+//int     action_size, defs1_offset, prolog_offset, action_offset,
+//	action_index;
+//char   *infilename = NULL;
+//char   *extra_type = NULL;
+//int     onestate[ONE_STACK_SIZE], onesym[ONE_STACK_SIZE];
+//int     onenext[ONE_STACK_SIZE], onedef[ONE_STACK_SIZE], onesp;
+//int     maximum_mns, current_mns, current_max_rules;
+//int     num_rules, num_eof_rules, default_rule, lastnfa;
+//int    *firstst, *lastst, *finalst, *transchar, *trans1, *trans2;
+//int    *accptnum, *assoc_rule, *state_type;
+//int    *rule_type, *rule_linenum;
+//int     current_state_type;
+//bool    variable_trailing_context_rules;
+//int     numtemps, numprots, protprev[MSP], protnext[MSP], prottbl[MSP];
+//int     protcomst[MSP], firstprot, lastprot, protsave[PROT_SAVE_SIZE];
+//int     numecs, nextecm[CSIZE + 1], ecgroup[CSIZE + 1], nummecs,
+//	tecfwd[CSIZE + 1];
+//int     tecbck[CSIZE + 1];
+//int     lastsc, *scset, *scbol;
+///* scxclu[] and sceof[] are boolean arrays, but allocated as char
+// * arrays for size. */
+//char   *scxclu, *sceof;
+//int     current_max_scs;
+//const char **scname;
+//int     current_max_dfa_size, current_max_xpairs;
+//int     current_max_template_xpairs, current_max_dfas;
+//int     lastdfa, *nxt, *chk, *tnxt;
+//int    *base, *def, *nultrans, NUL_ec, tblend, firstfree, **dss, *dfasiz;
+//union dfaacc_union *dfaacc;
+//int    *accsiz, *dhash, numas;
+//int     numsnpairs, jambase, jamstate;
+//int     lastccl, *cclmap, *ccllen, *cclng, cclreuse;
+//int     current_maxccls, current_max_ccl_tbl_size;
+//unsigned char   *ccltbl;
+//char    nmstr[MAXLINE];
+//int     sectnum, nummt, hshcol, dfaeql, numeps, eps2, num_reallocs, nmval;
+//int     tmpuses, totnst, peakpairs, numuniq, numdup, hshsave;
+//int     num_backing_up, bol_needed;
+//int     end_of_buffer_state;
+//char  **input_files;
+//int     num_input_files;
+//jmp_buf flex_main_jmp_buf;
+///* rule_useful[], rule_has_nl[] and ccl_has_nl[] are boolean arrays,
+// * but allocated as char arrays for size. */
+//char   *rule_useful, *rule_has_nl, *ccl_has_nl;
+//int     nlch = '\n';
+//
+//bool    tablesext, tablesverify, gentables;
+//char   *tablesfilename=0,*tablesname=0;
+//struct yytbl_writer tableswr;
+//size_t footprint;
+//
+//struct ctrl_bundle_t ctrl;
+//struct env_bundle_t env;
+//
+///* Make sure program_name is initialized so we don't crash if writing
+// * out an error message before getting the program name from argv[0].
+// */
+//char   *program_name = "flex";
 
-bool    tablesext, tablesverify, gentables;
-char   *tablesfilename=0,*tablesname=0;
-struct yytbl_writer tableswr;
-size_t footprint;
+FlexState *gv;
+void initFlexState(FlexState *fgv)
+{
+    memset(fgv, 0, sizeof(*fgv));
+    fgv->nlch = '\n';
+    fgv->program_name = "flex";
+    fgv->escaped_qstart = "]]M4_YY_NOOP[M4_YY_NOOP[M4_YY_NOOP[[";
+    fgv->escaped_qend   = "]]M4_YY_NOOP]M4_YY_NOOP]M4_YY_NOOP[[";
+    fgv->called_before = -1;
+    fgv->outfile_template = "lex.%s.%s";
+    fgv->backing_name = "lex.backup";
+    fgv->tablesfile_template = "lex.%s.tables";
+    fgv->preproc_level = 1000;
+}
 
-struct ctrl_bundle_t ctrl;
-struct env_bundle_t env;
-
-/* Make sure program_name is initialized so we don't crash if writing
- * out an error message before getting the program name from argv[0].
- */
-char   *program_name = "flex";
-
-static const char outfile_template[] = "lex.%s.%s";
-static const char *backing_name = "lex.backup";
-static const char tablesfile_template[] = "lex.%s.tables";
+//static const char outfile_template[] = "lex.%s.%s";
+//static const char *backing_name = "lex.backup";
+//static const char tablesfile_template[] = "lex.%s.tables";
 
 /* From scan.l */
 extern FILE* yyout;
 
-static char outfile_path[MAXLINE];
-static int outfile_created = 0;
-static int _stdout_closed = 0; /* flag to prevent double-fclose() on stdout. */
-const char *escaped_qstart = "]]M4_YY_NOOP[M4_YY_NOOP[M4_YY_NOOP[[";
-const char *escaped_qend   = "]]M4_YY_NOOP]M4_YY_NOOP]M4_YY_NOOP[[";
+//static char outfile_path[MAXLINE];
+//static int outfile_created = 0;
+//static int _stdout_closed = 0; /* flag to prevent double-fclose() on stdout. */
+//const char *escaped_qstart = "]]M4_YY_NOOP[M4_YY_NOOP[M4_YY_NOOP[[";
+//const char *escaped_qend   = "]]M4_YY_NOOP]M4_YY_NOOP]M4_YY_NOOP[[";
 
 /* For debugging. The max number of filters to apply to skeleton. */
-static int preproc_level = 1000;
+//static int preproc_level = 1000;
 
 int flex_main (int argc, char *argv[]);
 
@@ -135,6 +150,9 @@ int flex_main (int argc, char *argv[])
 {
 	int     i, exit_status, child_status;
 	int	did_eof_rule = false;
+        FlexState fgv;
+        initFlexState(&fgv);
+        gv = &fgv;
 
 	/* Set a longjmp target. Yes, I know it's a hack, but it gets worse: The
 	 * return value of setjmp, if non-zero, is the desired exit code PLUS ONE.
@@ -143,9 +161,9 @@ int flex_main (int argc, char *argv[])
 	 * specify a value of 0 to longjmp. FLEX_EXIT(n) should be used instead of
 	 * exit(n);
 	 */
-	exit_status = setjmp (flex_main_jmp_buf);
+	exit_status = setjmp (gv->flex_main_jmp_buf);
 	if (exit_status){
-		if (stdout && !_stdout_closed && !ferror(stdout)){
+		if (stdout && !gv->_stdout_closed && !ferror(stdout)){
 			fflush(stdout);
 			fclose(stdout);
 		}
@@ -166,31 +184,31 @@ int flex_main (int argc, char *argv[])
 
 	readin ();
 	skelout (true);		/* %% [1.0] DFA */
-	footprint += ntod ();
+	gv->footprint += ntod ();
 
-	for (i = 1; i <= num_rules; ++i)
-		if (!rule_useful[i] && i != default_rule)
+	for (i = 1; i <= gv->num_rules; ++i)
+		if (!gv->rule_useful[i] && i != gv->default_rule)
 			line_warning (_("rule cannot be matched"),
-				      rule_linenum[i]);
+				      gv->rule_linenum[i]);
 
-	if (ctrl.spprdflt && !reject && rule_useful[default_rule])
+	if (gv->ctrl.spprdflt && !gv->reject && gv->rule_useful[gv->default_rule])
 		line_warning (_
 			      ("-s option given but default rule can be matched"),
-			      rule_linenum[default_rule]);
+			      gv->rule_linenum[gv->default_rule]);
 
 	comment("START of m4 controls\n");
 
 	// mode switches for yy_trans_info specification
 	// nultrans
-	if (nultrans)
+	if (gv->nultrans)
 		visible_define ( "M4_MODE_NULTRANS");
 	else {
 		visible_define ( "M4_MODE_NO_NULTRANS");
-		if (ctrl.fulltbl)
+		if (gv->ctrl.fulltbl)
 		    visible_define ( "M4_MODE_NULTRANS_FULLTBL");
 		else
 		    visible_define ( "M4_MODE_NO_NULTRANS_FULLTBL");
-		if (ctrl.fullspd)
+		if (gv->ctrl.fullspd)
 		    visible_define ( "M4_MODE_NULTRANS_FULLSPD");
 		else
 		    visible_define ( "M4_MODE_NO_NULTRANS_FULLSPD");
@@ -200,15 +218,15 @@ int flex_main (int argc, char *argv[])
 	out ("\n");
 
 	comment("START of Flex-generated definitions\n");
-	out_str_dec ("M4_HOOK_CONST_DEFINE_UINT(%s, %d)", "YY_NUM_RULES", num_rules);
-	out_str_dec ("M4_HOOK_CONST_DEFINE_STATE(%s, %d)", "YY_END_OF_BUFFER", num_rules + 1);
-	out_str_dec ("M4_HOOK_CONST_DEFINE_STATE(%s, %d)", "YY_JAMBASE", jambase);
-	out_str_dec ("M4_HOOK_CONST_DEFINE_STATE(%s, %d)", "YY_JAMSTATE", jamstate);
-	out_str_dec ("M4_HOOK_CONST_DEFINE_BYTE(%s, %d)", "YY_NUL_EC", NUL_ec);
+	out_str_dec ("M4_HOOK_CONST_DEFINE_UINT(%s, %d)", "YY_NUM_RULES", gv->num_rules);
+	out_str_dec ("M4_HOOK_CONST_DEFINE_STATE(%s, %d)", "YY_END_OF_BUFFER", gv->num_rules + 1);
+	out_str_dec ("M4_HOOK_CONST_DEFINE_STATE(%s, %d)", "YY_JAMBASE", gv->jambase);
+	out_str_dec ("M4_HOOK_CONST_DEFINE_STATE(%s, %d)", "YY_JAMSTATE", gv->jamstate);
+	out_str_dec ("M4_HOOK_CONST_DEFINE_BYTE(%s, %d)", "YY_NUL_EC", gv->NUL_ec);
 	/* Need to define the transet type as a size large
 	 * enough to hold the biggest offset.
 	 */
-	out_str ("M4_HOOK_SET_OFFSET_TYPE(%s)", optimize_pack(tblend + numecs + 1)->name);
+	out_str ("M4_HOOK_SET_OFFSET_TYPE(%s)", optimize_pack(gv->tblend + gv->numecs + 1)->name);
 	comment("END of Flex-generated definitions\n");
 
 	skelout (true);		/* %% [2.0] - tables get dumped here */
@@ -218,28 +236,28 @@ int flex_main (int argc, char *argv[])
 
 	skelout (true);		/* %% [3.0] - mode-dependent static declarations get dumped here */
 
-	out (&action_array[defs1_offset]);
+	out (&gv->action_array[gv->defs1_offset]);
 
-	line_directive_out (stdout, NULL, linenum);
+	line_directive_out (stdout, NULL, gv->linenum);
 
 	skelout (true);		/* %% [4.0] - various random yylex internals get dumped here */
 
 	/* Copy prolog to output file. */
-	out (&action_array[prolog_offset]);
+	out (&gv->action_array[gv->prolog_offset]);
 
-	line_directive_out (stdout, NULL, linenum);
+	line_directive_out (stdout, NULL, gv->linenum);
 
 	skelout (true);		/* %% [5.0] - main loop of matching-engine code gets dumped here */
 
 	/* Copy actions to output file. */
-	out (&action_array[action_offset]);
+	out (&gv->action_array[gv->action_offset]);
 
-	line_directive_out (stdout, NULL, linenum);
+	line_directive_out (stdout, NULL, gv->linenum);
 
 	/* generate cases for any missing EOF rules */
-	for (i = 1; i <= lastsc; ++i)
-		if (!sceof[i]) {
-			out_str ("M4_HOOK_EOF_STATE_CASE_ARM(%s)", scname[i]);
+	for (i = 1; i <= gv->lastsc; ++i)
+		if (!gv->sceof[i]) {
+			out_str ("M4_HOOK_EOF_STATE_CASE_ARM(%s)", gv->scname[i]);
 			outc('\n');
 			out ("M4_HOOK_EOF_STATE_CASE_FALLTHROUGH");
 			outc('\n');
@@ -254,14 +272,14 @@ int flex_main (int argc, char *argv[])
 
 	/* Copy remainder of input to output. */
 
-	line_directive_out (stdout, infilename, linenum);
+	line_directive_out (stdout, gv->infilename, gv->linenum);
 
-	if (sectnum == 3) {
+	if (gv->sectnum == 3) {
 		OUT_BEGIN_CODE ();
-                if (!ctrl.no_section3_escape)
+                if (!gv->ctrl.no_section3_escape)
                    fputs("[[", stdout);
 		(void) flexscan ();	/* copy remainder of input to output */
-                if (!ctrl.no_section3_escape)
+                if (!gv->ctrl.no_section3_escape)
                    fputs("]]", stdout);
 		OUT_END_CODE ();
 	}
@@ -295,17 +313,17 @@ void initialize_output_filters(void)
 {
 	const char * m4 = NULL;
 
-	output_chain = filter_create_int(NULL, filter_tee_header, env.headerfilename);
+	gv->output_chain = filter_create_int(NULL, filter_tee_header, gv->env.headerfilename);
 	if ( !(m4 = getenv("M4"))) {
 		m4 = M4;
 	}
-	filter_create_ext(output_chain, m4, "-P", (char *) 0);
-	filter_create_int(output_chain, filter_fix_linedirs, NULL);
+	filter_create_ext(gv->output_chain, m4, "-P", (char *) 0);
+	filter_create_int(gv->output_chain, filter_fix_linedirs, NULL);
 
 	/* For debugging, only run the requested number of filters. */
-	if (preproc_level > 0) {
-		filter_truncate(output_chain, preproc_level);
-		filter_apply_chain(output_chain);
+	if (gv->preproc_level > 0) {
+		filter_truncate(gv->output_chain, gv->preproc_level);
+		filter_apply_chain(gv->output_chain);
 	}
 }
 
@@ -316,116 +334,116 @@ void check_options (void)
 {
 	int     i;
 
-	if (ctrl.lex_compat) {
-		if (ctrl.C_plus_plus)
+	if (gv->ctrl.lex_compat) {
+		if (gv->ctrl.C_plus_plus)
 			flexerror (_("Can't use -+ with -l option"));
 
-		if (ctrl.fulltbl || ctrl.fullspd)
+		if (gv->ctrl.fulltbl || gv->ctrl.fullspd)
 			flexerror (_("Can't use -f or -F with -l option"));
 
-		if (ctrl.reentrant || ctrl.bison_bridge_lval)
+		if (gv->ctrl.reentrant || gv->ctrl.bison_bridge_lval)
 			flexerror (_
 				   ("Can't use --ctrl.reentrant or --bison-bridge with -l option"));
 
-		ctrl.yytext_is_array = true;
-		ctrl.do_yylineno = true;
-		ctrl.use_read = false;
+		gv->ctrl.yytext_is_array = true;
+		gv->ctrl.do_yylineno = true;
+		gv->ctrl.use_read = false;
 	}
 
 
 #if 0
 	/* This makes no sense whatsoever. I'm removing it. */
-	if (ctrl.do_yylineno)
+	if (gv->ctrl.do_yylineno)
 		/* This should really be "maintain_backup_tables = true" */
-		ctrl.reject_really_used = true;
+		gv->ctrl.reject_really_used = true;
 #endif
 
-	if (ctrl.csize == trit_unspecified) {
-		if ((ctrl.fulltbl || ctrl.fullspd) && !ctrl.useecs)
-			ctrl.csize = DEFAULT_CSIZE;
+	if (gv->ctrl.csize == trit_unspecified) {
+		if ((gv->ctrl.fulltbl || gv->ctrl.fullspd) && !gv->ctrl.useecs)
+			gv->ctrl.csize = DEFAULT_CSIZE;
 		else
-			ctrl.csize = CSIZE;
+			gv->ctrl.csize = CSIZE;
 	}
 
-	if (ctrl.interactive == trit_unspecified) {
-		if (ctrl.fulltbl || ctrl.fullspd)
-			ctrl.interactive = trit_false;
+	if (gv->ctrl.interactive == trit_unspecified) {
+		if (gv->ctrl.fulltbl || gv->ctrl.fullspd)
+			gv->ctrl.interactive = trit_false;
 		else
-			ctrl.interactive = trit_true;
+			gv->ctrl.interactive = trit_true;
 	}
 
-	if (ctrl.fulltbl || ctrl.fullspd) {
-		if (ctrl.usemecs)
+	if (gv->ctrl.fulltbl || gv->ctrl.fullspd) {
+		if (gv->ctrl.usemecs)
 			flexerror (_
 				   ("-Cf/-CF and -Cm don't make sense together"));
 
-		if (ctrl.interactive != trit_false)
+		if (gv->ctrl.interactive != trit_false)
 			flexerror (_("-Cf/-CF and -I are incompatible"));
 
-		if (ctrl.lex_compat)
+		if (gv->ctrl.lex_compat)
 			flexerror (_
 				   ("-Cf/-CF are incompatible with lex-compatibility mode"));
 
 
-		if (ctrl.fulltbl && ctrl.fullspd)
+		if (gv->ctrl.fulltbl && gv->ctrl.fullspd)
 			flexerror (_
 				   ("-Cf and -CF are mutually exclusive"));
 	}
 
-	if (ctrl.C_plus_plus && ctrl.fullspd)
+	if (gv->ctrl.C_plus_plus && gv->ctrl.fullspd)
 		flexerror (_("Can't use -+ with -CF option"));
 
-	if (ctrl.C_plus_plus && ctrl.yytext_is_array) {
+	if (gv->ctrl.C_plus_plus && gv->ctrl.yytext_is_array) {
 		lwarn (_("%array incompatible with -+ option"));
-		ctrl.yytext_is_array = false;
+		gv->ctrl.yytext_is_array = false;
 	}
 
-	if (ctrl.C_plus_plus && (ctrl.reentrant))
+	if (gv->ctrl.C_plus_plus && (gv->ctrl.reentrant))
 		flexerror (_("Options -+ and --reentrant are mutually exclusive."));
 
-	if (ctrl.C_plus_plus && ctrl.bison_bridge_lval)
+	if (gv->ctrl.C_plus_plus && gv->ctrl.bison_bridge_lval)
 		flexerror (_("bison bridge not supported for the C++ scanner."));
 
 
-	if (ctrl.useecs) {		/* Set up doubly-linked equivalence classes. */
+	if (gv->ctrl.useecs) {		/* Set up doubly-linked equivalence classes. */
 
 		/* We loop all the way up to ctrl.csize, since ecgroup[ctrl.csize] is
 		 * the position used for NUL characters.
 		 */
-		ecgroup[1] = NIL;
+		gv->ecgroup[1] = NIL;
 
-		for (i = 2; i <= ctrl.csize; ++i) {
-			ecgroup[i] = i - 1;
-			nextecm[i - 1] = i;
+		for (i = 2; i <= gv->ctrl.csize; ++i) {
+			gv->ecgroup[i] = i - 1;
+			gv->nextecm[i - 1] = i;
 		}
 
-		nextecm[ctrl.csize] = NIL;
+		gv->nextecm[gv->ctrl.csize] = NIL;
 	}
 
 	else {
 		/* Put everything in its own equivalence class. */
-		for (i = 1; i <= ctrl.csize; ++i) {
-			ecgroup[i] = i;
-			nextecm[i] = BAD_SUBSCRIPT;	/* to catch errors */
+		for (i = 1; i <= gv->ctrl.csize; ++i) {
+			gv->ecgroup[i] = i;
+			gv->nextecm[i] = BAD_SUBSCRIPT;	/* to catch errors */
 		}
 	}
 
-	if (!env.use_stdout) {
+	if (!gv->env.use_stdout) {
 		FILE   *prev_stdout;
 
-		if (!env.did_outfilename) {
-			snprintf (outfile_path, sizeof(outfile_path), outfile_template,
-				  ctrl.prefix, suffix());
+		if (!gv->env.did_outfilename) {
+			snprintf (gv->outfile_path, sizeof(gv->outfile_path), gv->outfile_template,
+				  gv->ctrl.prefix, suffix());
 
-			env.outfilename = outfile_path;
+			gv->env.outfilename = gv->outfile_path;
 		}
 
-		prev_stdout = freopen (env.outfilename, "w+", stdout);
+		prev_stdout = freopen (gv->env.outfilename, "w+", stdout);
 
 		if (prev_stdout == NULL)
-			lerr (_("could not create %s"), env.outfilename);
+			lerr (_("could not create %s"), gv->env.outfilename);
 
-		outfile_created = 1;
+		gv->outfile_created = 1;
 	}
 }
 
@@ -437,244 +455,244 @@ void check_options (void)
 
 void flexend (int exit_status)
 {
-	static int called_before = -1;	/* prevent infinite recursion. */
+	//static int called_before = -1;	/* prevent infinite recursion. */
 	int     tblsiz;
 
-	if (++called_before)
+	if (++gv->called_before)
 		FLEX_EXIT (exit_status);
 
-	if (ctrl.yyclass != NULL && !ctrl.C_plus_plus)
+	if (gv->ctrl.yyclass != NULL && !gv->ctrl.C_plus_plus)
 		flexerror (_("%option yyclass only meaningful for C++ scanners"));
 
-	if (skelfile != NULL) {
-		if (ferror (skelfile))
+	if (gv->skelfile != NULL) {
+		if (ferror (gv->skelfile))
 			lerr (_("input error reading skeleton file %s"),
-				env.skelname);
+				gv->env.skelname);
 
-		else if (fclose (skelfile))
+		else if (fclose (gv->skelfile))
 			lerr (_("error closing skeleton file %s"),
-				env.skelname);
+				gv->env.skelname);
 	}
 
-	if (exit_status != 0 && outfile_created) {
+	if (exit_status != 0 && gv->outfile_created) {
 		if (ferror (stdout))
 			lerr (_("error writing output file %s"),
-				env.outfilename);
+				gv->env.outfilename);
 
-		else if ((_stdout_closed = 1) && fclose (stdout))
+		else if ((gv->_stdout_closed = 1) && fclose (stdout))
 			lerr (_("error closing output file %s"),
-				env.outfilename);
+				gv->env.outfilename);
 
-		else if (unlink (env.outfilename))
+		else if (unlink (gv->env.outfilename))
 			lerr (_("error deleting output file %s"),
-				env.outfilename);
+				gv->env.outfilename);
 	}
 
 
-	if (env.backing_up_report && ctrl.backing_up_file) {
-		if (num_backing_up == 0)
-			fprintf (ctrl.backing_up_file, _("No backing up.\n"));
-		else if (ctrl.fullspd || ctrl.fulltbl)
-			fprintf (ctrl.backing_up_file,
+	if (gv->env.backing_up_report && gv->ctrl.backing_up_file) {
+		if (gv->num_backing_up == 0)
+			fprintf (gv->ctrl.backing_up_file, _("No backing up.\n"));
+		else if (gv->ctrl.fullspd || gv->ctrl.fulltbl)
+			fprintf (gv->ctrl.backing_up_file,
 				 _
 				 ("%d backing up (non-accepting) states.\n"),
-				 num_backing_up);
+				 gv->num_backing_up);
 		else
-			fprintf (ctrl.backing_up_file,
+			fprintf (gv->ctrl.backing_up_file,
 				 _("Compressed tables always back up.\n"));
 
-		if (ferror (ctrl.backing_up_file))
+		if (ferror (gv->ctrl.backing_up_file))
 			lerr (_("error writing backup file %s"),
-				backing_name);
+				gv->backing_name);
 
-		else if (fclose (ctrl.backing_up_file))
+		else if (fclose (gv->ctrl.backing_up_file))
 			lerr (_("error closing backup file %s"),
-				backing_name);
+				gv->backing_name);
 	}
 
-	if (env.printstats) {
+	if (gv->env.printstats) {
 		fprintf (stderr, _("%s version %s usage statistics:\n"),
-			 program_name, flex_version);
+			 gv->program_name, flex_version);
 
 		fprintf (stderr, _("  scanner options: -"));
 
-		if (ctrl.C_plus_plus)
+		if (gv->ctrl.C_plus_plus)
 			putc ('+', stderr);
-		if (env.backing_up_report)
+		if (gv->env.backing_up_report)
 			putc ('b', stderr);
-		if (ctrl.ddebug)
+		if (gv->ctrl.ddebug)
 			putc ('d', stderr);
 		if (sf_case_ins())
 			putc ('i', stderr);
-		if (ctrl.lex_compat)
+		if (gv->ctrl.lex_compat)
 			putc ('l', stderr);
-		if (ctrl.posix_compat)
+		if (gv->ctrl.posix_compat)
 			putc ('X', stderr);
-		if (env.performance_hint > 0)
+		if (gv->env.performance_hint > 0)
 			putc ('p', stderr);
-		if (env.performance_hint > 1)
+		if (gv->env.performance_hint > 1)
 			putc ('p', stderr);
-		if (ctrl.spprdflt)
+		if (gv->ctrl.spprdflt)
 			putc ('s', stderr);
-		if (ctrl.reentrant)
+		if (gv->ctrl.reentrant)
 			fputs ("--reentrant", stderr);
-        if (ctrl.bison_bridge_lval)
+        if (gv->ctrl.bison_bridge_lval)
             fputs ("--bison-bridge", stderr);
-        if (ctrl.bison_bridge_lloc)
+        if (gv->ctrl.bison_bridge_lloc)
             fputs ("--bison-locations", stderr);
-		if (env.use_stdout)
+		if (gv->env.use_stdout)
 			putc ('t', stderr);
-		if (env.printstats)
+		if (gv->env.printstats)
 			putc ('v', stderr);	/* always true! */
-		if (env.nowarn)
+		if (gv->env.nowarn)
 			putc ('w', stderr);
-		if (ctrl.interactive == trit_false)
+		if (gv->ctrl.interactive == trit_false)
 			putc ('B', stderr);
-		if (ctrl.interactive == trit_true)
+		if (gv->ctrl.interactive == trit_true)
 			putc ('I', stderr);
-		if (!ctrl.gen_line_dirs)
+		if (!gv->ctrl.gen_line_dirs)
 			putc ('L', stderr);
-		if (env.trace)
+		if (gv->env.trace)
 			putc ('T', stderr);
 
-		if (ctrl.csize == trit_unspecified)
+		if (gv->ctrl.csize == trit_unspecified)
 			/* We encountered an error fairly early on, so ctrl.csize
 			 * never got specified.  Define it now, to prevent
 			 * bogus table sizes being written out below.
 			 */
-			ctrl.csize = 256;
+			gv->ctrl.csize = 256;
 
-		if (ctrl.csize == 128)
+		if (gv->ctrl.csize == 128)
 			putc ('7', stderr);
 		else
 			putc ('8', stderr);
 
 		fprintf (stderr, " -C");
 
-		if (ctrl.long_align)
+		if (gv->ctrl.long_align)
 			putc ('a', stderr);
-		if (ctrl.fulltbl)
+		if (gv->ctrl.fulltbl)
 			putc ('f', stderr);
-		if (ctrl.fullspd)
+		if (gv->ctrl.fullspd)
 			putc ('F', stderr);
-		if (ctrl.useecs)
+		if (gv->ctrl.useecs)
 			putc ('e', stderr);
-		if (ctrl.usemecs)
+		if (gv->ctrl.usemecs)
 			putc ('m', stderr);
-		if (ctrl.use_read)
+		if (gv->ctrl.use_read)
 			putc ('r', stderr);
 
-		if (env.did_outfilename)
-			fprintf (stderr, " -o%s", env.outfilename);
+		if (gv->env.did_outfilename)
+			fprintf (stderr, " -o%s", gv->env.outfilename);
 
-		if (env.skelname != NULL)
-			fprintf (stderr, " -S%s", env.skelname);
+		if (gv->env.skelname != NULL)
+			fprintf (stderr, " -S%s", gv->env.skelname);
 
-		if (strcmp (ctrl.prefix, "yy"))
-			fprintf (stderr, " -P%s", ctrl.prefix);
+		if (strcmp (gv->ctrl.prefix, "yy"))
+			fprintf (stderr, " -P%s", gv->ctrl.prefix);
 
 		putc ('\n', stderr);
 
 		fprintf (stderr, _("  %d/%d NFA states\n"),
-			 lastnfa, current_mns);
+			 gv->lastnfa, gv->current_mns);
 		fprintf (stderr, _("  %d/%d DFA states (%d words)\n"),
-			 lastdfa, current_max_dfas, totnst);
+			 gv->lastdfa, gv->current_max_dfas, gv->totnst);
 		fprintf (stderr, _("  %d rules\n"),
-			 num_rules + num_eof_rules -
+			 gv->num_rules + gv->num_eof_rules -
 			 1 /* - 1 for def. rule */ );
 
-		if (num_backing_up == 0)
+		if (gv->num_backing_up == 0)
 			fprintf (stderr, _("  No backing up\n"));
-		else if (ctrl.fullspd || ctrl.fulltbl)
+		else if (gv->ctrl.fullspd || gv->ctrl.fulltbl)
 			fprintf (stderr,
 				 _
 				 ("  %d backing-up (non-accepting) states\n"),
-				 num_backing_up);
+				 gv->num_backing_up);
 		else
 			fprintf (stderr,
 				 _
 				 ("  Compressed tables always back-up\n"));
 
-		if (bol_needed)
+		if (gv->bol_needed)
 			fprintf (stderr,
 				 _("  Beginning-of-line patterns used\n"));
 
-		fprintf (stderr, _("  %d/%d start conditions\n"), lastsc,
-			 current_max_scs);
+		fprintf (stderr, _("  %d/%d start conditions\n"), gv->lastsc,
+			 gv->current_max_scs);
 		fprintf (stderr,
 			 _
 			 ("  %d epsilon states, %d double epsilon states\n"),
-			 numeps, eps2);
+			 gv->numeps, gv->eps2);
 
-		if (lastccl == 0)
+		if (gv->lastccl == 0)
 			fprintf (stderr, _("  no character classes\n"));
 		else
 			fprintf (stderr,
 				 _
 				 ("  %d/%d character classes needed %d/%d words of storage, %d reused\n"),
-				 lastccl, current_maxccls,
-				 cclmap[lastccl] + ccllen[lastccl],
-				 current_max_ccl_tbl_size, cclreuse);
+				 gv->lastccl, gv->current_maxccls,
+				 gv->cclmap[gv->lastccl] + gv->ccllen[gv->lastccl],
+				 gv->current_max_ccl_tbl_size, gv->cclreuse);
 
 		fprintf (stderr, _("  %d state/nextstate pairs created\n"),
-			 numsnpairs);
+			 gv->numsnpairs);
 		fprintf (stderr,
 			 _("  %d/%d unique/duplicate transitions\n"),
-			 numuniq, numdup);
+			 gv->numuniq, gv->numdup);
 
-		if (ctrl.fulltbl) {
-			tblsiz = lastdfa * numecs;
+		if (gv->ctrl.fulltbl) {
+			tblsiz = gv->lastdfa * gv->numecs;
 			fprintf (stderr, _("  %d table entries\n"),
 				 tblsiz);
 		}
 
 		else {
-			tblsiz = 2 * (lastdfa + numtemps) + 2 * tblend;
+			tblsiz = 2 * (gv->lastdfa + gv->numtemps) + 2 * gv->tblend;
 
 			fprintf (stderr,
 				 _("  %d/%d base-def entries created\n"),
-				 lastdfa + numtemps, current_max_dfas);
+				 gv->lastdfa + gv->numtemps, gv->current_max_dfas);
 			fprintf (stderr,
 				 _
 				 ("  %d/%d (peak %d) nxt-chk entries created\n"),
-				 tblend, current_max_xpairs, peakpairs);
+				 gv->tblend, gv->current_max_xpairs, gv->peakpairs);
 			fprintf (stderr,
 				 _
 				 ("  %d/%d (peak %d) template nxt-chk entries created\n"),
-				 numtemps * nummecs,
-				 current_max_template_xpairs,
-				 numtemps * numecs);
+				 gv->numtemps * gv->nummecs,
+				 gv->current_max_template_xpairs,
+				 gv->numtemps * gv->numecs);
 			fprintf (stderr, _("  %d empty table entries\n"),
-				 nummt);
+				 gv->nummt);
 			fprintf (stderr, _("  %d protos created\n"),
-				 numprots);
+				 gv->numprots);
 			fprintf (stderr,
 				 _("  %d templates created, %d uses\n"),
-				 numtemps, tmpuses);
+				 gv->numtemps, gv->tmpuses);
 		}
 
-		if (ctrl.useecs) {
-			tblsiz = tblsiz + ctrl.csize;
+		if (gv->ctrl.useecs) {
+			tblsiz = tblsiz + gv->ctrl.csize;
 			fprintf (stderr,
 				 _
 				 ("  %d/%d equivalence classes created\n"),
-				 numecs, ctrl.csize);
+				 gv->numecs, gv->ctrl.csize);
 		}
 
-		if (ctrl.usemecs) {
-			tblsiz = tblsiz + numecs;
+		if (gv->ctrl.usemecs) {
+			tblsiz = tblsiz + gv->numecs;
 			fprintf (stderr,
 				 _
 				 ("  %d/%d meta-equivalence classes created\n"),
-				 nummecs, ctrl.csize);
+				 gv->nummecs, gv->ctrl.csize);
 		}
 
 		fprintf (stderr,
 			 _
 			 ("  %d (%d saved) hash collisions, %d DFAs equal\n"),
-			 hshcol, hshsave, dfaeql);
+			 gv->hshcol, gv->hshsave, gv->dfaeql);
 		fprintf (stderr, _("  %d sets of reallocations needed\n"),
-			 num_reallocs);
+			 gv->num_reallocs);
 		fprintf (stderr, _("  %d total table entries needed\n"),
 			 tblsiz);
 	}
@@ -691,45 +709,45 @@ void flexinit (int argc, char **argv)
 	char   *arg;
 	scanopt_t sopt;
 
-	memset(&ctrl, '\0', sizeof(ctrl));
-	syntaxerror = false;
-	yymore_used = continued_action = false;
-	in_rule = reject = false;
-	ctrl.yymore_really_used = ctrl.reject_really_used = trit_unspecified;
+	memset(&gv->ctrl, '\0', sizeof(gv->ctrl));
+	gv->syntaxerror = false;
+	gv->yymore_used = gv->continued_action = false;
+	gv->in_rule = gv->reject = false;
+	gv->ctrl.yymore_really_used = gv->ctrl.reject_really_used = trit_unspecified;
 
-	ctrl.do_main = trit_unspecified;
-	ctrl.interactive = ctrl.csize = trit_unspecified;
-	ctrl.do_yywrap = ctrl.gen_line_dirs = ctrl.usemecs = ctrl.useecs = true;
-	ctrl.reentrant = ctrl.bison_bridge_lval = ctrl.bison_bridge_lloc = false;
-	env.performance_hint = 0;
-	ctrl.prefix = "yy";
-	ctrl.rewrite = false;
-	ctrl.yylmax = BUFSIZ;
+	gv->ctrl.do_main = trit_unspecified;
+	gv->ctrl.interactive = gv->ctrl.csize = trit_unspecified;
+	gv->ctrl.do_yywrap = gv->ctrl.gen_line_dirs = gv->ctrl.usemecs = gv->ctrl.useecs = true;
+	gv->ctrl.reentrant = gv->ctrl.bison_bridge_lval = gv->ctrl.bison_bridge_lloc = false;
+	gv->env.performance_hint = 0;
+	gv->ctrl.prefix = "yy";
+	gv->ctrl.rewrite = false;
+	gv->ctrl.yylmax = BUFSIZ;
 
-	tablesext = tablesverify = false;
-	gentables = true;
-	tablesfilename = tablesname = NULL;
+	gv->tablesext = gv->tablesverify = false;
+	gv->gentables = true;
+	gv->tablesfilename = gv->tablesname = NULL;
 
 	sawcmpflag = false;
 	
 	/* Initialize dynamic array for holding the rule actions. */
-	action_size = 2048;	/* default size of action array in bytes */
-	action_array = allocate_character_array (action_size);
-	defs1_offset = prolog_offset = action_offset = action_index = 0;
-	action_array[0] = '\0';
+	gv->action_size = 2048;	/* default size of action array in bytes */
+	gv->action_array = allocate_character_array (gv->action_size);
+	gv->defs1_offset = gv->prolog_offset = gv->action_offset = gv->action_index = 0;
+	gv->action_array[0] = '\0';
 
 	/* Initialize any buffers. */
-	buf_init (&userdef_buf, sizeof (char));	/* one long string */
-	buf_init (&top_buf, sizeof (char));	    /* one long string */
+	buf_init (&gv->userdef_buf, sizeof (char));	/* one long string */
+	buf_init (&gv->top_buf, sizeof (char));	    /* one long string */
 
 	sf_init ();
 
 	/* Enable C++ if program name ends with '+'. */
-	program_name = argv[0];
+	gv->program_name = argv[0];
 
-	if (program_name != NULL &&
-	    program_name[strlen (program_name) - 1] == '+')
-		ctrl.C_plus_plus = true;
+	if (gv->program_name != NULL &&
+	    gv->program_name[strlen (gv->program_name) - 1] == '+')
+		gv->ctrl.C_plus_plus = true;
 
 	/* read flags */
 	sopt = scanopt_init (flexopts, argc, argv, 0);
@@ -747,26 +765,26 @@ void flexinit (int argc, char **argv)
 			fprintf (stderr,
 				 _
 				 ("Try `%s --help' for more information.\n"),
-				 program_name);
+				 gv->program_name);
 			FLEX_EXIT (1);
 		}
 
 		switch ((enum flexopt_flag_t) rv) {
 		    case OPT_CPLUSPLUS:
-			ctrl.C_plus_plus = true;
+			gv->ctrl.C_plus_plus = true;
 			break;
 
 		    case OPT_BATCH:
-			ctrl.interactive = trit_false;
+			gv->ctrl.interactive = trit_false;
 			break;
 
 		    case OPT_BACKUP:
-			env.backing_up_report = trit_true;
+			gv->env.backing_up_report = trit_true;
 			break;
 
 		    case OPT_BACKUP_FILE:
-			env.backing_up_report = true;
-                        backing_name = arg;
+			gv->env.backing_up_report = true;
+                        gv->backing_name = arg;
 			break;
 
 		    case OPT_DONOTHING:
@@ -774,36 +792,36 @@ void flexinit (int argc, char **argv)
 
 		    case OPT_COMPRESSION:
 			if (!sawcmpflag) {
-				ctrl.useecs = false;
-				ctrl.usemecs = false;
-				ctrl.fulltbl = false;
+				gv->ctrl.useecs = false;
+				gv->ctrl.usemecs = false;
+				gv->ctrl.fulltbl = false;
 				sawcmpflag = true;
 			}
 
 			for (i = 0; arg && arg[i] != '\0'; i++)
 				switch (arg[i]) {
 				    case 'a':
-					ctrl.long_align = true;
+					gv->ctrl.long_align = true;
 					break;
 
 				    case 'e':
-					ctrl.useecs = true;
+					gv->ctrl.useecs = true;
 					break;
 
 				    case 'F':
-					ctrl.fullspd = true;
+					gv->ctrl.fullspd = true;
 					break;
 
 				    case 'f':
-					ctrl.fulltbl = true;
+					gv->ctrl.fulltbl = true;
 					break;
 
 				    case 'm':
-					ctrl.usemecs = true;
+					gv->ctrl.usemecs = true;
 					break;
 
 				    case 'r':
-					ctrl.use_read = true;
+					gv->ctrl.use_read = true;
 					break;
 
 				    default:
@@ -815,21 +833,21 @@ void flexinit (int argc, char **argv)
 			break;
 
 		    case OPT_DEBUG:
-			ctrl.ddebug = true;
+			gv->ctrl.ddebug = true;
 			break;
 
 		    case OPT_NO_DEBUG:
-			ctrl.ddebug = false;
+			gv->ctrl.ddebug = false;
 			break;
 
 		    case OPT_FULL:
-			ctrl.useecs = ctrl.usemecs = false;
-			ctrl.use_read = ctrl.fulltbl = true;
+			gv->ctrl.useecs = gv->ctrl.usemecs = false;
+			gv->ctrl.use_read = gv->ctrl.fulltbl = true;
 			break;
 
 		    case OPT_FAST:
-			ctrl.useecs = ctrl.usemecs = false;
-			ctrl.use_read = ctrl.fullspd = true;
+			gv->ctrl.useecs = gv->ctrl.usemecs = false;
+			gv->ctrl.use_read = gv->ctrl.fullspd = true;
 			break;
 
 		    case OPT_HELP:
@@ -837,7 +855,7 @@ void flexinit (int argc, char **argv)
 			FLEX_EXIT (0);
 
 		    case OPT_INTERACTIVE:
-			ctrl.interactive = true;
+			gv->ctrl.interactive = true;
 			break;
 
 		    case OPT_CASE_INSENSITIVE:
@@ -845,162 +863,162 @@ void flexinit (int argc, char **argv)
 			break;
 
 		    case OPT_LEX_COMPAT:
-			ctrl.lex_compat = true;
+			gv->ctrl.lex_compat = true;
 			break;
 
 		    case OPT_POSIX_COMPAT:
-			ctrl.posix_compat = true;
+			gv->ctrl.posix_compat = true;
 			break;
 
 		    case OPT_PREPROC_LEVEL:
-			preproc_level = (int) strtol(arg,NULL,0);
+			gv->preproc_level = (int) strtol(arg,NULL,0);
 			break;
 
 		    case OPT_MAIN:
-			ctrl.do_yywrap = false;
-			ctrl.do_main = trit_true;
+			gv->ctrl.do_yywrap = false;
+			gv->ctrl.do_main = trit_true;
 			break;
 
 		    case OPT_NO_MAIN:
-			ctrl.do_main = trit_false;
+			gv->ctrl.do_main = trit_false;
 			break;
 
 		    case OPT_NO_LINE:
-			ctrl.gen_line_dirs = false;
+			gv->ctrl.gen_line_dirs = false;
 			break;
 
 		    case OPT_OUTFILE:
-			env.outfilename = arg;
-			env.did_outfilename = 1;
+			gv->env.outfilename = arg;
+			gv->env.did_outfilename = 1;
 			break;
 
 		    case OPT_PREFIX:
-			ctrl.prefix = arg;
+			gv->ctrl.prefix = arg;
 			break;
 
 		    case OPT_PERF_REPORT:
-			++env.performance_hint;
+			++gv->env.performance_hint;
 			break;
 
 		    case OPT_BISON_BRIDGE:
-			ctrl.bison_bridge_lval = true;
+			gv->ctrl.bison_bridge_lval = true;
 			break;
 
 		    case OPT_BISON_BRIDGE_LOCATIONS:
-			ctrl.bison_bridge_lval = ctrl.bison_bridge_lloc = true;
+			gv->ctrl.bison_bridge_lval = gv->ctrl.bison_bridge_lloc = true;
 			break;
 
 		    case OPT_REENTRANT:
-			ctrl.reentrant = true;
+			gv->ctrl.reentrant = true;
 			break;
 
 		    case OPT_NO_REENTRANT:
-			ctrl.reentrant = false;
+			gv->ctrl.reentrant = false;
 			break;
 
 		    case OPT_SKEL:
-			env.skelname = arg;
+			gv->env.skelname = arg;
 			break;
 
 		    case OPT_DEFAULT:
-			ctrl.spprdflt = false;
+			gv->ctrl.spprdflt = false;
 			break;
 
 		    case OPT_NO_DEFAULT:
-			ctrl.spprdflt = true;
+			gv->ctrl.spprdflt = true;
 			break;
 
 		    case OPT_STDOUT:
-			env.use_stdout = true;
+			gv->env.use_stdout = true;
 			break;
 
 		    case OPT_NO_UNISTD_H:
-			ctrl.no_unistd = true;
+			gv->ctrl.no_unistd = true;
 			break;
 
 		    case OPT_TABLES_FILE:
-			tablesext = true;
-			tablesfilename = arg;
+			gv->tablesext = true;
+			gv->tablesfilename = arg;
 			break;
 
 		    case OPT_TABLES_VERIFY:
-			tablesverify = true;
+			gv->tablesverify = true;
 			break;
 
 		    case OPT_TRACE:
-			env.trace = true;
+			gv->env.trace = true;
 			break;
 
 		    case OPT_VERBOSE:
-			env.printstats = true;
+			gv->env.printstats = true;
 			break;
 
 		    case OPT_VERSION:
-			printf ("%s %s\n", (ctrl.C_plus_plus ? "flex++" : "flex"), flex_version);
+			printf ("%s %s\n", (gv->ctrl.C_plus_plus ? "flex++" : "flex"), flex_version);
 			FLEX_EXIT (0);
 
 		    case OPT_WARN:
-			env.nowarn = false;
+			gv->env.nowarn = false;
 			break;
 
 		    case OPT_NO_WARN:
-			env.nowarn = true;
+			gv->env.nowarn = true;
 			break;
 
 		    case OPT_7BIT:
-			ctrl.csize = 128;
+			gv->ctrl.csize = 128;
 			break;
 
 		    case OPT_8BIT:
-			ctrl.csize = CSIZE;
+			gv->ctrl.csize = CSIZE;
 			break;
 
 		    case OPT_ALIGN:
-			ctrl.long_align = true;
+			gv->ctrl.long_align = true;
 			break;
 
 		    case OPT_NO_ALIGN:
-			ctrl.long_align = false;
+			gv->ctrl.long_align = false;
 			break;
 
 		    case OPT_ALWAYS_INTERACTIVE:
-			ctrl.always_interactive = true;
+			gv->ctrl.always_interactive = true;
 			break;
 
 		    case OPT_NEVER_INTERACTIVE:
-			ctrl.never_interactive = true;
+			gv->ctrl.never_interactive = true;
 			break;
 
 		    case OPT_ARRAY:
-			ctrl.yytext_is_array = true;
+			gv->ctrl.yytext_is_array = true;
 			break;
 
 		    case OPT_POINTER:
-			ctrl.yytext_is_array = false;
+			gv->ctrl.yytext_is_array = false;
 			break;
 
 		    case OPT_ECS:
-			ctrl.useecs = true;
+			gv->ctrl.useecs = true;
 			break;
 
 		    case OPT_NO_ECS:
-			ctrl.useecs = false;
+			gv->ctrl.useecs = false;
 			break;
 
 		    case OPT_EMIT:
-			ctrl.emit = arg;
+			gv->ctrl.emit = arg;
 			break;
 
 		    case OPT_HEADER_FILE:
-			env.headerfilename = arg;
+			gv->env.headerfilename = arg;
 			break;
 
 		    case OPT_META_ECS:
-			ctrl.usemecs = true;
+			gv->ctrl.usemecs = true;
 			break;
 
 		    case OPT_NO_META_ECS:
-			ctrl.usemecs = false;
+			gv->ctrl.usemecs = false;
 			break;
 
 		    case OPT_PREPROCDEFINE:
@@ -1016,173 +1034,173 @@ void flexinit (int argc, char **argv)
 				    def = "1";
 
 			    snprintf(buf2, sizeof(buf2), "M4_HOOK_CONST_DEFINE_UNKNOWN(%s, %s)", arg, def);
-			    buf_strappend (&userdef_buf, buf2);
+			    buf_strappend (&gv->userdef_buf, buf2);
 		    }
 		    break;
 
 		    case OPT_READ:
-			ctrl.use_read = true;
+			gv->ctrl.use_read = true;
 			break;
 
 		    case OPT_STACK:
-			ctrl.stack_used = true;
+			gv->ctrl.stack_used = true;
 			break;
 
 		    case OPT_STDINIT:
-			ctrl.do_stdinit = true;
+			gv->ctrl.do_stdinit = true;
 			break;
 
 		    case OPT_NO_STDINIT:
-			ctrl.do_stdinit = false;
+			gv->ctrl.do_stdinit = false;
 			break;
 
 		    case OPT_YYCLASS:
-			ctrl.yyclass = arg;
+			gv->ctrl.yyclass = arg;
 			break;
 
 		    case OPT_YYLINENO:
-			ctrl.do_yylineno = true;
+			gv->ctrl.do_yylineno = true;
 			break;
 
 		    case OPT_NO_YYLINENO:
-			ctrl.do_yylineno = false;
+			gv->ctrl.do_yylineno = false;
 			break;
 
 		    case OPT_YYWRAP:
-			ctrl.do_yywrap = true;
+			gv->ctrl.do_yywrap = true;
 			break;
 
 		    case OPT_NO_YYWRAP:
-			ctrl.do_yywrap = false;
+			gv->ctrl.do_yywrap = false;
 			break;
 
 		    case OPT_YYMORE:
-			ctrl.yymore_really_used = true;
+			gv->ctrl.yymore_really_used = true;
 			break;
 
 		    case OPT_NO_YYMORE:
-			ctrl.yymore_really_used = false;
+			gv->ctrl.yymore_really_used = false;
 			break;
 
 		    case OPT_REJECT:
-			ctrl.reject_really_used = true;
+			gv->ctrl.reject_really_used = true;
 			break;
 
 		    case OPT_NO_REJECT:
-			ctrl.reject_really_used = false;
+			gv->ctrl.reject_really_used = false;
 			break;
 
 		    case OPT_NO_YY_PUSH_STATE:
-			ctrl.no_yy_push_state = true;
+			gv->ctrl.no_yy_push_state = true;
 			break;
 		    case OPT_NO_YY_POP_STATE:
-			ctrl.no_yy_pop_state = true;
+			gv->ctrl.no_yy_pop_state = true;
 			break;
 		    case OPT_NO_YY_TOP_STATE:
-			ctrl.no_yy_top_state = true;
+			gv->ctrl.no_yy_top_state = true;
 			break;
 		    case OPT_NO_YYINPUT:
-			ctrl.no_yyinput = true;
+			gv->ctrl.no_yyinput = true;
 			break;
 		    case OPT_NO_YYUNPUT:
-			ctrl.no_yyunput = true;
+			gv->ctrl.no_yyunput = true;
 			break;
 		    case OPT_NO_YY_SCAN_BUFFER:
-			ctrl.no_yy_scan_buffer = true;
+			gv->ctrl.no_yy_scan_buffer = true;
 			break;
 		    case OPT_NO_YY_SCAN_BYTES:
-			ctrl.no_yy_scan_bytes = true;
+			gv->ctrl.no_yy_scan_bytes = true;
 			break;
 		    case OPT_NO_YY_SCAN_STRING:
-			ctrl.no_yy_scan_string = true;
+			gv->ctrl.no_yy_scan_string = true;
 			break;
 		    case OPT_NO_YYGET_EXTRA:
-			ctrl.no_yyget_extra = true;
+			gv->ctrl.no_yyget_extra = true;
 			break;
 		    case OPT_NO_YYSET_EXTRA:
-			ctrl.no_yyset_extra = true;
+			gv->ctrl.no_yyset_extra = true;
 			break;
 		    case OPT_NO_YYGET_LENG:
-			ctrl.no_yyget_leng = true;
+			gv->ctrl.no_yyget_leng = true;
 			break;
 		    case OPT_NO_YYGET_TEXT:
-			ctrl.no_yyget_text = true;
+			gv->ctrl.no_yyget_text = true;
 			break;
 		    case OPT_NO_YYGET_LINENO:
-			ctrl.no_yyget_lineno = true;
+			gv->ctrl.no_yyget_lineno = true;
 			break;
 		    case OPT_NO_YYSET_LINENO:
-			ctrl.no_yyset_lineno = true;
+			gv->ctrl.no_yyset_lineno = true;
 			break;
 		    case OPT_NO_YYGET_COLUMN:
-			ctrl.no_yyget_column = true;
+			gv->ctrl.no_yyget_column = true;
 			break;
 		    case OPT_NO_YYSET_COLUMN:
-			ctrl.no_yyset_column = true;
+			gv->ctrl.no_yyset_column = true;
 			break;
 		    case OPT_NO_YYGET_IN:
-			ctrl.no_yyget_in = true;
+			gv->ctrl.no_yyget_in = true;
 			break;
 		    case OPT_NO_YYSET_IN:
-			ctrl.no_yyset_in = true;
+			gv->ctrl.no_yyset_in = true;
 			break;
 		    case OPT_NO_YYGET_OUT:
-			ctrl.no_yyget_out = true;
+			gv->ctrl.no_yyget_out = true;
 			break;
 		    case OPT_NO_YYSET_OUT:
-			ctrl.no_yyset_out = true;
+			gv->ctrl.no_yyset_out = true;
 			break;
 		    case OPT_NO_YYGET_LVAL:
-			ctrl.no_yyget_lval = true;
+			gv->ctrl.no_yyget_lval = true;
 			break;
 		    case OPT_NO_YYSET_LVAL:
-			ctrl.no_yyset_lval = true;
+			gv->ctrl.no_yyset_lval = true;
 			break;
 		    case OPT_NO_YYGET_LLOC:
-			ctrl.no_yyget_lloc = true;
+			gv->ctrl.no_yyget_lloc = true;
 			break;
 		    case OPT_NO_YYSET_LLOC:
-			ctrl.no_yyset_lloc = true;
+			gv->ctrl.no_yyset_lloc = true;
 			break;
 		    case OPT_NO_YYGET_DEBUG:
-			ctrl.no_get_debug = true;
+			gv->ctrl.no_get_debug = true;
 			break;
 		    case OPT_NO_YYSET_DEBUG:
-			ctrl.no_set_debug = true;
+			gv->ctrl.no_set_debug = true;
 			break;
 
 		    case OPT_HEX:
-			env.trace_hex = true;
+			gv->env.trace_hex = true;
                         break;
 		    case OPT_NO_SECT3_ESCAPE:
-                        ctrl.no_section3_escape = true;
+                        gv->ctrl.no_section3_escape = true;
                         break;
 		}		/* switch */
 	}			/* while scanopt() */
 
 	scanopt_destroy (sopt);
 
-	num_input_files = argc - optind;
-	input_files = argv + optind;
-	set_input_file (num_input_files > 0 ? input_files[0] : NULL);
+	gv->num_input_files = argc - optind;
+	gv->input_files = argv + optind;
+	set_input_file (gv->num_input_files > 0 ? gv->input_files[0] : NULL);
 
-	lastccl = lastsc = lastdfa = lastnfa = 0;
-	num_rules = num_eof_rules = default_rule = 0;
-	numas = numsnpairs = tmpuses = 0;
-	numecs = numeps = eps2 = num_reallocs = hshcol = dfaeql = totnst =
+	gv->lastccl = gv->lastsc = gv->lastdfa = gv->lastnfa = 0;
+	gv->num_rules = gv->num_eof_rules = gv->default_rule = 0;
+	gv->numas = gv->numsnpairs = gv->tmpuses = 0;
+	gv->numecs = gv->numeps = gv->eps2 = gv->num_reallocs = gv->hshcol = gv->dfaeql = gv->totnst =
 	    0;
-	numuniq = numdup = hshsave = datapos = dataline = 0;
-	eofseen = false;
-	num_backing_up = onesp = numprots = 0;
-	variable_trailing_context_rules = bol_needed = false;
+	gv->numuniq = gv->numdup = gv->hshsave = gv->datapos = gv->dataline = 0;
+	gv->eofseen = false;
+	gv->num_backing_up = gv->onesp = gv->numprots = 0;
+	gv->variable_trailing_context_rules = gv->bol_needed = false;
 
-	linenum = sectnum = 1;
-	firstprot = NIL;
+	gv->linenum = gv->sectnum = 1;
+	gv->firstprot = NIL;
 
 	/* Used in mkprot() so that the first proto goes in slot 1
 	 * of the proto queue.
 	 */
-	lastprot = 1;
+	gv->lastprot = 1;
 
 	set_up_initial_allocations ();
 }
@@ -1194,14 +1212,14 @@ void readin (void)
 {
 	char buf[256];
 
-	line_directive_out(NULL, infilename, linenum);
+	line_directive_out(NULL, gv->infilename, gv->linenum);
 
 	if (yyparse ()) {
 		pinpoint_message (_("fatal parse error"));
 		flexend (1);
 	}
 
-	if (syntaxerror)
+	if (gv->syntaxerror)
 		flexend (1);
 
 	/* On --emit, -e, or change backends This is where backend
@@ -1210,56 +1228,56 @@ void readin (void)
 	 * when %option emit was evaluated; this catches command-line
 	 * optiins and the default case.
 	 */
-	backend_by_name(ctrl.emit);
+	backend_by_name(gv->ctrl.emit);
 
 	initialize_output_filters();
 
 	yyout = stdout;
 
-	if (tablesext)
-		gentables = false;
+	if (gv->tablesext)
+		gv->gentables = false;
 
-	if (tablesverify)
+	if (gv->tablesverify)
 		/* force generation of C tables. */
-		gentables = true;
+		gv->gentables = true;
 
 
-	if (tablesext) {
+	if (gv->tablesext) {
 		FILE   *tablesout;
 		struct yytbl_hdr hdr;
 		char   *pname = 0;
 		size_t  nbytes = 0;
 
-		if (!tablesfilename) {
-			nbytes = strlen (ctrl.prefix) + strlen (tablesfile_template) + 2;
-			tablesfilename = pname = calloc(nbytes, 1);
-			snprintf (pname, nbytes, tablesfile_template, ctrl.prefix);
+		if (!gv->tablesfilename) {
+			nbytes = strlen (gv->ctrl.prefix) + strlen (gv->tablesfile_template) + 2;
+			gv->tablesfilename = pname = calloc(nbytes, 1);
+			snprintf (pname, nbytes, gv->tablesfile_template, gv->ctrl.prefix);
 		}
 
-		if ((tablesout = fopen (tablesfilename, "w")) == NULL)
-			lerr (_("could not create %s"), tablesfilename);
+		if ((tablesout = fopen (gv->tablesfilename, "w")) == NULL)
+			lerr (_("could not create %s"), gv->tablesfilename);
 		free(pname);
-		tablesfilename = 0;
+		gv->tablesfilename = 0;
 
-		yytbl_writer_init (&tableswr, tablesout);
+		yytbl_writer_init (&gv->tableswr, tablesout);
 
-		nbytes = strlen (ctrl.prefix) + strlen ("tables") + 2;
-		tablesname = calloc(nbytes, 1);
-		snprintf (tablesname, nbytes, "%stables", ctrl.prefix);
-		yytbl_hdr_init (&hdr, flex_version, tablesname);
+		nbytes = strlen (gv->ctrl.prefix) + strlen ("tables") + 2;
+		gv->tablesname = calloc(nbytes, 1);
+		snprintf (gv->tablesname, nbytes, "%stables", gv->ctrl.prefix);
+		yytbl_hdr_init (&hdr, flex_version, gv->tablesname);
 
-		if (yytbl_hdr_fwrite (&tableswr, &hdr) <= 0)
+		if (yytbl_hdr_fwrite (&gv->tableswr, &hdr) <= 0)
 			flexerror (_("could not write tables header"));
 	}
 
-	if (env.skelname && (skelfile = fopen (env.skelname, "r")) == NULL)
-		lerr (_("can't open skeleton file %s"), env.skelname);
+	if (gv->env.skelname && (gv->skelfile = fopen (gv->env.skelname, "r")) == NULL)
+		lerr (_("can't open skeleton file %s"), gv->env.skelname);
 
-	if (strchr(ctrl.prefix, '[') || strchr(ctrl.prefix, ']'))
+	if (strchr(gv->ctrl.prefix, '[') || strchr(gv->ctrl.prefix, ']'))
 		flexerror(_("Prefix cannot include '[' or ']'"));
 
-	if (env.did_outfilename)
-		line_directive_out (stdout, NULL, linenum);
+	if (gv->env.did_outfilename)
+		line_directive_out (stdout, NULL, gv->linenum);
 
 	/* This is where we begin writing to the file. */
 
@@ -1268,36 +1286,36 @@ void readin (void)
 	comment("A lexical scanner generated by flex\n");
 
 	/* Dump the %top code. */
-	if( top_buf.elts)
-		outn((char*) top_buf.elts);
+	if( gv->top_buf.elts)
+		outn((char*) gv->top_buf.elts);
 
 	/* Place a bogus line directive, it will be fixed in the filter. */
 	line_directive_out(NULL, NULL, 0);
 
 	/* User may want to set the scanner prototype */
-	if (ctrl.yydecl != NULL) {
-		out_str ("M4_HOOK_SET_YY_DECL(%s)\n", ctrl.yydecl);
+	if (gv->ctrl.yydecl != NULL) {
+		out_str ("M4_HOOK_SET_YY_DECL(%s)\n", gv->ctrl.yydecl);
 	}
 
-	if (ctrl.userinit != NULL) {
-		out_str ("M4_HOOK_SET_USERINIT(%s)\n", ctrl.userinit);
+	if (gv->ctrl.userinit != NULL) {
+		out_str ("M4_HOOK_SET_USERINIT(%s)\n", gv->ctrl.userinit);
 	}
-	if (ctrl.preaction != NULL) {
-		out_str ("M4_HOOK_SET_PREACTION(%s)\n", ctrl.preaction);
+	if (gv->ctrl.preaction != NULL) {
+		out_str ("M4_HOOK_SET_PREACTION(%s)\n", gv->ctrl.preaction);
 	}
-	if (ctrl.postaction != NULL) {
-		out_str ("M4_HOOK_SET_POSTACTION(%s)\n", ctrl.postaction);
+	if (gv->ctrl.postaction != NULL) {
+		out_str ("M4_HOOK_SET_POSTACTION(%s)\n", gv->ctrl.postaction);
 	}
 
 	/* This has to be a straight textual substitution rather
 	 * than a constant declaration because in C a const is
 	 * not const enough to be a static array bound.
 	 */
-	out_dec ("m4_define([[YYLMAX]], [[%d]])\n", ctrl.yylmax);
+	out_dec ("m4_define([[YYLMAX]], [[%d]])\n", gv->ctrl.yylmax);
 
 	/* Dump the user defined preproc directives. */
-	if (userdef_buf.elts)
-		outn ((char *) (userdef_buf.elts));
+	if (gv->userdef_buf.elts)
+		outn ((char *) (gv->userdef_buf.elts));
 
 	/* If the user explicitly requested posix compatibility by specifying the
 	 * posix-compat option, then we check for conflicting options. However, if
@@ -1308,7 +1326,7 @@ void readin (void)
 	 * Note: The posix option was added to flex to provide the posix behavior
 	 * of the repeat operator in regular expressions, e.g., `ab{3}'
 	 */
-	if (ctrl.posix_compat) {
+	if (gv->ctrl.posix_compat) {
 		/* TODO: This is where we try to make flex behave according to
 		 * POSIX, *and* check for conflicting ctrl. How far should we go
 		 * with this? Should we disable all the neat-o flex features?
@@ -1317,32 +1335,32 @@ void readin (void)
 	}
 
 	if (getenv ("POSIXLY_CORRECT")) {
-		ctrl.posix_compat = true;
+		gv->ctrl.posix_compat = true;
 	}
 
-	if (env.backing_up_report) {
-		ctrl.backing_up_file = fopen (backing_name, "w");
-		if (ctrl.backing_up_file == NULL)
+	if (gv->env.backing_up_report) {
+		gv->ctrl.backing_up_file = fopen (gv->backing_name, "w");
+		if (gv->ctrl.backing_up_file == NULL)
 			lerr (_
 				("could not create backing-up info file %s"),
-				backing_name);
+				gv->backing_name);
 	}
 
 	else
-		ctrl.backing_up_file = NULL;
+		gv->ctrl.backing_up_file = NULL;
 
-	if (ctrl.yymore_really_used == true)
-		yymore_used = true;
-	else if (ctrl.yymore_really_used == false)
-		yymore_used = false;
+	if (gv->ctrl.yymore_really_used == true)
+		gv->yymore_used = true;
+	else if (gv->ctrl.yymore_really_used == false)
+		gv->yymore_used = false;
 
-	if (ctrl.reject_really_used == true)
-		reject = true;
-	else if (ctrl.reject_really_used == false)
-		reject = false;
+	if (gv->ctrl.reject_really_used == true)
+		gv->reject = true;
+	else if (gv->ctrl.reject_really_used == false)
+		gv->reject = false;
 
-	if (env.performance_hint > 0) {
-		if (ctrl.lex_compat) {
+	if (gv->env.performance_hint > 0) {
+		if (gv->ctrl.lex_compat) {
 			fprintf (stderr,
 				 _
 				 ("-l AT&T lex compatibility option entails a large performance penalty\n"));
@@ -1351,46 +1369,46 @@ void readin (void)
 				 (" and may be the actual source of other reported performance penalties\n"));
 		}
 
-		else if (ctrl.do_yylineno) {
+		else if (gv->ctrl.do_yylineno) {
 			fprintf (stderr,
 				 _
 				 ("%%option yylineno entails a performance penalty ONLY on rules that can match newline characters\n"));
 		}
 
-		if (env.performance_hint > 1) {
-			if (ctrl.interactive == trit_true)
+		if (gv->env.performance_hint > 1) {
+			if (gv->ctrl.interactive == trit_true)
 				fprintf (stderr,
 					 _
 					 ("-I (interactive) entails a minor performance penalty\n"));
 
-			if (yymore_used)
+			if (gv->yymore_used)
 				fprintf (stderr,
 					 _
 					 ("yymore() entails a minor performance penalty\n"));
 		}
 
-		if (reject)
+		if (gv->reject)
 			fprintf (stderr,
 				 _
 				 ("REJECT entails a large performance penalty\n"));
 
-		if (variable_trailing_context_rules)
+		if (gv->variable_trailing_context_rules)
 			fprintf (stderr,
 				 _
 				 ("Variable trailing context rules entail a large performance penalty\n"));
 	}
 
-	if (reject)
-		real_reject = true;
+	if (gv->reject)
+		gv->real_reject = true;
 
-	if (variable_trailing_context_rules)
-		reject = true;
+	if (gv->variable_trailing_context_rules)
+		gv->reject = true;
 
-	if ((ctrl.fulltbl || ctrl.fullspd) && reject) {
-		if (real_reject)
+	if ((gv->ctrl.fulltbl || gv->ctrl.fullspd) && gv->reject) {
+		if (gv->real_reject)
 			flexerror (_
 				   ("REJECT cannot be used with -f or -F"));
-		else if (ctrl.do_yylineno)
+		else if (gv->ctrl.do_yylineno)
 			flexerror (_
 				   ("%option yylineno cannot be used with REJECT"));
 		else
@@ -1398,23 +1416,23 @@ void readin (void)
 				   ("variable trailing context rules cannot be used with -f or -F"));
 	}
 
-	if (ctrl.useecs)
-		numecs = cre8ecs (nextecm, ecgroup, ctrl.csize);
+	if (gv->ctrl.useecs)
+		gv->numecs = cre8ecs (gv->nextecm, gv->ecgroup, gv->ctrl.csize);
 	else
-		numecs = ctrl.csize;
+		gv->numecs = gv->ctrl.csize;
 
 	/* Now map the equivalence class for NUL to its expected place. */
-	ecgroup[0] = ecgroup[ctrl.csize];
-	NUL_ec = ABS (ecgroup[0]);
+	gv->ecgroup[0] = gv->ecgroup[gv->ctrl.csize];
+	gv->NUL_ec = ABS (gv->ecgroup[0]);
 
-	if (ctrl.useecs)
+	if (gv->ctrl.useecs)
 		ccl2ecl ();
 
 	// These are used to conditionalize code in the lex skeleton
 	// that historically used to be generated by C code in flex
 	// itself; by shoving all this stuff out to the skeleton file
 	// we make it easier to retarget the code generation.
-	snprintf(buf, sizeof(buf), "Target: %s\n", ctrl.backend_name);
+	snprintf(buf, sizeof(buf), "Target: %s\n", gv->ctrl.backend_name);
 	comment(buf);
 	comment("START of m4 controls\n");
 
@@ -1423,15 +1441,15 @@ void readin (void)
 		struct Buf tmpbuf;
 		int i;
 		buf_init(&tmpbuf, sizeof(char));
-		for (i = 1; i <= lastsc; i++) {
+		for (i = 1; i <= gv->lastsc; i++) {
 			char *str, *fmt = "M4_HOOK_CONST_DEFINE_STATE(%s, %d)";
 			size_t strsz;
 
-			strsz = strlen(fmt) + strlen(scname[i]) + (size_t)(1 + ceil (log10(i))) + 2;
+			strsz = strlen(fmt) + strlen(gv->scname[i]) + (size_t)(1 + ceil (log10(i))) + 2;
 			str = malloc(strsz);
 			if (!str)
 				flexfatal(_("allocation of macro definition failed"));
-			snprintf(str, strsz, fmt, scname[i], i - 1);
+			snprintf(str, strsz, fmt, gv->scname[i], i - 1);
 			buf_strappend(&tmpbuf, str);
 			free(str);
 		}
@@ -1440,235 +1458,235 @@ void readin (void)
 		buf_destroy(&tmpbuf);
 	}
 
-	if (ctrl.bison_bridge_lval)
+	if (gv->ctrl.bison_bridge_lval)
 		visible_define("M4_YY_BISON_LVAL");
 
-	if (ctrl.bison_bridge_lloc)
+	if (gv->ctrl.bison_bridge_lloc)
 		visible_define("<M4_YY_BISON_LLOC>");
 
-	if (extra_type != NULL)
-		visible_define_str ("M4_MODE_EXTRA_TYPE", extra_type);
+	if (gv->extra_type != NULL)
+		visible_define_str ("M4_MODE_EXTRA_TYPE", gv->extra_type);
 
 	/* always generate the tablesverify flag. */
-	visible_define_str ("M4_YY_TABLES_VERIFY", tablesverify ? "1" : "0");
+	visible_define_str ("M4_YY_TABLES_VERIFY", gv->tablesverify ? "1" : "0");
 
-	if (ctrl.reentrant) {
+	if (gv->ctrl.reentrant) {
 		visible_define ("M4_YY_REENTRANT");
-		if (ctrl.yytext_is_array)
+		if (gv->ctrl.yytext_is_array)
 			visible_define ("M4_MODE_REENTRANT_TEXT_IS_ARRAY");
 	}
 
-	if (ctrl.do_main == trit_true)
+	if (gv->ctrl.do_main == trit_true)
 		visible_define_str ( "YY_MAIN", "1");
-	else if (ctrl.do_main == trit_false)
+	else if (gv->ctrl.do_main == trit_false)
 		visible_define_str ( "YY_MAIN", "0");
 
-	if (ctrl.do_stdinit)
+	if (gv->ctrl.do_stdinit)
 		visible_define ( "M4_MODE_DO_STDINIT");
 	else
 		visible_define ( "M4_MODE_NO_DO_STDINIT");
 
 	// mode switches for YY_DO_BEFORE_ACTION code generation
-	if (ctrl.yytext_is_array)
+	if (gv->ctrl.yytext_is_array)
 		visible_define ( "M4_MODE_YYTEXT_IS_ARRAY");
 	else
 		visible_define ( "M4_MODE_NO_YYTEXT_IS_ARRAY");
-	if (yymore_used)
+	if (gv->yymore_used)
 		visible_define ( "M4_MODE_YYMORE_USED");
 	else
 		visible_define ( "M4_MODE_NO_YYMORE_USED");
 
-	if (ctrl.fullspd)
+	if (gv->ctrl.fullspd)
 		visible_define ( "M4_MODE_REAL_FULLSPD");
 	else
 		visible_define ( "M4_MODE_NO_REAL_FULLSPD");
 
-	if (ctrl.fulltbl)
+	if (gv->ctrl.fulltbl)
 		visible_define ( "M4_MODE_REAL_FULLTBL");
 	else
 		visible_define ( "M4_MODE_NO_REAL_FULLTBL");
 
 	// niode switches for YYINPUT code generation
-	if (ctrl.use_read)
+	if (gv->ctrl.use_read)
 		visible_define ( "M4_MODE_CPP_USE_READ");
 	else
 		visible_define ( "M4_MODE_NO_CPP_USE_READ");
 
 	// mode switches for next-action code
-	if (variable_trailing_context_rules) {
+	if (gv->variable_trailing_context_rules) {
 		visible_define ( "M4_MODE_VARIABLE_TRAILING_CONTEXT_RULES");
 	} else {
 		visible_define ( "M4_MODE_NO_VARIABLE_TRAILING_CONTEXT_RULES");
 	}
-	if (real_reject)
+	if (gv->real_reject)
 		visible_define ( "M4_MODE_REAL_REJECT");
-	if (ctrl.reject_really_used)
+	if (gv->ctrl.reject_really_used)
 		visible_define ( "M4_MODE_FIND_ACTION_REJECT_REALLY_USED");
-	if (reject)
+	if (gv->reject)
 		visible_define ( "M4_MODE_USES_REJECT");
 	else
 		visible_define ( "M4_MODE_NO_USES_REJECT");
 
 	// mode switches for computing next compressed state
-	if (ctrl.usemecs)
+	if (gv->ctrl.usemecs)
 		visible_define ( "M4_MODE_USEMECS");
 
 	// mode switches for find-action code
-	if (ctrl.fullspd)
+	if (gv->ctrl.fullspd)
 		visible_define ( "M4_MODE_FULLSPD");
-	else if (ctrl.fulltbl)
+	else if (gv->ctrl.fulltbl)
 	    visible_define ( "M4_MODE_FIND_ACTION_FULLTBL");
-	else if (reject)
+	else if (gv->reject)
 	    visible_define ( "M4_MODE_FIND_ACTION_REJECT");
 	else
 	    visible_define ( "M4_MODE_FIND_ACTION_COMPRESSED");
 
 	// mode switches for backup generation and gen_start_state
-	if (!ctrl.fullspd)
+	if (!gv->ctrl.fullspd)
 		visible_define ( "M4_MODE_NO_FULLSPD");
-	if (bol_needed)
+	if (gv->bol_needed)
 		visible_define ( "M4_MODE_BOL_NEEDED");
 	else
 		visible_define ( "M4_MODE_NO_BOL_NEEDED");
 
 	// yylineno
-	if (ctrl.do_yylineno)
+	if (gv->ctrl.do_yylineno)
 		visible_define ( "M4_MODE_YYLINENO");
 
 	// Equivalence classes
-	if (ctrl.useecs)
+	if (gv->ctrl.useecs)
 		visible_define ( "M4_MODE_USEECS");
 	else
 		visible_define ( "M4_MODE_NO_USEECS");
 
 	// mode switches for getting next action
-	if (gentables)
+	if (gv->gentables)
 		visible_define ( "M4_MODE_GENTABLES");
 	else
 		visible_define ( "M4_MODE_NO_GENTABLES");
-	if (ctrl.interactive == trit_true)
+	if (gv->ctrl.interactive == trit_true)
 		visible_define ( "M4_MODE_INTERACTIVE");
 	else
 		visible_define ( "M4_MODE_NO_INTERACTIVE");
-	if (!(ctrl.fullspd || ctrl.fulltbl))
+	if (!(gv->ctrl.fullspd || gv->ctrl.fulltbl))
 		visible_define ( "M4_MODE_NO_FULLSPD_OR_FULLTBL");
-	if (reject || ctrl.interactive == trit_true)
+	if (gv->reject || gv->ctrl.interactive == trit_true)
 		visible_define ( "M4_MODE_FIND_ACTION_REJECT_OR_INTERACTIVE");
 
-	if (ctrl.yyclass != NULL) {
+	if (gv->ctrl.yyclass != NULL) {
 		visible_define ( "M4_MODE_YYCLASS");
-		out_m4_define("M4_YY_CLASS_NAME", ctrl.yyclass);
+		out_m4_define("M4_YY_CLASS_NAME", gv->ctrl.yyclass);
 	}
 
-	if (ctrl.ddebug)
+	if (gv->ctrl.ddebug)
 		visible_define ( "M4_MODE_DEBUG");
 
-	if (ctrl.lex_compat)
+	if (gv->ctrl.lex_compat)
 		visible_define ( "M4_MODE_OPTIONS.LEX_COMPAT");
 
-	if (ctrl.do_yywrap)
+	if (gv->ctrl.do_yywrap)
 		visible_define ( "M4_MODE_YYWRAP");
 	else
 		visible_define ( "M4_MODE_NO_YYWRAP");
 
-	if (ctrl.interactive == trit_true)
+	if (gv->ctrl.interactive == trit_true)
 		visible_define ( "M4_MODE_INTERACTIVE");
 
-	if (ctrl.noyyread)
+	if (gv->ctrl.noyyread)
 		visible_define("M4_MODE_USER_YYREAD");
 
 	if (is_default_backend()) {
-		if (ctrl.C_plus_plus) {
+		if (gv->ctrl.C_plus_plus) {
 			visible_define ( "M4_MODE_CXX_ONLY");
 		} else {
 			visible_define ( "M4_MODE_C_ONLY");
 		}
 	}
 
-	if (tablesext)
+	if (gv->tablesext)
 		visible_define ( "M4_MODE_TABLESEXT");
-	if (ctrl.prefix != NULL)
-	    visible_define_str ( "M4_MODE_PREFIX", ctrl.prefix);
+	if (gv->ctrl.prefix != NULL)
+	    visible_define_str ( "M4_MODE_PREFIX", gv->ctrl.prefix);
 
-	if (ctrl.no_yyinput)
+	if (gv->ctrl.no_yyinput)
 		visible_define("M4_MODE_NO_YYINPUT");
 
-	if (ctrl.bufsize != 0)
-	    visible_define_int("M4_MODE_YY_BUFSIZE", ctrl.bufsize);
+	if (gv->ctrl.bufsize != 0)
+	    visible_define_int("M4_MODE_YY_BUFSIZE", gv->ctrl.bufsize);
 
-	if (ctrl.yyterminate != NULL)
-	    visible_define_str("M4_MODE_YYTERMINATE", ctrl.yyterminate);
+	if (gv->ctrl.yyterminate != NULL)
+	    visible_define_str("M4_MODE_YYTERMINATE", gv->ctrl.yyterminate);
 	
-	if (ctrl.no_yypanic)
+	if (gv->ctrl.no_yypanic)
 		visible_define("M4_YY_NO_YYPANIC");
-	if (ctrl.no_yy_push_state)
+	if (gv->ctrl.no_yy_push_state)
 		visible_define("M4_YY_NO_PUSH_STATE");
-	if (ctrl.no_yy_pop_state)
+	if (gv->ctrl.no_yy_pop_state)
 		visible_define("M4_YY_NO_POP_STATE");
-	if (ctrl.no_yy_top_state)
+	if (gv->ctrl.no_yy_top_state)
 		visible_define("M4_YY_NO_TOP_STATE");
-	if (ctrl.no_yyunput)
+	if (gv->ctrl.no_yyunput)
 		visible_define("M4_YY_NO_YYUNPUT");
-	if (ctrl.no_yy_scan_buffer)
+	if (gv->ctrl.no_yy_scan_buffer)
 		visible_define("M4_YY_NO_SCAN_BUFFER");
-	if (ctrl.no_yy_scan_bytes)
+	if (gv->ctrl.no_yy_scan_bytes)
 		visible_define("M4_YY_NO_SCAN_BYTES");
-	if (ctrl.no_yy_scan_string)
+	if (gv->ctrl.no_yy_scan_string)
 		visible_define("M4_YY_NO_SCAN_STRING");
-	if (ctrl.no_yyget_extra)
+	if (gv->ctrl.no_yyget_extra)
 		visible_define("M4_YY_NO_GET_EXTRA");
-	if (ctrl.no_yyset_extra)
+	if (gv->ctrl.no_yyset_extra)
 		visible_define("M4_YY_NO_SET_EXTRA");
-	if (ctrl.no_yyget_leng)
+	if (gv->ctrl.no_yyget_leng)
 		visible_define("M4_YY_NO_GET_LENG");
-	if (ctrl.no_yyget_text)
+	if (gv->ctrl.no_yyget_text)
 		visible_define("M4_YY_NO_GET_TEXT");
-	if (ctrl.no_yyget_lineno)
+	if (gv->ctrl.no_yyget_lineno)
 		visible_define("M4_YY_NO_GET_LINENO");
-	if (ctrl.no_yyset_lineno)
+	if (gv->ctrl.no_yyset_lineno)
 		visible_define("M4_YY_NO_SET_LINENO");
-	if (ctrl.no_yyget_column)
+	if (gv->ctrl.no_yyget_column)
 		visible_define("M4_YY_NO_GET_COLUMN");
-	if (ctrl.no_yyset_column)
+	if (gv->ctrl.no_yyset_column)
 		visible_define("M4_YY_NO_SET_COLUMN");
-	if (ctrl.no_yyget_in)
+	if (gv->ctrl.no_yyget_in)
 		visible_define("M4_YY_NO_GET_IN");
-	if (ctrl.no_yyset_in)
+	if (gv->ctrl.no_yyset_in)
 		visible_define("M4_YY_NO_SET_IN");
-	if (ctrl.no_yyget_out)
+	if (gv->ctrl.no_yyget_out)
 		visible_define("M4_YY_NO_GET_OUT");
-	if (ctrl.no_yyset_out)
+	if (gv->ctrl.no_yyset_out)
 		visible_define("M4_YY_NO_SET_OUT");
-	if (ctrl.no_yyget_lval)
+	if (gv->ctrl.no_yyget_lval)
 		visible_define("M4_YY_NO_GET_LVAL");
-	if (ctrl.no_yyset_lval)
+	if (gv->ctrl.no_yyset_lval)
 		visible_define("M4_YY_NO_SET_LVAL");
-	if (ctrl.no_yyget_lloc)
+	if (gv->ctrl.no_yyget_lloc)
 		visible_define("M4_YY_NO_GET_LLOC");
-	if (ctrl.no_yyset_lloc)
+	if (gv->ctrl.no_yyset_lloc)
 		visible_define("M4_YY_NO_SET_LLOC");
-	if (ctrl.no_flex_alloc)
+	if (gv->ctrl.no_flex_alloc)
 		visible_define("M4_YY_NO_FLEX_ALLOC");
-	if (ctrl.no_flex_realloc)
+	if (gv->ctrl.no_flex_realloc)
 		visible_define("M4_YY_NO_FLEX_REALLOC");
-	if (ctrl.no_flex_free)
+	if (gv->ctrl.no_flex_free)
 		visible_define("M4_YY_NO_FLEX_FREE");
-	if (ctrl.no_get_debug)
+	if (gv->ctrl.no_get_debug)
 		visible_define("M4_YY_NO_GET_DEBUG");
-	if (ctrl.no_set_debug)
+	if (gv->ctrl.no_set_debug)
 		visible_define("M4_YY_NO_SET_DEBUG");
 
-	if (ctrl.no_unistd)
+	if (gv->ctrl.no_unistd)
 		visible_define("M4_YY_NO_UNISTD_H");
 
-	if (ctrl.always_interactive)
+	if (gv->ctrl.always_interactive)
 		visible_define("M4_YY_ALWAYS_INTERACTIVE");
-	if (ctrl.never_interactive)
+	if (gv->ctrl.never_interactive)
 		visible_define("M4_YY_NEVER_INTERACTIVE");
-	if (ctrl.stack_used)
+	if (gv->ctrl.stack_used)
 		visible_define("M4_YY_STACK_USED");
 
-	if (ctrl.rewrite)
+	if (gv->ctrl.rewrite)
 		visible_define ( "M4_MODE_REWRITE");
 	else
 		visible_define ( "M4_MODE_NO_REWRITE");
@@ -1681,60 +1699,60 @@ void readin (void)
 
 void set_up_initial_allocations (void)
 {
-	maximum_mns = (ctrl.long_align ? MAXIMUM_MNS_LONG : MAXIMUM_MNS);
-	current_mns = INITIAL_MNS;
-	firstst = allocate_integer_array (current_mns);
-	lastst = allocate_integer_array (current_mns);
-	finalst = allocate_integer_array (current_mns);
-	transchar = allocate_integer_array (current_mns);
-	trans1 = allocate_integer_array (current_mns);
-	trans2 = allocate_integer_array (current_mns);
-	accptnum = allocate_integer_array (current_mns);
-	assoc_rule = allocate_integer_array (current_mns);
-	state_type = allocate_integer_array (current_mns);
+	gv->maximum_mns = (gv->ctrl.long_align ? MAXIMUM_MNS_LONG : MAXIMUM_MNS);
+	gv->current_mns = INITIAL_MNS;
+	gv->firstst = allocate_integer_array (gv->current_mns);
+	gv->lastst = allocate_integer_array (gv->current_mns);
+	gv->finalst = allocate_integer_array (gv->current_mns);
+	gv->transchar = allocate_integer_array (gv->current_mns);
+	gv->trans1 = allocate_integer_array (gv->current_mns);
+	gv->trans2 = allocate_integer_array (gv->current_mns);
+	gv->accptnum = allocate_integer_array (gv->current_mns);
+	gv->assoc_rule = allocate_integer_array (gv->current_mns);
+	gv->state_type = allocate_integer_array (gv->current_mns);
 
-	current_max_rules = INITIAL_MAX_RULES;
-	rule_type = allocate_integer_array (current_max_rules);
-	rule_linenum = allocate_integer_array (current_max_rules);
-	rule_useful = allocate_array(current_max_rules, sizeof(char));
-	rule_has_nl = allocate_array(current_max_rules, sizeof(char));
+	gv->current_max_rules = INITIAL_MAX_RULES;
+	gv->rule_type = allocate_integer_array (gv->current_max_rules);
+	gv->rule_linenum = allocate_integer_array (gv->current_max_rules);
+	gv->rule_useful = allocate_array(gv->current_max_rules, sizeof(char));
+	gv->rule_has_nl = allocate_array(gv->current_max_rules, sizeof(char));
 
-	current_max_scs = INITIAL_MAX_SCS;
-	scset = allocate_integer_array (current_max_scs);
-	scbol = allocate_integer_array (current_max_scs);
-	scxclu = allocate_array(current_max_scs, sizeof(char));
-	sceof = allocate_array(current_max_scs, sizeof(char));
-	scname = allocate_char_ptr_array (current_max_scs);
+	gv->current_max_scs = INITIAL_MAX_SCS;
+	gv->scset = allocate_integer_array (gv->current_max_scs);
+	gv->scbol = allocate_integer_array (gv->current_max_scs);
+	gv->scxclu = allocate_array(gv->current_max_scs, sizeof(char));
+	gv->sceof = allocate_array(gv->current_max_scs, sizeof(char));
+	gv->scname = allocate_char_ptr_array (gv->current_max_scs);
 
-	current_maxccls = INITIAL_MAX_CCLS;
-	cclmap = allocate_integer_array (current_maxccls);
-	ccllen = allocate_integer_array (current_maxccls);
-	cclng = allocate_integer_array (current_maxccls);
-	ccl_has_nl = allocate_array(current_maxccls, sizeof(char));
+	gv->current_maxccls = INITIAL_MAX_CCLS;
+	gv->cclmap = allocate_integer_array (gv->current_maxccls);
+	gv->ccllen = allocate_integer_array (gv->current_maxccls);
+	gv->cclng = allocate_integer_array (gv->current_maxccls);
+	gv->ccl_has_nl = allocate_array(gv->current_maxccls, sizeof(char));
 
-	current_max_ccl_tbl_size = INITIAL_MAX_CCL_TBL_SIZE;
-	ccltbl = allocate_Character_array (current_max_ccl_tbl_size);
+	gv->current_max_ccl_tbl_size = INITIAL_MAX_CCL_TBL_SIZE;
+	gv->ccltbl = allocate_Character_array (gv->current_max_ccl_tbl_size);
 
-	current_max_dfa_size = INITIAL_MAX_DFA_SIZE;
+	gv->current_max_dfa_size = INITIAL_MAX_DFA_SIZE;
 
-	current_max_xpairs = INITIAL_MAX_XPAIRS;
-	nxt = allocate_integer_array (current_max_xpairs);
-	chk = allocate_integer_array (current_max_xpairs);
+	gv->current_max_xpairs = INITIAL_MAX_XPAIRS;
+	gv->nxt = allocate_integer_array (gv->current_max_xpairs);
+	gv->chk = allocate_integer_array (gv->current_max_xpairs);
 
-	current_max_template_xpairs = INITIAL_MAX_TEMPLATE_XPAIRS;
-	tnxt = allocate_integer_array (current_max_template_xpairs);
+	gv->current_max_template_xpairs = INITIAL_MAX_TEMPLATE_XPAIRS;
+	gv->tnxt = allocate_integer_array (gv->current_max_template_xpairs);
 
-	current_max_dfas = INITIAL_MAX_DFAS;
-	base = allocate_integer_array (current_max_dfas);
-	def = allocate_integer_array (current_max_dfas);
-	dfasiz = allocate_integer_array (current_max_dfas);
-	accsiz = allocate_integer_array (current_max_dfas);
-	dhash = allocate_integer_array (current_max_dfas);
-	dss = allocate_int_ptr_array (current_max_dfas);
-	dfaacc = allocate_array(current_max_dfas,
+	gv->current_max_dfas = INITIAL_MAX_DFAS;
+	gv->base = allocate_integer_array (gv->current_max_dfas);
+	gv->def = allocate_integer_array (gv->current_max_dfas);
+	gv->dfasiz = allocate_integer_array (gv->current_max_dfas);
+	gv->accsiz = allocate_integer_array (gv->current_max_dfas);
+	gv->dhash = allocate_integer_array (gv->current_max_dfas);
+	gv->dss = allocate_int_ptr_array (gv->current_max_dfas);
+	gv->dfaacc = allocate_array(gv->current_max_dfas,
 		sizeof(union dfaacc_union));
 
-	nultrans = NULL;
+	gv->nultrans = NULL;
 }
 
 
@@ -1742,13 +1760,13 @@ void usage (void)
 {
 	FILE   *f = stdout;
 
-	if (!env.did_outfilename) {
-		snprintf (outfile_path, sizeof(outfile_path), outfile_template,
-			  ctrl.prefix, suffix());
-		env.outfilename = outfile_path;
+	if (!gv->env.did_outfilename) {
+		snprintf (gv->outfile_path, sizeof(gv->outfile_path), gv->outfile_template,
+			  gv->ctrl.prefix, suffix());
+		gv->env.outfilename = gv->outfile_path;
 	}
 
-	fprintf (f, _("Usage: %s [OPTIONS] [FILE]...\n"), program_name);
+	fprintf (f, _("Usage: %s [OPTIONS] [FILE]...\n"), gv->program_name);
 	fprintf (f,
 		 _
 		 ("Generates programs that perform pattern-matching on text.\n"
@@ -1806,6 +1824,6 @@ void usage (void)
 		  "  -?\n"
 		  "  -h, --help              produce this help message\n"
 		  "  -V, --version           report %s version\n"),
-		 backing_name, "flex", outfile_path, "flex");
+		 gv->backing_name, "flex", gv->outfile_path, "flex");
 
 }

--- a/src/misc.c
+++ b/src/misc.c
@@ -38,24 +38,24 @@ void add_action (const char *new_text)
 {
 	int     len = (int) strlen (new_text);
 
-	while (len + action_index >= action_size - 10 /* slop */ ) {
+	while (len + gv->action_index >= gv->action_size - 10 /* slop */ ) {
 
-		if (action_size > INT_MAX / 2)
+		if (gv->action_size > INT_MAX / 2)
 			/* Increase just a little, to try to avoid overflow
 			 * on 16-bit machines.
 			 */
-			action_size += action_size / 8;
+			gv->action_size += gv->action_size / 8;
 		else
-			action_size = action_size * 2;
+			gv->action_size = gv->action_size * 2;
 
-		action_array =
-			reallocate_character_array (action_array,
-						    action_size);
+		gv->action_array =
+			reallocate_character_array (gv->action_array,
+						    gv->action_size);
 	}
 
-	strcpy (&action_array[action_index], new_text);
+	strcpy (&gv->action_array[gv->action_index], new_text);
 
-	action_index += len;
+	gv->action_index += len;
 }
 
 
@@ -114,7 +114,7 @@ void check_char (int c)
 		lerr (_("bad character '%s' detected in check_char()"),
 			readable_form (c));
 
-	if (c >= ctrl.csize)
+	if (c >= gv->ctrl.csize)
 		lerr (_
 			("scanner requires -8 flag to use the character %s"),
 			readable_form (c));
@@ -160,17 +160,17 @@ int cclcmp (const void *a, const void *b)
 void dataend (const char *endit)
 {
 	/* short circuit any output */
-	if (gentables) {
+	if (gv->gentables) {
 
-		if (datapos > 0)
+		if (gv->datapos > 0)
 			dataflush ();
 
 		/* add terminator for initialization; { for vi */
 		if (endit)
 			outn (endit);
 	}
-	dataline = 0;
-	datapos = 0;
+	gv->dataline = 0;
+	gv->datapos = 0;
 }
 
 
@@ -180,19 +180,19 @@ void dataflush (void)
 {
 	assert (gentables);
 
-	if (datapos > 0)
+	if (gv->datapos > 0)
 		outc ('\n');
 
-	if (++dataline >= NUMDATALINES) {
+	if (++gv->dataline >= NUMDATALINES) {
 		/* Put out a blank line so that the table is grouped into
 		 * large blocks that enable the user to find elements easily.
 		 */
 		outc ('\n');
-		dataline = 0;
+		gv->dataline = 0;
 	}
 
 	/* Reset the number of characters written on the current line. */
-	datapos = 0;
+	gv->datapos = 0;
 }
 
 
@@ -200,7 +200,7 @@ void dataflush (void)
 
 void flexerror (const char *msg)
 {
-	fprintf (stderr, "%s: %s\n", program_name, msg);
+	fprintf (stderr, "%s: %s\n", gv->program_name, msg);
 	flexend (1);
 }
 
@@ -210,7 +210,7 @@ void flexerror (const char *msg)
 void flexfatal (const char *msg)
 {
 	fprintf (stderr, _("%s: fatal internal error, %s\n"),
-		 program_name, msg);
+		 gv->program_name, msg);
 	FLEX_EXIT (1);
 }
 
@@ -250,7 +250,7 @@ void line_directive_out (FILE *output_file, char *path, int linenum)
 	char    directive[MAXLINE*2], filename[MAXLINE];
 	char   *s1, *s2, *s3;
 
-	if (!ctrl.gen_line_dirs)
+	if (!gv->ctrl.gen_line_dirs)
 		return;
 
 	s1 = (path != NULL) ? path : "M4_YY_OUTFILE_NAME";
@@ -294,10 +294,10 @@ void line_directive_out (FILE *output_file, char *path, int linenum)
  */
 void mark_defs1 (void)
 {
-	defs1_offset = 0;
-	action_array[action_index++] = '\0';
-	action_offset = prolog_offset = action_index;
-	action_array[action_index] = '\0';
+	gv->defs1_offset = 0;
+	gv->action_array[gv->action_index++] = '\0';
+	gv->action_offset = gv->prolog_offset = gv->action_index;
+	gv->action_array[gv->action_index] = '\0';
 }
 
 
@@ -306,9 +306,9 @@ void mark_defs1 (void)
  */
 void mark_prolog (void)
 {
-	action_array[action_index++] = '\0';
-	action_offset = action_index;
-	action_array[action_index] = '\0';
+	gv->action_array[gv->action_index++] = '\0';
+	gv->action_offset = gv->action_index;
+	gv->action_array[gv->action_index] = '\0';
 }
 
 
@@ -319,22 +319,22 @@ void mark_prolog (void)
 void mk2data (int value)
 {
 	/* short circuit any output */
-	if (!gentables)
+	if (!gv->gentables)
 		return;
 
-	if (datapos >= NUMDATAITEMS) {
+	if (gv->datapos >= NUMDATAITEMS) {
 		outc (',');
 		dataflush ();
 	}
 
-	if (datapos == 0)
+	if (gv->datapos == 0)
 		/* Indent. */
 		out ("    ");
 
 	else
 	  outc (',');
 
-	++datapos;
+	++gv->datapos;
 
 	out_dec ("%5d", value);
 }
@@ -348,20 +348,20 @@ void mk2data (int value)
 void mkdata (int value)
 {
 	/* short circuit any output */
-	if (!gentables)
+	if (!gv->gentables)
 		return;
 
-	if (datapos >= NUMDATAITEMS) {
+	if (gv->datapos >= NUMDATAITEMS) {
 		outc (',');
 		dataflush ();
 	}
 
-	if (datapos == 0)
+	if (gv->datapos == 0)
 		/* Indent. */
 		out ("    ");
 	else
 		outc (',');
-	++datapos;
+	++gv->datapos;
 
 	out_dec ("%5d", value);
 }
@@ -517,7 +517,7 @@ void out_m4_define (const char* def, const char* val)
 
 char   *readable_form (int c)
 {
-	static char rform[20];
+	//static char rform[20];
 
 	if ((c >= 0 && c < 32) || c >= 127) {
 		switch (c) {
@@ -536,11 +536,11 @@ char   *readable_form (int c)
 		case '\v':
 			return "\\v";
 		default:
-			if(env.trace_hex)
-				snprintf (rform, sizeof(rform), "\\x%.2x", (unsigned int) c);
+			if(gv->env.trace_hex)
+				snprintf (gv->rform, sizeof(gv->rform), "\\x%.2x", (unsigned int) c);
 			else
-				snprintf (rform, sizeof(rform), "\\%.3o", (unsigned int) c);
-			return rform;
+				snprintf (gv->rform, sizeof(gv->rform), "\\%.3o", (unsigned int) c);
+			return gv->rform;
 		}
 	}
 
@@ -548,10 +548,10 @@ char   *readable_form (int c)
 		return "' '";
 
 	else {
-		rform[0] = (char) c;
-		rform[1] = '\0';
+		gv->rform[0] = (char) c;
+		gv->rform[1] = '\0';
 
-		return rform;
+		return gv->rform;
 	}
 }
 
@@ -601,21 +601,21 @@ void transition_struct_out (int element_v, int element_n)
 {
 
 	/* short circuit any output */
-	if (!gentables)
+	if (!gv->gentables)
 		return;
 
 	out_dec2 ("M4_HOOK_TABLE_OPENER[[%4d]],[[%4d]]M4_HOOK_TABLE_CONTINUE", element_v, element_n);
 	outc ('\n');
 
-	datapos += TRANS_STRUCT_PRINT_LENGTH;
+	gv->datapos += TRANS_STRUCT_PRINT_LENGTH;
 
-	if (datapos >= 79 - TRANS_STRUCT_PRINT_LENGTH) {
+	if (gv->datapos >= 79 - TRANS_STRUCT_PRINT_LENGTH) {
 		outc ('\n');
 
-		if (++dataline % 10 == 0)
+		if (++gv->dataline % 10 == 0)
 			outc ('\n');
 
-		datapos = 0;
+		gv->datapos = 0;
 	}
 }
 

--- a/src/options.c
+++ b/src/options.c
@@ -40,7 +40,7 @@
 
 
 /* The command-line options, passed to scanopt_init() */
-optspec_t flexopts[] = {
+const optspec_t flexopts[] = {
 
 	{"-7", OPT_7BIT, 0}
 	,

--- a/src/options.h
+++ b/src/options.h
@@ -35,7 +35,7 @@
 #define OPTIONS_H
 #include "scanopt.h"
 
-extern optspec_t flexopts[];
+extern const optspec_t flexopts[];
 
 enum flexopt_flag_t {
 	/* Use positive integers only, since they are return codes for scanopt.

--- a/src/parse.y
+++ b/src/parse.y
@@ -67,17 +67,17 @@
 #include "flexdef.h"
 #include "tables.h"
 
-int pat, scnum, eps, headcnt, trailcnt, lastchar, i, rulelen;
-static int currccl;
-bool trlcontxt;
-static bool sc_is_exclusive, cclsorted, varlength, variable_trail_rule;
+//int pat, scnum, eps, headcnt, trailcnt, lastchar, i, rulelen;
+//static int currccl;
+//bool trlcontxt;
+//static bool sc_is_exclusive, cclsorted, varlength, variable_trail_rule;
 
-int *scon_stk;
-int scon_stk_ptr;
+//int *scon_stk;
+//int scon_stk_ptr;
 
-static int madeany = false;  /* whether we've made the '.' character class */
-static int ccldot, cclany;
-int previous_continued_action;	/* whether the previous rule's action was '|' */
+//static int madeany = false;  /* whether we've made the '.' character class */
+//static int ccldot, cclany;
+//int previous_continued_action;	/* whether the previous rule's action was '|' */
 
 #define format_warn3(fmt, a1, a2) \
 	do{ \
@@ -90,18 +90,18 @@ int previous_continued_action;	/* whether the previous rule's action was '|' */
 #define CCL_EXPR(func) \
 	do{ \
 	int c; \
-	for ( c = 0; c < ctrl.csize; ++c ) \
+	for ( c = 0; c < gv->ctrl.csize; ++c ) \
 		if ( isascii(c) && func(c) ) \
-			ccladd( currccl, c ); \
+			ccladd( gv->currccl, c ); \
 	}while(0)
 
 /* negated class */
 #define CCL_NEG_EXPR(func) \
 	do{ \
 	int c; \
-	for ( c = 0; c < ctrl.csize; ++c ) \
+	for ( c = 0; c < gv->ctrl.csize; ++c ) \
 		if ( !func(c) ) \
-			ccladd( currccl, c ); \
+			ccladd( gv->currccl, c ); \
 	}while(0)
 
 /* While POSIX defines isblank(), it's not ANSI C. */
@@ -122,24 +122,24 @@ goal		:  initlex sect1 sect1end sect2 initforrule
 			{ /* add default rule */
 			int def_rule;
 
-			pat = cclinit();
-			cclnegate( pat );
+			gv->pat = cclinit();
+			cclnegate( gv->pat );
 
-			def_rule = mkstate( -pat );
+			def_rule = mkstate( -gv->pat );
 
 			/* Remember the number of the default rule so we
 			 * don't generate "can't match" warnings for it.
 			 */
-			default_rule = num_rules;
+			gv->default_rule = gv->num_rules;
 
 			finish_rule( def_rule, false, 0, 0, 0);
 
-			for ( i = 1; i <= lastsc; ++i )
-				scset[i] = mkbranch( scset[i], def_rule );
+			for ( gv->i_parse = 1; gv->i_parse <= gv->lastsc; ++gv->i_parse )
+				gv->scset[gv->i_parse] = mkbranch( gv->scset[gv->i_parse], def_rule );
 
 			add_action("]]");
 
-			if ( ctrl.spprdflt )
+			if ( gv->ctrl.spprdflt )
 				add_action(
 				"M4_HOOK_FATAL_ERROR(\"flex scanner jammed\")");
 			else {
@@ -168,23 +168,23 @@ sect1		:  sect1 startconddecl namelist1
 sect1end	:  SECTEND
 			{
 			check_options();
-			scon_stk = allocate_integer_array( lastsc + 1 );
-			scon_stk_ptr = 0;
+			gv->scon_stk = allocate_integer_array( gv->lastsc + 1 );
+			gv->scon_stk_ptr = 0;
 			}
 		;
 
 startconddecl	:  SCDECL
-			{ sc_is_exclusive = false; }
+			{ gv->sc_is_exclusive = false; }
 
 		|  XSCDECL
-			{ sc_is_exclusive = true; }
+			{ gv->sc_is_exclusive = true; }
 		;
 
 namelist1	:  namelist1 NAME
-			{ scinstal( nmstr, sc_is_exclusive ); }
+			{ scinstal( gv->nmstr, gv->sc_is_exclusive ); }
 
 		|  NAME
-			{ scinstal( nmstr, sc_is_exclusive ); }
+			{ scinstal( gv->nmstr, gv->sc_is_exclusive ); }
 
 		|  error
 			{ synerr( _("bad start condition list") ); }
@@ -199,54 +199,54 @@ optionlist	:  optionlist option
 
 option		:  TOK_OUTFILE '=' NAME
 			{
-			env.outfilename = xstrdup(nmstr);
-			env.did_outfilename = 1;
+			gv->env.outfilename = xstrdup(gv->nmstr);
+			gv->env.did_outfilename = 1;
 			}
 		|  TOK_EXTRA_TYPE '=' NAME
-			{ extra_type = xstrdup(nmstr); }
+			{ gv->extra_type = xstrdup(gv->nmstr); }
 		|  TOK_PREFIX '=' NAME
-			{ ctrl.prefix = xstrdup(nmstr);
-                          if (strchr(ctrl.prefix, '[') || strchr(ctrl.prefix, ']'))
+			{ gv->ctrl.prefix = xstrdup(gv->nmstr);
+                          if (strchr(gv->ctrl.prefix, '[') || strchr(gv->ctrl.prefix, ']'))
                               flexerror(_("Prefix must not contain [ or ]")); }
 		|  TOK_YYCLASS '=' NAME
-			{ ctrl.yyclass = xstrdup(nmstr); }
+			{ gv->ctrl.yyclass = xstrdup(gv->nmstr); }
 		|  TOK_HEADER_FILE '=' NAME
-			{ env.headerfilename = xstrdup(nmstr); }
+			{ gv->env.headerfilename = xstrdup(gv->nmstr); }
 		|  TOK_YYLMAX '=' TOK_NUMERIC
-			{ ctrl.yylmax = nmval; }
+			{ gv->ctrl.yylmax = gv->nmval; }
 		|  TOK_YYDECL '=' NAME
-			{ ctrl.yydecl = xstrdup(nmstr); }
+			{ gv->ctrl.yydecl = xstrdup(gv->nmstr); }
 		|  TOK_PREACTION '=' NAME
-			{ ctrl.preaction = xstrdup(nmstr); }
+			{ gv->ctrl.preaction = xstrdup(gv->nmstr); }
 		|  TOK_POSTACTION '=' NAME
-			{ ctrl.postaction = xstrdup(nmstr); }
+			{ gv->ctrl.postaction = xstrdup(gv->nmstr); }
 		|  TOK_BUFSIZE '=' TOK_NUMERIC
-			{ ctrl.bufsize = nmval; }
+			{ gv->ctrl.bufsize = gv->nmval; }
 		|  TOK_EMIT '=' NAME
-			{ ctrl.emit = xstrdup(nmstr); backend_by_name(ctrl.emit); }
+			{ gv->ctrl.emit = xstrdup(gv->nmstr); backend_by_name(gv->ctrl.emit); }
 		|  TOK_USERINIT '=' NAME
-			{ ctrl.userinit = xstrdup(nmstr); }
+			{ gv->ctrl.userinit = xstrdup(gv->nmstr); }
 		|  TOK_YYTERMINATE '=' NAME
-			{ ctrl.yyterminate = xstrdup(nmstr); }
+			{ gv->ctrl.yyterminate = xstrdup(gv->nmstr); }
 		|  TOK_TABLES_FILE '=' NAME
-        		{ tablesext = true; tablesfilename = xstrdup(nmstr); }
+        		{ gv->tablesext = true; gv->tablesfilename = xstrdup(gv->nmstr); }
 		;
 
 sect2		:  sect2 scon initforrule flexrule '\n'
-			{ scon_stk_ptr = $2; }
+			{ gv->scon_stk_ptr = $2; }
 		|  sect2 scon '{' sect2 '}'
-			{ scon_stk_ptr = $2; }
+			{ gv->scon_stk_ptr = $2; }
 		|
 		;
 
 initforrule	:
 			{
 			/* Initialize for a parse of one rule. */
-			trlcontxt = variable_trail_rule = varlength = false;
-			trailcnt = headcnt = rulelen = 0;
-			current_state_type = STATE_NORMAL;
-			previous_continued_action = continued_action;
-			in_rule = true;
+			gv->trlcontxt = gv->variable_trail_rule = gv->varlength = false;
+			gv->trailcnt = gv->headcnt = gv->rulelen = 0;
+			gv->current_state_type = STATE_NORMAL;
+			gv->previous_continued_action = gv->continued_action;
+			gv->in_rule = true;
 
 			new_rule();
 			}
@@ -254,16 +254,16 @@ initforrule	:
 
 flexrule	:  '^' rule
 			{
-			pat = $2;
-			finish_rule( pat, variable_trail_rule,
-				headcnt, trailcnt , previous_continued_action);
+			gv->pat = $2;
+			finish_rule( gv->pat, gv->variable_trail_rule,
+				gv->headcnt, gv->trailcnt , gv->previous_continued_action);
 
-			if ( scon_stk_ptr > 0 )
+			if ( gv->scon_stk_ptr > 0 )
 				{
-				for ( i = 1; i <= scon_stk_ptr; ++i )
-					scbol[scon_stk[i]] =
-						mkbranch( scbol[scon_stk[i]],
-								pat );
+				for ( gv->i_parse = 1; gv->i_parse <= gv->scon_stk_ptr; ++gv->i_parse )
+					gv->scbol[gv->scon_stk[gv->i_parse]] =
+						mkbranch( gv->scbol[gv->scon_stk[gv->i_parse]],
+								gv->pat );
 				}
 
 			else
@@ -272,17 +272,17 @@ flexrule	:  '^' rule
 				 * including the default (0) start condition.
 				 */
 
-				for ( i = 1; i <= lastsc; ++i )
-					if ( ! scxclu[i] )
-						scbol[i] = mkbranch( scbol[i],
-									pat );
+				for ( gv->i_parse = 1; gv->i_parse <= gv->lastsc; ++gv->i_parse )
+					if ( ! gv->scxclu[gv->i_parse] )
+						gv->scbol[gv->i_parse] = mkbranch( gv->scbol[gv->i_parse],
+									gv->pat );
 				}
 
-			if ( ! bol_needed )
+			if ( ! gv->bol_needed )
 				{
-				bol_needed = true;
+				gv->bol_needed = true;
 
-				if ( env.performance_hint > 1 )
+				if ( gv->env.performance_hint > 1 )
 					pinpoint_message(
 			"'^' operator results in sub-optimal performance" );
 				}
@@ -290,31 +290,31 @@ flexrule	:  '^' rule
 
 		|  rule
 			{
-			pat = $1;
-			finish_rule( pat, variable_trail_rule,
-				headcnt, trailcnt , previous_continued_action);
+			gv->pat = $1;
+			finish_rule( gv->pat, gv->variable_trail_rule,
+				gv->headcnt, gv->trailcnt , gv->previous_continued_action);
 
-			if ( scon_stk_ptr > 0 )
+			if ( gv->scon_stk_ptr > 0 )
 				{
-				for ( i = 1; i <= scon_stk_ptr; ++i )
-					scset[scon_stk[i]] =
-						mkbranch( scset[scon_stk[i]],
-								pat );
+				for ( gv->i_parse = 1; gv->i_parse <= gv->scon_stk_ptr; ++gv->i_parse )
+					gv->scset[gv->scon_stk[gv->i_parse]] =
+						mkbranch( gv->scset[gv->scon_stk[gv->i_parse]],
+								gv->pat );
 				}
 
 			else
 				{
-				for ( i = 1; i <= lastsc; ++i )
-					if ( ! scxclu[i] )
-						scset[i] =
-							mkbranch( scset[i],
-								pat );
+				for ( gv->i_parse = 1; gv->i_parse <= gv->lastsc; ++gv->i_parse )
+					if ( ! gv->scxclu[gv->i_parse] )
+						gv->scset[gv->i_parse] =
+							mkbranch( gv->scset[gv->i_parse],
+								gv->pat );
 				}
 			}
 
 		|  EOF_OP
 			{
-			if ( scon_stk_ptr > 0 )
+			if ( gv->scon_stk_ptr > 0 )
 				build_eof_action();
 	
 			else
@@ -322,11 +322,11 @@ flexrule	:  '^' rule
 				/* This EOF applies to all start conditions
 				 * which don't already have EOF actions.
 				 */
-				for ( i = 1; i <= lastsc; ++i )
-					if ( ! sceof[i] )
-						scon_stk[++scon_stk_ptr] = i;
+				for ( gv->i_parse = 1; gv->i_parse <= gv->lastsc; ++gv->i_parse )
+					if ( ! gv->sceof[gv->i_parse] )
+						gv->scon_stk[++gv->scon_stk_ptr] = gv->i_parse;
 
-				if ( scon_stk_ptr == 0 )
+				if ( gv->scon_stk_ptr == 0 )
 					lwarn(
 			"all start conditions already have <<EOF>> rules" );
 
@@ -340,7 +340,7 @@ flexrule	:  '^' rule
 		;
 
 scon_stk_ptr	:
-			{ $$ = scon_stk_ptr; }
+			{ $$ = gv->scon_stk_ptr; }
 		;
 
 scon		:  '<' scon_stk_ptr namelist2 '>'
@@ -348,23 +348,23 @@ scon		:  '<' scon_stk_ptr namelist2 '>'
 
 		|  '<' '*' '>'
 			{
-			$$ = scon_stk_ptr;
+			$$ = gv->scon_stk_ptr;
 
-			for ( i = 1; i <= lastsc; ++i )
+			for ( gv->i_parse = 1; gv->i_parse <= gv->lastsc; ++gv->i_parse )
 				{
 				int j;
 
-				for ( j = 1; j <= scon_stk_ptr; ++j )
-					if ( scon_stk[j] == i )
+				for ( j = 1; j <= gv->scon_stk_ptr; ++j )
+					if ( gv->scon_stk[j] == gv->i_parse )
 						break;
 
-				if ( j > scon_stk_ptr )
-					scon_stk[++scon_stk_ptr] = i;
+				if ( j > gv->scon_stk_ptr )
+					gv->scon_stk[++gv->scon_stk_ptr] = gv->i_parse;
 				}
 			}
 
 		|
-			{ $$ = scon_stk_ptr; }
+			{ $$ = gv->scon_stk_ptr; }
 		;
 
 namelist2	:  namelist2 ',' sconname
@@ -377,30 +377,30 @@ namelist2	:  namelist2 ',' sconname
 
 sconname	:  NAME
 			{
-			if ( (scnum = sclookup( nmstr )) == 0 )
+			if ( (gv->scnum = sclookup( gv->nmstr )) == 0 )
 				format_pinpoint_message(
 					"undeclared start condition %s",
-					nmstr );
+					gv->nmstr );
 			else
 				{
-				for ( i = 1; i <= scon_stk_ptr; ++i )
-					if ( scon_stk[i] == scnum )
+				for ( gv->i_parse = 1; gv->i_parse <= gv->scon_stk_ptr; ++gv->i_parse )
+					if ( gv->scon_stk[gv->i_parse] == gv->scnum )
 						{
 						format_warn(
 							"<%s> specified twice",
-							scname[scnum] );
+							gv->scname[gv->scnum] );
 						break;
 						}
 
-				if ( i > scon_stk_ptr )
-					scon_stk[++scon_stk_ptr] = scnum;
+				if ( gv->i_parse > gv->scon_stk_ptr )
+					gv->scon_stk[++gv->scon_stk_ptr] = gv->scnum;
 				}
 			}
 		;
 
 rule		:  re2 re
 			{
-			if ( transchar[lastst[$2]] != SYM_EPSILON )
+			if ( gv->transchar[gv->lastst[$2]] != SYM_EPSILON )
 				/* Provide final transition \now/ so it
 				 * will be marked as a trailing context
 				 * state.
@@ -409,9 +409,9 @@ rule		:  re2 re
 						mkstate( SYM_EPSILON ) );
 
 			mark_beginning_as_normal( $2 );
-			current_state_type = STATE_NORMAL;
+			gv->current_state_type = STATE_NORMAL;
 
-			if ( previous_continued_action )
+			if ( gv->previous_continued_action )
 				{
 				/* We need to treat this as variable trailing
 				 * context so that the backup does not happen
@@ -421,17 +421,17 @@ rule		:  re2 re
 				 * one's action will *also* do the backup,
 				 * erroneously.
 				 */
-				if ( ! varlength || headcnt != 0 )
+				if ( ! gv->varlength || gv->headcnt != 0 )
 					lwarn(
 		"trailing context made variable due to preceding '|' action" );
 
 				/* Mark as variable. */
-				varlength = true;
-				headcnt = 0;
+				gv->varlength = true;
+				gv->headcnt = 0;
 
 				}
 
-			if ( ctrl.lex_compat || (varlength && headcnt == 0) )
+			if ( gv->ctrl.lex_compat || (gv->varlength && gv->headcnt == 0) )
 				{ /* variable trailing context rule */
 				/* Mark the first part of the rule as the
 				 * accepting "head" part of a trailing
@@ -444,12 +444,12 @@ rule		:  re2 re
 				 * a new state ...
 				 */
 				add_accept( $1,
-					num_rules | YY_TRAILING_HEAD_MASK );
-				variable_trail_rule = true;
+					gv->num_rules | YY_TRAILING_HEAD_MASK );
+				gv->variable_trail_rule = true;
 				}
 			
 			else
-				trailcnt = rulelen;
+				gv->trailcnt = gv->rulelen;
 
 			$$ = link_machines( $1, $2 );
 			}
@@ -459,20 +459,20 @@ rule		:  re2 re
 
 		|  re '$'
 			{
-			headcnt = 0;
-			trailcnt = 1;
-			rulelen = 1;
-			varlength = false;
+			gv->headcnt = 0;
+			gv->trailcnt = 1;
+			gv->rulelen = 1;
+			gv->varlength = false;
 
-			current_state_type = STATE_TRAILING_CONTEXT;
+			gv->current_state_type = STATE_TRAILING_CONTEXT;
 
-			if ( trlcontxt )
+			if ( gv->trlcontxt )
 				{
 				synerr( _("trailing context used twice") );
 				$$ = mkstate( SYM_EPSILON );
 				}
 
-			else if ( previous_continued_action )
+			else if ( gv->previous_continued_action )
 				{
 				/* See the comment in the rule for "re2 re"
 				 * above.
@@ -480,39 +480,39 @@ rule		:  re2 re
 				lwarn(
 		"trailing context made variable due to preceding '|' action" );
 
-				varlength = true;
+				gv->varlength = true;
 				}
 
-			if ( ctrl.lex_compat || varlength )
+			if ( gv->ctrl.lex_compat || gv->varlength )
 				{
 				/* Again, see the comment in the rule for
 				 * "re2 re" above.
 				 */
 				add_accept( $1,
-					num_rules | YY_TRAILING_HEAD_MASK );
-				variable_trail_rule = true;
+					gv->num_rules | YY_TRAILING_HEAD_MASK );
+				gv->variable_trail_rule = true;
 				}
 
-			trlcontxt = true;
+			gv->trlcontxt = true;
 
-			eps = mkstate( SYM_EPSILON );
+			gv->eps = mkstate( SYM_EPSILON );
 			$$ = link_machines( $1,
-				link_machines( eps, mkstate( '\n' ) ) );
+				link_machines( gv->eps, mkstate( '\n' ) ) );
 			}
 
 		|  re
 			{
 			$$ = $1;
 
-			if ( trlcontxt )
+			if ( gv->trlcontxt )
 				{
-				if ( ctrl.lex_compat || (varlength && headcnt == 0) )
+				if ( gv->ctrl.lex_compat || (gv->varlength && gv->headcnt == 0) )
 					/* Both head and trail are
 					 * variable-length.
 					 */
-					variable_trail_rule = true;
+					gv->variable_trail_rule = true;
 				else
-					trailcnt = rulelen;
+					gv->trailcnt = gv->rulelen;
 				}
 			}
 		;
@@ -520,7 +520,7 @@ rule		:  re2 re
 
 re		:  re '|' series
 			{
-			varlength = true;
+			gv->varlength = true;
 			$$ = mkor( $1, $3 );
 			}
 
@@ -536,22 +536,22 @@ re2		:  re '/'
 			 * series is parsed.
 			 */
 
-			if ( trlcontxt )
+			if ( gv->trlcontxt )
 				synerr( _("trailing context used twice") );
 			else
-				trlcontxt = true;
+				gv->trlcontxt = true;
 
-			if ( varlength )
+			if ( gv->varlength )
 				/* We hope the trailing context is
 				 * fixed-length.
 				 */
-				varlength = false;
+				gv->varlength = false;
 			else
-				headcnt = rulelen;
+				gv->headcnt = gv->rulelen;
 
-			rulelen = 0;
+			gv->rulelen = 0;
 
-			current_state_type = STATE_TRAILING_CONTEXT;
+			gv->current_state_type = STATE_TRAILING_CONTEXT;
 			$$ = $1;
 			}
 		;
@@ -569,7 +569,7 @@ series		:  series singleton
 
 		|  series BEGIN_REPEAT_POSIX NUMBER ',' NUMBER END_REPEAT_POSIX
 			{
-			varlength = true;
+			gv->varlength = true;
 
 			if ( $3 > $5 || $3 < 0 )
 				{
@@ -597,7 +597,7 @@ series		:  series singleton
 
 		|  series BEGIN_REPEAT_POSIX NUMBER ',' END_REPEAT_POSIX
 			{
-			varlength = true;
+			gv->varlength = true;
 
 			if ( $3 <= 0 )
 				{
@@ -615,7 +615,7 @@ series		:  series singleton
 			 * in which case we have no idea what its length
 			 * is, so we punt here.
 			 */
-			varlength = true;
+			gv->varlength = true;
 
 			if ( $3 <= 0 )
 				{
@@ -633,26 +633,26 @@ series		:  series singleton
 
 singleton	:  singleton '*'
 			{
-			varlength = true;
+			gv->varlength = true;
 
 			$$ = mkclos( $1 );
 			}
 
 		|  singleton '+'
 			{
-			varlength = true;
+			gv->varlength = true;
 			$$ = mkposcl( $1 );
 			}
 
 		|  singleton '?'
 			{
-			varlength = true;
+			gv->varlength = true;
 			$$ = mkopt( $1 );
 			}
 
 		|  singleton BEGIN_REPEAT_FLEX NUMBER ',' NUMBER END_REPEAT_FLEX
 			{
-			varlength = true;
+			gv->varlength = true;
 
 			if ( $3 > $5 || $3 < 0 )
 				{
@@ -680,7 +680,7 @@ singleton	:  singleton '*'
 
 		|  singleton BEGIN_REPEAT_FLEX NUMBER ',' END_REPEAT_FLEX
 			{
-			varlength = true;
+			gv->varlength = true;
 
 			if ( $3 <= 0 )
 				{
@@ -698,7 +698,7 @@ singleton	:  singleton '*'
 			 * in which case we have no idea what its length
 			 * is, so we punt here.
 			 */
-			varlength = true;
+			gv->varlength = true;
 
 			if ( $3 <= 0 )
 				{
@@ -713,62 +713,62 @@ singleton	:  singleton '*'
 
 		|  '.'
 			{
-			if ( ! madeany )
+			if ( ! gv->madeany )
 				{
 				/* Create the '.' character class. */
-                    ccldot = cclinit();
-                    ccladd( ccldot, '\n' );
-                    cclnegate( ccldot );
+                    gv->ccldot = cclinit();
+                    ccladd( gv->ccldot, '\n' );
+                    cclnegate( gv->ccldot );
 
-                    if ( ctrl.useecs )
-                        mkeccl( ccltbl + cclmap[ccldot],
-                            ccllen[ccldot], nextecm,
-                            ecgroup, ctrl.csize, ctrl.csize );
+                    if ( gv->ctrl.useecs )
+                        mkeccl( gv->ccltbl + gv->cclmap[gv->ccldot],
+                            gv->ccllen[gv->ccldot], gv->nextecm,
+                            gv->ecgroup, gv->ctrl.csize, gv->ctrl.csize );
 
 				/* Create the (?s:'.') character class. */
-                    cclany = cclinit();
-                    cclnegate( cclany );
+                    gv->cclany = cclinit();
+                    cclnegate( gv->cclany );
 
-                    if ( ctrl.useecs )
-                        mkeccl( ccltbl + cclmap[cclany],
-                            ccllen[cclany], nextecm,
-                            ecgroup, ctrl.csize, ctrl.csize );
+                    if ( gv->ctrl.useecs )
+                        mkeccl( gv->ccltbl + gv->cclmap[gv->cclany],
+                            gv->ccllen[gv->cclany],gv-> nextecm,
+                            gv->ecgroup, gv->ctrl.csize, gv->ctrl.csize );
 
-				madeany = true;
+				gv->madeany = true;
 				}
 
-			++rulelen;
+			++gv->rulelen;
 
             if (sf_dot_all())
-                $$ = mkstate( -cclany );
+                $$ = mkstate( -gv->cclany );
             else
-                $$ = mkstate( -ccldot );
+                $$ = mkstate( -gv->ccldot );
 			}
 
 		|  fullccl
 			{
 				/* Sort characters for fast searching.
 				 */
-				qsort( ccltbl + cclmap[$1], (size_t) ccllen[$1], sizeof (*ccltbl), cclcmp );
+				qsort( gv->ccltbl + gv->cclmap[$1], (size_t) gv->ccllen[$1], sizeof (*gv->ccltbl), cclcmp );
 
-			if ( ctrl.useecs )
-				mkeccl( ccltbl + cclmap[$1], ccllen[$1],
-					nextecm, ecgroup, ctrl.csize, ctrl.csize);
+			if ( gv->ctrl.useecs )
+				mkeccl( gv->ccltbl + gv->cclmap[$1], gv->ccllen[$1],
+					gv->nextecm, gv->ecgroup, gv->ctrl.csize, gv->ctrl.csize);
 
-			++rulelen;
+			++gv->rulelen;
 
-			if (ccl_has_nl[$1])
-				rule_has_nl[num_rules] = true;
+			if (gv->ccl_has_nl[$1])
+				gv->rule_has_nl[gv->num_rules] = true;
 
 			$$ = mkstate( -$1 );
 			}
 
 		|  PREVCCL
 			{
-			++rulelen;
+			++gv->rulelen;
 
-			if (ccl_has_nl[$1])
-				rule_has_nl[num_rules] = true;
+			if (gv->ccl_has_nl[$1])
+				gv->rule_has_nl[gv->num_rules] = true;
 
 			$$ = mkstate( -$1 );
 			}
@@ -781,10 +781,10 @@ singleton	:  singleton '*'
 
 		|  CHAR
 			{
-			++rulelen;
+			++gv->rulelen;
 
-			if ($1 == nlch)
-				rule_has_nl[num_rules] = true;
+			if ($1 == gv->nlch)
+				gv->rule_has_nl[gv->num_rules] = true;
 
             if (sf_case_ins() && has_case($1))
                 /* create an alternation, as in (a|A) */
@@ -844,25 +844,25 @@ ccl		:  ccl CHAR '-' CHAR
 
 			else
 				{
-				for ( i = $2; i <= $4; ++i )
-					ccladd( $1, i );
+				for ( gv->i_parse = $2; gv->i_parse <= $4; ++gv->i_parse )
+					ccladd( $1, gv->i_parse );
 
 				/* Keep track if this ccl is staying in
 				 * alphabetical order.
 				 */
-				cclsorted = cclsorted && ($2 > lastchar);
-				lastchar = $4;
+				gv->cclsorted = gv->cclsorted && ($2 > gv->lastchar);
+				gv->lastchar = $4;
 
                 /* Do it again for upper/lowercase */
                 if (sf_case_ins() && has_case($2) && has_case($4)){
                     $2 = reverse_case ($2);
                     $4 = reverse_case ($4);
                     
-                    for ( i = $2; i <= $4; ++i )
-                        ccladd( $1, i );
+                    for ( gv->i_parse = $2; gv->i_parse <= $4; ++gv->i_parse )
+                        ccladd( $1, gv->i_parse );
 
-                    cclsorted = cclsorted && ($2 > lastchar);
-                    lastchar = $4;
+                    gv->cclsorted = gv->cclsorted && ($2 > gv->lastchar);
+                    gv->lastchar = $4;
                 }
 
 				}
@@ -873,16 +873,16 @@ ccl		:  ccl CHAR '-' CHAR
 		|  ccl CHAR
 			{
 			ccladd( $1, $2 );
-			cclsorted = cclsorted && ($2 > lastchar);
-			lastchar = $2;
+			gv->cclsorted = gv->cclsorted && ($2 > gv->lastchar);
+			gv->lastchar = $2;
 
             /* Do it again for upper/lowercase */
             if (sf_case_ins() && has_case($2)){
                 $2 = reverse_case ($2);
                 ccladd ($1, $2);
 
-                cclsorted = cclsorted && ($2 > lastchar);
-                lastchar = $2;
+                gv->cclsorted = gv->cclsorted && ($2 > gv->lastchar);
+                gv->lastchar = $2;
             }
 
 			$$ = $1;
@@ -890,16 +890,16 @@ ccl		:  ccl CHAR '-' CHAR
 
 		|  ccl ccl_expr
 			{
-			/* Too hard to properly maintain cclsorted. */
-			cclsorted = false;
+			/* Too hard to properly maintain gv->cclsorted. */
+			gv->cclsorted = false;
 			$$ = $1;
 			}
 
 		|
 			{
-			cclsorted = true;
-			lastchar = 0;
-			currccl = $$ = cclinit();
+			gv->cclsorted = true;
+			gv->lastchar = 0;
+			gv->currccl = $$ = cclinit();
 			}
 		;
 
@@ -951,10 +951,10 @@ ccl_expr:
 		
 string		:  string CHAR
 			{
-			if ( $2 == nlch )
-				rule_has_nl[num_rules] = true;
+			if ( $2 == gv->nlch )
+				gv->rule_has_nl[gv->num_rules] = true;
 
-			++rulelen;
+			++gv->rulelen;
 
             if (sf_case_ins() && has_case($2))
                 $$ = mkor (mkstate($2), mkstate(reverse_case($2)));
@@ -980,27 +980,27 @@ void build_eof_action(void)
 	int i;
 	char action_text[MAXLINE];
 
-	for ( i = 1; i <= scon_stk_ptr; ++i )
+	for ( i = 1; i <= gv->scon_stk_ptr; ++i )
 		{
-		if ( sceof[scon_stk[i]] )
+		if ( gv->sceof[gv->scon_stk[i]] )
 			format_pinpoint_message(
 				"multiple <<EOF>> rules for start condition %s",
-				scname[scon_stk[i]] );
+				gv->scname[gv->scon_stk[i]] );
 
 		else
 			{
-			sceof[scon_stk[i]] = true;
+			gv->sceof[gv->scon_stk[i]] = true;
 
-			if (previous_continued_action /* && previous action was regular */)
+			if (gv->previous_continued_action /* && previous action was regular */)
 				add_action("YY_RULE_SETUP\n");
 
 			snprintf( action_text, sizeof(action_text), "M4_HOOK_EOF_STATE_CASE_ARM(%s)\n",
-				scname[scon_stk[i]] );
+				gv->scname[gv->scon_stk[i]] );
 			add_action( action_text );
 			}
 		}
 
-	line_directive_out(NULL, infilename, linenum);
+	line_directive_out(NULL, gv->infilename, gv->linenum);
         add_action("[[");
 
 	/* This isn't a normal rule after all - don't count it as
@@ -1008,8 +1008,8 @@ void build_eof_action(void)
 	 * (which make generating "rule can never match" warnings
 	 * more difficult.
 	 */
-	--num_rules;
-	++num_eof_rules;
+	--gv->num_rules;
+	++gv->num_eof_rules;
 	}
 
 
@@ -1028,7 +1028,7 @@ void format_synerr( const char *msg, const char arg[] )
 
 void synerr( const char *str )
 	{
-	syntaxerror = true;
+	gv->syntaxerror = true;
 	pinpoint_message( str );
 	}
 
@@ -1048,7 +1048,7 @@ void format_warn( const char *msg, const char arg[] )
 
 void lwarn( const char *str )
 	{
-	line_warning( str, linenum );
+	line_warning( str, gv->linenum );
 	}
 
 /* format_pinpoint_message - write out a message formatted with one string,
@@ -1068,7 +1068,7 @@ void format_pinpoint_message( const char *msg, const char arg[] )
 
 void pinpoint_message( const char *str )
 	{
-	line_pinpoint( str, linenum );
+	line_pinpoint( str, gv->linenum );
 	}
 
 
@@ -1078,7 +1078,7 @@ void line_warning( const char *str, int line )
 	{
 	char warning[MAXLINE*2];
 
-	if ( ! env.nowarn )
+	if ( ! gv->env.nowarn )
 		{
 		snprintf( warning, sizeof(warning), "warning, %s", str );
 		line_pinpoint( warning, line );
@@ -1090,7 +1090,7 @@ void line_warning( const char *str, int line )
 
 void line_pinpoint( const char *str, int line )
 	{
-	fprintf( stderr, "%s:%d: %s\n", infilename, line, str );
+	fprintf( stderr, "%s:%d: %s\n", gv->infilename, line, str );
 	}
 
 

--- a/src/regex.c
+++ b/src/regex.c
@@ -24,7 +24,7 @@
 #include "flexdef.h"
 
 
-regex_t regex_linedir; /**< matches line directives */
+//regex_t regex_linedir; /**< matches line directives */
 
 
 /** Initialize the regular expressions.
@@ -33,7 +33,7 @@ regex_t regex_linedir; /**< matches line directives */
 bool flex_init_regex(const char *traceline_re)
 {
 	if (traceline_re != NULL)
-		flex_regcomp(&regex_linedir, traceline_re, REG_EXTENDED);
+		flex_regcomp(&gv->regex_linedir, traceline_re, REG_EXTENDED);
 	return true;
 }
 

--- a/src/regex.c
+++ b/src/regex.c
@@ -30,10 +30,10 @@
 /** Initialize the regular expressions.
  * @return true upon success.
  */
-bool flex_init_regex(const char *traceline_re)
+bool flex_init_regex(FlexState* gv, const char *traceline_re)
 {
 	if (traceline_re != NULL)
-		flex_regcomp(&gv->regex_linedir, traceline_re, REG_EXTENDED);
+		flex_regcomp(gv, &gv->regex_linedir, traceline_re, REG_EXTENDED);
 	return true;
 }
 
@@ -42,7 +42,7 @@ bool flex_init_regex(const char *traceline_re)
  * @param regex Same as for regcomp().
  * @param cflags Same as for regcomp().
  */
-void flex_regcomp(regex_t *preg, const char *regex, int cflags)
+void flex_regcomp(FlexState* gv, regex_t *preg, const char *regex, int cflags)
 {
 	int err;
 
@@ -55,11 +55,11 @@ void flex_regcomp(regex_t *preg, const char *regex, int cflags)
 
 		errbuf = malloc(errbuf_sz * sizeof(char));
 		if (!errbuf)
-			flexfatal(_("Unable to allocate buffer to report regcomp"));
+			flexfatal(gv, _("Unable to allocate buffer to report regcomp"));
 		n = snprintf(errbuf, errbuf_sz, "regcomp for \"%s\" failed: ", regex);
 		regerror(err, preg, errbuf+n, errbuf_sz-(size_t)n);
 
-		flexfatal (errbuf); /* never returns - no need to free(errbuf) */
+		flexfatal (gv, errbuf); /* never returns - no need to free(errbuf) */
 	}
 }
 
@@ -68,7 +68,7 @@ void flex_regcomp(regex_t *preg, const char *regex, int cflags)
  * @param src The source string that was passed to regexec().
  * @return The allocated string.
  */
-char   *regmatch_dup (regmatch_t * m, const char *src)
+char   *regmatch_dup (FlexState* gv, regmatch_t * m, const char *src)
 {
 	char   *str;
 	size_t  len;
@@ -78,7 +78,7 @@ char   *regmatch_dup (regmatch_t * m, const char *src)
 	len = (size_t) (m->rm_eo - m->rm_so);
 	str = malloc((len + 1) * sizeof(char));
 	if (!str)
-		flexfatal(_("Unable to allocate a copy of the match"));
+		flexfatal(gv, _("Unable to allocate a copy of the match"));
 	strncpy (str, src + m->rm_so, len);
 	str[len] = 0;
 	return str;
@@ -124,7 +124,7 @@ int regmatch_len (regmatch_t * m)
  * @param base   Same as the third argument to strtol().
  * @return The converted integer or error (Return value is the same as for strtol()).
  */
-int regmatch_strtol (regmatch_t * m, const char *src, char **endptr,
+int regmatch_strtol (FlexState* gv, regmatch_t * m, const char *src, char **endptr,
 		     int base)
 {
 	int     n = 0;
@@ -139,7 +139,7 @@ int regmatch_strtol (regmatch_t * m, const char *src, char **endptr,
 	if (regmatch_len (m) < bufsz)
 		s = regmatch_cpy (m, buf, src);
 	else
-		s = regmatch_dup (m, src);
+		s = regmatch_dup (gv, m, src);
 
 	n = (int) strtol (s, endptr, base);
 

--- a/src/scan.l
+++ b/src/scan.l
@@ -49,17 +49,17 @@
 #define ESCAPED_QSTART "[" M4QEND M4QSTART "[" M4QEND M4QSTART
 #define ESCAPED_QEND M4QEND "]" M4QSTART M4QEND "]" M4QSTART
 
-#define ACTION_ECHO add_action( yytext )
-#define ACTION_ECHO_QSTART add_action (ESCAPED_QSTART)
-#define ACTION_ECHO_QEND   add_action (ESCAPED_QEND)
+#define ACTION_ECHO add_action( gv, yytext )
+#define ACTION_ECHO_QSTART add_action (gv, ESCAPED_QSTART)
+#define ACTION_ECHO_QEND   add_action (gv, ESCAPED_QEND)
 
 #define MARK_END_OF_PROLOG mark_prolog();
 
 #define YY_DECL \
-	int flexscan(void)
+	int flexscan(YYSTYPE * yylval_param, yyscan_t yyscanner)
 
 #define RETURNCHAR \
-	yylval = (unsigned char) yytext[0]; \
+	*yylval = (unsigned char) yytext[0]; \
 	return CHAR;
 
 #define RETURNNAME \
@@ -70,7 +70,7 @@
 	 } \
 	else \
 	 do { \
-	   synerr(_("Input line too long\n")); \
+	   synerr(gv, _("Input line too long\n")); \
 	   FLEX_EXIT(EXIT_FAILURE);  \
 	 } while (0)
 
@@ -89,30 +89,33 @@
 		gv->reject = true;
 
 #define YY_USER_INIT \
-	if ( getenv("POSIXLY_CORRECT") ) \
-		gv->ctrl.posix_compat = true;
+	if ( getenv("POSIXLY_CORRECT") ) {\
+                FlexState* gv = yyget_extra ( yyscanner ); \
+		gv->ctrl.posix_compat = true; \
+                }
 
 #define START_CODEBLOCK(x) do { \
     /* Emit the needed line directive... */\
     if (gv->indented_code == false) { \
         if (!x) gv->linenum++; \
-        line_directive_out(NULL, gv->infilename, gv->linenum);	\
+        line_directive_out(gv, NULL, gv->infilename, gv->linenum);	\
     } \
-    add_action(M4QSTART); \
-    yy_push_state(CODEBLOCK); \
+    add_action(gv, M4QSTART); \
+    yy_push_state(CODEBLOCK, yyscanner); \
     if ((gv->indented_code = x)) ACTION_ECHO; \
 } while(0)
 
 #define END_CODEBLOCK do { \
-    yy_pop_state();\
-    add_action(M4QEND); \
-    if (!gv->indented_code) line_directive_out(NULL, NULL, gv->linenum);	\
+    yy_pop_state(yyscanner);\
+    add_action(gv, M4QEND); \
+    if (!gv->indented_code) line_directive_out(gv, NULL, NULL, gv->linenum);	\
 } while (0)
 
+#define YY_EXTRA_TYPE FlexState*
 %}
 
 %option caseless nodefault noreject stack noyy_top_state
-%option nostdinit
+%option nostdinit reentrant bison-bridge
 
 %x SECT2 SECT2PROLOG SECT3 CODEBLOCK PICKUPDEF SC CARETISBOL NUM QUOTE
 %x FIRSTCCL CCL ACTION RECOVER COMMENT ACTION_STRING PERCENT_BRACE_ACTION
@@ -149,8 +152,8 @@ M4QEND      "]""]"
 FUNARGS     [^)]*
 
 %{
-void context_call(char *);
-void context_member(char *, const char *);
+void context_call(FlexState* gv, char *);
+void context_member(FlexState* gv, char *, const char *);
 #undef yyreject
 %}
 %%
@@ -161,12 +164,13 @@ void context_member(char *, const char *);
 	//static bool doing_codeblock = false;
 	//int brace_depth=0, brace_start_line=0;
 	//char nmdef[MAXLINE];
+        FlexState* gv = yyget_extra ( yyscanner );
 
 
 <INITIAL>{
 	^{WS}		START_CODEBLOCK(true);
-	^"/*"		add_action("/*[""["); yy_push_state( COMMENT );
-	^#{OPTWS}line{WS}	yy_push_state( LINEDIR );
+	^"/*"		add_action(gv, "/*[""["); yy_push_state( COMMENT, yyscanner );
+	^#{OPTWS}line{WS}	yy_push_state( LINEDIR, yyscanner );
 	^"%s"{NAME}?	return SCDECL;
 	^"%x"{NAME}?	return XSCDECL;
 	^"%{".*{NL}	START_CODEBLOCK(false);
@@ -177,20 +181,20 @@ void context_member(char *, const char *);
 		snprintf(trampoline, sizeof(trampoline),
 			 "M4_HOOK_TRACE_LINE_FORMAT(%d, [[%s]])",
 			 gv->linenum, gv->infilename?gv->infilename:"<stdin>");
-                buf_strappend(&gv->top_buf, trampoline);
+                buf_strappend(gv, &gv->top_buf, trampoline);
                 gv->brace_depth = 1;
-                yy_push_state(CODEBLOCK_MATCH_BRACE);
+                yy_push_state(CODEBLOCK_MATCH_BRACE, yyscanner);
             }
 
-    ^"%top".*   synerr( _("malformed '%top' directive") );
+    ^"%top".*   synerr(gv, _("malformed '%top' directive") );
 
 	{WS}		/* discard */
 
 	^"%%".*		{
 			gv->sectnum = 2;
 			gv->bracelevel = 0;
-			mark_defs1();
-			line_directive_out(NULL, gv->infilename, gv->linenum);
+			mark_defs1(gv);
+			line_directive_out(gv, NULL, gv->infilename, gv->linenum);
 			BEGIN(SECT2PROLOG);
 			return SECTEND;
 			}
@@ -204,7 +208,7 @@ void context_member(char *, const char *);
 	^"%"{LEXOPT}{WS}.*{NL}	++gv->linenum;	/* ignore */
 
 	/* xgettext: no-c-format */
-	^"%"[^sxaceknopr{}].*	synerr( _( "unrecognized '%' directive" ) );
+	^"%"[^sxaceknopr{}].*	synerr(gv, _( "unrecognized '%' directive" ) );
 
 	^{NAME}		{
 			if(yyleng < MAXLINE)
@@ -213,7 +217,7 @@ void context_member(char *, const char *);
 			 }
 			else
 			 {
-			   synerr( _("Definition name too long\n"));
+			   synerr(gv, _("Definition name too long\n"));
 			   FLEX_EXIT(EXIT_FAILURE);
 			 }
 
@@ -234,33 +238,33 @@ void context_member(char *, const char *);
 	{NL}	    ++gv->linenum; ACTION_ECHO;
 }
 <COMMENT>{
-	"*/"	    add_action("*/]""]"); yy_pop_state();
+	"*/"	    add_action(gv, "*/]""]"); yy_pop_state(yyscanner);
 }
 <CODE_COMMENT>{
-        "*/"        ACTION_ECHO; yy_pop_state();
+        "*/"        ACTION_ECHO; yy_pop_state(yyscanner);
 }
 
 <COMMENT_DISCARD>{
         /* This is the same as COMMENT, but is discarded rather than output. */
-	"*/"		yy_pop_state();
+	"*/"		yy_pop_state(yyscanner);
     "*"         ;
 	[^*\n]      ;
 	{NL}	    ++gv->linenum;
 }
 
 <EXTENDED_COMMENT>{
-    ")"         yy_pop_state();
+    ")"         yy_pop_state(yyscanner);
     [^\n\)]+      ;
     {NL}        ++gv->linenum;
 }
 
 <LINEDIR>{
-	\n		yy_pop_state();
+	\n		yy_pop_state(yyscanner);
 	[[:digit:]]+	gv->linenum = myctoi( yytext );
 
 	"\""[^""\n]*"\""	{
 			free(gv->infilename);
-			gv->infilename = xstrdup(yytext + 1);
+			gv->infilename = xstrdup(gv, yytext + 1);
 			gv->infilename[strlen( gv->infilename ) - 1] = '\0';
 			}
 	.		/* ignore spurious characters */
@@ -285,30 +289,30 @@ void context_member(char *, const char *);
     "}"     {
                 if( --gv->brace_depth == 0){
                     /* TODO: Matched. */
-                    yy_pop_state();
+                    yy_pop_state(yyscanner);
                 }else
-                    buf_strnappend(&gv->top_buf, yytext, yyleng);
+                    buf_strnappend(gv, &gv->top_buf, yytext, yyleng);
             }
 
     "{"     {
                 gv->brace_depth++;
-                buf_strnappend(&gv->top_buf, yytext, yyleng);
+                buf_strnappend(gv, &gv->top_buf, yytext, yyleng);
             }
 
     {NL}    {
                 ++gv->linenum;
-                buf_strnappend(&gv->top_buf, yytext, yyleng);
+                buf_strnappend(gv, &gv->top_buf, yytext, yyleng);
             }
 
-    {M4QSTART}  buf_strnappend(&gv->top_buf, gv->escaped_qstart, (int) strlen(gv->escaped_qstart));
-    {M4QEND}    buf_strnappend(&gv->top_buf, gv->escaped_qend, (int) strlen(gv->escaped_qend));
+    {M4QSTART}  buf_strnappend(gv, &gv->top_buf, gv->escaped_qstart, (int) strlen(gv->escaped_qstart));
+    {M4QEND}    buf_strnappend(gv, &gv->top_buf, gv->escaped_qend, (int) strlen(gv->escaped_qend));
     ([^{}\r\n\[\]]+)|[^{}\r\n]  {
-       buf_strnappend(&gv->top_buf, yytext, yyleng);
+       buf_strnappend(gv, &gv->top_buf, yytext, yyleng);
     }
 
     <<EOF>>     {
                 gv->linenum = gv->brace_start_line;
-                synerr(_("Unmatched '{'"));
+                synerr(gv, _("Unmatched '{'"));
                 return YY_NULL;
                 }
 }
@@ -324,7 +328,7 @@ void context_member(char *, const char *);
  		         }
  		        else
  		         {
- 		           format_synerr( _("Definition value for {%s} too long\n"), gv->nmstr);
+ 		           format_synerr(gv, _("Definition value for {%s} too long\n"), gv->nmstr);
  		           FLEX_EXIT(EXIT_FAILURE);
 			 }
 			/* Skip trailing whitespace. */
@@ -335,13 +339,13 @@ void context_member(char *, const char *);
 			    gv->nmdef[i] = '\0';
 			}
 
-			ndinstal( gv->nmstr, gv->nmdef );
+			ndinstal( gv, gv->nmstr, gv->nmdef );
 			gv->didadef = true;
 			}
 
 	{NL}		{
 			if ( ! gv->didadef )
-				synerr( _( "incomplete name definition" ) );
+				synerr(gv, _( "incomplete name definition" ) );
 			BEGIN(INITIAL);
 			++gv->linenum;
 			}
@@ -483,7 +487,7 @@ void context_member(char *, const char *);
 			 }
 			else
 			 {
-			   synerr( _("Option line too long\n"));
+			   synerr(gv, _("Option line too long\n"));
 			   FLEX_EXIT(EXIT_FAILURE);
 			 }
 			gv->nmstr[strlen( gv->nmstr ) - 1] = '\0';
@@ -491,7 +495,7 @@ void context_member(char *, const char *);
 			}
 
 	(([a-mo-z]|n[a-np-z])[[:alpha:]\-+]*)|.	{
-			format_synerr( _( "unrecognized %%option: %s" ),
+			format_synerr(gv, _( "unrecognized %%option: %s" ),
 				yytext );
 			BEGIN(RECOVER);
 			}
@@ -512,7 +516,7 @@ void context_member(char *, const char *);
             /* not in %{ ... %} */
             yyless( 0 );	/* put it all back */
             yy_set_bol( 1 );
-            mark_prolog();
+            mark_prolog(gv);
             BEGIN(SECT2);
         } else {
             START_CODEBLOCK(true);
@@ -523,7 +527,7 @@ void context_member(char *, const char *);
 	{NL}	++gv->linenum; ACTION_ECHO;
 
 	<<EOF>>		{
-			mark_prolog();
+			mark_prolog(gv);
 			gv->sectnum = 0;
 			return YY_NULL; /* to stop the parser */
 			}
@@ -575,7 +579,7 @@ void context_member(char *, const char *);
                             yyless(amt);
                         }
                         else {
-                            add_action("]""]");
+                            add_action(gv, "]""]");
                             gv->continued_action = true;
                             ++gv->linenum;
                             return '\n';
@@ -586,7 +590,7 @@ void context_member(char *, const char *);
 
                 if (sf_skip_ws()){
                     /* We're in the middle of a (?x: ) pattern. */
-                    yy_push_state(COMMENT_DISCARD);
+                    yy_push_state(COMMENT_DISCARD, yyscanner);
                 }
                 else{
                     yyless( yyleng - 2 );	/* put back '/', '*' */
@@ -659,7 +663,7 @@ void context_member(char *, const char *);
 			 }
 			else
 			 {
-			   synerr( _("Input line too long\n"));
+			   synerr(gv, _("Input line too long\n"));
 			   FLEX_EXIT(EXIT_FAILURE);
 			 }
 
@@ -671,7 +675,7 @@ void context_member(char *, const char *);
                    * The reason it was disabled is so yacc/bison can parse
                    * ccl operations, such as ccl difference and union.
                    */
-                &&  (cclval = ccllookup( gv->nmstr )) != 0 )
+                &&  (cclval = ccllookup( gv, gv->nmstr )) != 0 )
 				{
      				 /* Dead code removed */
 				}
@@ -680,7 +684,7 @@ void context_member(char *, const char *);
 				/* We fudge a bit.  We know that this ccl will
 				 * soon be numbered as lastccl + 1 by cclinit.
 				 */
-				cclinstal( gv->nmstr, gv->lastccl + 1 );
+				cclinstal( gv, gv->nmstr, gv->lastccl + 1 );
 
 				/* Push back everything but the leading bracket
 				 * so the ccl can be rescanned.
@@ -712,13 +716,13 @@ void context_member(char *, const char *);
  			 }
  			else
  			 {
- 			   synerr( _("Input line too long\n"));
+ 			   synerr(gv, _("Input line too long\n"));
  			   FLEX_EXIT(EXIT_FAILURE);
  			 }
 gv->nmstr[yyleng - 2 - end_is_ws] = '\0';  /* chop trailing brace */
 
-			if ( (nmdefptr = ndlookup( gv->nmstr )) == 0 )
-				format_synerr(
+			if ( (nmdefptr = ndlookup( gv, gv->nmstr )) == 0 )
+				format_synerr(gv,
 					_( "undefined definition {%s}" ),
 						gv->nmstr );
 
@@ -749,7 +753,7 @@ gv->nmstr[yyleng - 2 - end_is_ws] = '\0';  /* chop trailing brace */
 
     "/*"        {
                     if (sf_skip_ws())
-                        yy_push_state(COMMENT_DISCARD);
+                        yy_push_state(COMMENT_DISCARD, yyscanner);
                     else{
                         /* Push back the "*" and return "/" as usual. */
                         yyless(1);
@@ -761,14 +765,14 @@ gv->nmstr[yyleng - 2 - end_is_ws] = '\0';  /* chop trailing brace */
                     if (gv->ctrl.lex_compat || gv->ctrl.posix_compat){
                         /* Push back the "?#" and treat it like a normal parens. */
                         yyless(1);
-                        sf_push(); 
+                        sf_push(gv);
                         return '(';
                     }
                     else
-                        yy_push_state(EXTENDED_COMMENT);
+                        yy_push_state(EXTENDED_COMMENT, yyscanner);
                 }
     "(?"        {
-                    sf_push();
+                    sf_push(gv);
                     if (gv->ctrl.lex_compat || gv->ctrl.posix_compat)
                         /* Push back the "?" and treat it like a normal parens. */
                         yyless(1);
@@ -776,13 +780,13 @@ gv->nmstr[yyleng - 2 - end_is_ws] = '\0';  /* chop trailing brace */
                         BEGIN(GROUP_WITH_PARAMS);
                     return '(';
                 }
-    "("         sf_push(); return '(';
+    "("         sf_push(gv); return '(';
     ")"         {
                     if (gv->_sf_top_ix > 0) {
-                        sf_pop();
+                        sf_pop(gv);
                         return ')';
                     } else
-                        synerr(_("unbalanced parenthesis"));
+                        synerr(gv, _("unbalanced parenthesis"));
                 }
 
 	[/|*+?.(){}]	return (unsigned char) yytext[0];
@@ -797,7 +801,7 @@ gv->nmstr[yyleng - 2 - end_is_ws] = '\0';  /* chop trailing brace */
 	">"/^		BEGIN(CARETISBOL); return '>';
 	{SCNAME}	RETURNNAME;
 	.		{
-			format_synerr( _( "bad <start condition>: %s" ),
+			format_synerr(gv, _( "bad <start condition>: %s" ),
 				yytext );
 			}
 }
@@ -810,7 +814,7 @@ gv->nmstr[yyleng - 2 - end_is_ws] = '\0';  /* chop trailing brace */
 	"\""		BEGIN(SECT2); return '"';
 
 	{NL}		{
-			synerr( _( "missing quote" ) );
+			synerr(gv, _( "missing quote" ) );
 			BEGIN(SECT2);
 			++gv->linenum;
 			return '"';
@@ -842,7 +846,7 @@ gv->nmstr[yyleng - 2 - end_is_ws] = '\0';  /* chop trailing brace */
 	[^\]\n]		RETURNCHAR;
 	"]"		BEGIN(SECT2); return ']';
 	.|{NL}		{
-			synerr( _( "bad character class" ) );
+			synerr(gv, _( "bad character class" ) );
 			BEGIN(SECT2);
 			return ']';
 			}
@@ -875,7 +879,7 @@ gv->nmstr[yyleng - 2 - end_is_ws] = '\0';  /* chop trailing brace */
 	"[:^upper:]"	BEGIN(CCL); return CCE_NEG_UPPER;
 	"[:^xdigit:]"	BEGIN(CCL); return CCE_NEG_XDIGIT;
 	{CCL_EXPR}	{
-			format_synerr(
+			format_synerr(gv,
 				_( "bad character class expression: %s" ),
 					yytext );
 			BEGIN(CCL); return CCE_ALNUM;
@@ -884,7 +888,7 @@ gv->nmstr[yyleng - 2 - end_is_ws] = '\0';  /* chop trailing brace */
 
 <NUM>{
 	[[:digit:]]+	{
-			yylval = myctoi( yytext );
+			*yylval = myctoi( yytext );
 			return NUMBER;
 			}
 
@@ -898,13 +902,13 @@ gv->nmstr[yyleng - 2 - end_is_ws] = '\0';  /* chop trailing brace */
 			}
 
 	.		{
-			synerr( _( "bad character inside {}'s" ) );
+			synerr(gv, _( "bad character inside {}'s" ) );
 			BEGIN(SECT2);
 			return '}';
 			}
 
 	{NL}		{
-			synerr( _( "missing }" ) );
+			synerr(gv, _( "missing }" ) );
 			BEGIN(SECT2);
 			++gv->linenum;
 			return '}';
@@ -915,7 +919,7 @@ gv->nmstr[yyleng - 2 - end_is_ws] = '\0';  /* chop trailing brace */
 <PERCENT_BRACE_ACTION>{
 	{OPTWS}"%}".*		gv->bracelevel = 0;
 
-	<ACTION>"/*"		ACTION_ECHO; yy_push_state( CODE_COMMENT );
+	<ACTION>"/*"		ACTION_ECHO; yy_push_state( CODE_COMMENT, yyscanner );
 
 	<CODEBLOCK,ACTION>{
 		"reject" {
@@ -923,13 +927,13 @@ gv->nmstr[yyleng - 2 - end_is_ws] = '\0';  /* chop trailing brace */
 			CHECK_REJECT(yytext);
         }
 		"yyreject"{OPTWS}"("{OPTWS}")" {
-			add_action("]""]M4_HOOK_REJECT[""[");
+			add_action(gv, "]""]M4_HOOK_REJECT[""[");
 			CHECK_YYREJECT(yytext);
         }
 		"yymore"{OPTWS}"("{OPTWS}")" {
 			gv->yymore_used = true;
 			if (gv->ctrl.rewrite)
-				context_call(yytext);
+				context_call(gv, yytext);
 			else
 				ACTION_ECHO;
         }
@@ -941,7 +945,7 @@ gv->nmstr[yyleng - 2 - end_is_ws] = '\0';  /* chop trailing brace */
 		ACTION_ECHO;
 		if (gv->bracelevel <= 0 || (gv->doing_codeblock && gv->indented_code)) {
             if ( gv->doing_rule_action )
-                add_action( "\t]""]M4_HOOK_STATE_CASE_BREAK\n" );
+                add_action( gv, "\t]""]M4_HOOK_STATE_CASE_BREAK\n" );
 
             gv->doing_rule_action = gv->doing_codeblock = false;
             BEGIN(SECT2);
@@ -956,24 +960,24 @@ gv->nmstr[yyleng - 2 - end_is_ws] = '\0';  /* chop trailing brace */
 	"}"		ACTION_ECHO; --gv->bracelevel;
 	yyecho\(\)|yyinput\(\)|yystart\({FUNARGS}\)|yybegin\({FUNARGS}\)|yyunput\({FUNARGS}\)|yypanic\({FUNARGS}\)|yyatbol\(\)|yysetbol\({FUNARGS}\) {
 			if (gv->ctrl.rewrite)
-				context_call(yytext);
+				context_call(gv, yytext);
 			else
 				ACTION_ECHO;
 	}
 	yyterminate\(\)|yyless\({FUNARGS}\) {
-			add_action("]""]");
-			add_action(yytext);
-			add_action("[""[");
+			add_action(gv, "]""]");
+			add_action(gv, yytext);
+			add_action(gv, "[""[");
 	}
 	(yyin|yyout|yyextra|yyleng|yytext|yyflexdebug)/[^[:alnum:]_] {
 			if (gv->ctrl.rewrite)
-				context_member(yytext, "M4_PROPERTY_CONTEXT_FORMAT");
+				context_member(gv, yytext, "M4_PROPERTY_CONTEXT_FORMAT");
 			else
 				ACTION_ECHO;
 	}
 	(yylineno|yycolumn)/[^[:alnum:]_] {
 			if (gv->ctrl.rewrite)
-				context_member(yytext, "M4_PROPERTY_BUFFERSTACK_CONTEXT_FORMAT");
+				context_member(gv, yytext, "M4_PROPERTY_BUFFERSTACK_CONTEXT_FORMAT");
 			else
 				ACTION_ECHO;
 	}
@@ -987,7 +991,7 @@ gv->nmstr[yyleng - 2 - end_is_ws] = '\0';  /* chop trailing brace */
                 ACTION_ECHO;
                 if (gv->bracelevel <= 0) {
                    if ( gv->doing_rule_action )
-                      add_action( "\t]""]M4_HOOK_STATE_CASE_BREAK\n" );
+                      add_action( gv, "\t]""]M4_HOOK_STATE_CASE_BREAK\n" );
 
                    gv->doing_rule_action = false;
                    BEGIN(SECT2);
@@ -1012,17 +1016,17 @@ gv->nmstr[yyleng - 2 - end_is_ws] = '\0';  /* chop trailing brace */
 }
 
 <COMMENT,CODE_COMMENT,COMMENT_DISCARD,ACTION,ACTION_STRING,CHARACTER_CONSTANT><<EOF>>	{
-			synerr( _( "EOF encountered inside an action" ) );
+			synerr(gv, _( "EOF encountered inside an action" ) );
 			yyterminate();
 			}
 
 <EXTENDED_COMMENT,GROUP_WITH_PARAMS,GROUP_MINUS_PARAMS><<EOF>>	{
-			synerr( _( "EOF encountered inside pattern" ) );
+			synerr(gv, _( "EOF encountered inside pattern" ) );
 			yyterminate();
 			}
 
 <SECT2,QUOTE,FIRSTCCL,CCL>{ESCSEQ}	{
-			yylval = myesc( (unsigned char *) yytext );
+			*yylval = myesc( (unsigned char *) yytext );
 
 			if ( YY_START == FIRSTCCL )
 				BEGIN(CCL);
@@ -1050,16 +1054,17 @@ gv->nmstr[yyleng - 2 - end_is_ws] = '\0';  /* chop trailing brace */
        yyterminate();
     }
 }
-<*>.|\n			format_synerr( _( "bad character: %s" ), yytext );
+<*>.|\n			format_synerr(gv, _( "bad character: %s" ), yytext );
 
 %%
 
 
-int yywrap(void)
+int yywrap(yyscan_t yyscanner)
 	{
+        FlexState* gv = yyget_extra ( yyscanner );
 	if ( --gv->num_input_files > 0 )
 		{
-		set_input_file( *++gv->input_files );
+		set_input_file( gv, *++gv->input_files );
 		return 0;
 		}
 
@@ -1070,32 +1075,38 @@ int yywrap(void)
 
 /* set_input_file - open the given file (if NULL, stdin) for scanning */
 
-void set_input_file( char *file )
+void set_input_file( yyscan_t yyscanner, char *file )
 	{
+        struct yyguts_t * yyg = (struct yyguts_t*)yyscanner;
+        FlexState* gv = yyget_extra ( yyscanner );
 	if ( file && strcmp( file, "-" ) )
 		{
-		gv->infilename = xstrdup(file);
+                free(gv->infilename);
+		gv->infilename = xstrdup(gv, file);
+                if(gv->fp_infilename && gv->fp_infilename != stdin) fclose(gv->fp_infilename);
 		yyin = fopen( gv->infilename, "r" );
 
 		if ( yyin == NULL )
-			lerr( _( "can't open %s: %s" ), file, strerror(errno));
+			lerr(gv, _( "can't open %s: %s" ), file, strerror(errno));
+                gv->fp_infilename = yyin;
 		}
 
 	else
 		{
 		yyin = stdin;
-		gv->infilename = xstrdup("<stdin>");
+                free(gv->infilename);
+		gv->infilename = xstrdup(gv, "<stdin>");
 		}
 
 	gv->linenum = 1;
 	}
 
-void context_call(char *txt) {
-	const char *context_arg = skel_property("M4_PROPERTY_CONTEXT_ARG");
+void context_call(FlexState* gv, char *txt) {
+	const char *context_arg = skel_property(gv, "M4_PROPERTY_CONTEXT_ARG");
 
 	/* if there's no such property, simply pass through */
 	if (context_arg == NULL) {
-		add_action(txt);
+		add_action(gv, txt);
 	} else {
 		char buf[BUFSIZ];
 
@@ -1103,24 +1114,24 @@ void context_call(char *txt) {
 		assert(txt[strlen(txt)-1] == ')');
 		strncpy(buf, txt, sizeof(buf));
 		buf[strlen(buf)-1] = '\0';	/* remove trailing ) */
-		add_action(buf);
+		add_action(gv, buf);
 		if (txt[strlen(buf)-1] != '(') {
-			add_action(", ");
+			add_action(gv, ", ");
 		}
-		add_action(context_arg);
-		add_action(")");
+		add_action(gv, context_arg);
+		add_action(gv, ")");
 	}
 }
 
-void context_member(char *txt, const char *prop) {
-	const char *context_format = skel_property(prop);
+void context_member(FlexState* gv, char *txt, const char *prop) {
+	const char *context_format = skel_property(gv, prop);
 
 	/* if there's no such property, simply pass through */
 	if (context_format == NULL) {
-		add_action(txt);
+		add_action(gv, txt);
 	} else {
 		char buf[128];
 		snprintf(buf, sizeof(buf), context_format, txt);
-		add_action(buf);
+		add_action(gv, buf);
 	}
 }

--- a/src/scan.l
+++ b/src/scan.l
@@ -39,9 +39,9 @@
 /*  PURPOSE. */
 
 #include "parse.h"
-extern bool tablesverify, tablesext;
-extern bool trlcontxt; /* Set in parse.y for each rule. */
-extern const char *escaped_qstart, *escaped_qend;
+//extern bool tablesverify, tablesext;
+//extern bool trlcontxt; /* Set in parse.y for each rule. */
+//extern const char *escaped_qstart, *escaped_qend;
 
 #define M4QSTART "[""["
 #define M4QEND "]""]"
@@ -65,7 +65,7 @@ extern const char *escaped_qstart, *escaped_qend;
 #define RETURNNAME \
 	if(yyleng < MAXLINE) \
          { \
-	strncpy( nmstr, yytext, sizeof(nmstr) ); \
+	strncpy( gv->nmstr, yytext, sizeof(gv->nmstr) ); \
 	return NAME; \
 	 } \
 	else \
@@ -82,31 +82,31 @@ extern const char *escaped_qstart, *escaped_qend;
 
 #define CHECK_REJECT(str) \
 	if ( all_upper( str ) ) \
-		reject = true;
+		gv->reject = true;
 
 #define CHECK_YYREJECT(str) \
 	if ( all_lower( str ) ) \
-		reject = true;
+		gv->reject = true;
 
 #define YY_USER_INIT \
 	if ( getenv("POSIXLY_CORRECT") ) \
-		ctrl.posix_compat = true;
+		gv->ctrl.posix_compat = true;
 
 #define START_CODEBLOCK(x) do { \
     /* Emit the needed line directive... */\
-    if (indented_code == false) { \
-        if (!x) linenum++; \
-        line_directive_out(NULL, infilename, linenum);	\
+    if (gv->indented_code == false) { \
+        if (!x) gv->linenum++; \
+        line_directive_out(NULL, gv->infilename, gv->linenum);	\
     } \
     add_action(M4QSTART); \
     yy_push_state(CODEBLOCK); \
-    if ((indented_code = x)) ACTION_ECHO; \
+    if ((gv->indented_code = x)) ACTION_ECHO; \
 } while(0)
 
 #define END_CODEBLOCK do { \
     yy_pop_state();\
     add_action(M4QEND); \
-    if (!indented_code) line_directive_out(NULL, NULL, linenum);	\
+    if (!gv->indented_code) line_directive_out(NULL, NULL, gv->linenum);	\
 } while (0)
 
 %}
@@ -154,13 +154,13 @@ void context_member(char *, const char *);
 #undef yyreject
 %}
 %%
-	static int bracelevel, didadef, indented_code;
-	static bool doing_rule_action = false;
-	static bool option_sense;
+	//static int bracelevel, didadef, indented_code;
+	//static bool doing_rule_action = false;
+	//static bool option_sense;
 
-	static bool doing_codeblock = false;
-	int brace_depth=0, brace_start_line=0;
-	char nmdef[MAXLINE];
+	//static bool doing_codeblock = false;
+	//int brace_depth=0, brace_start_line=0;
+	//char nmdef[MAXLINE];
 
 
 <INITIAL>{
@@ -172,13 +172,13 @@ void context_member(char *, const char *);
 	^"%{".*{NL}	START_CODEBLOCK(false);
     ^"%top"[[:blank:]]*"{"[[:blank:]]*{NL}    {
 		char trampoline[512];
-                brace_start_line = linenum;
-                ++linenum;
+                gv->brace_start_line = gv->linenum;
+                ++gv->linenum;
 		snprintf(trampoline, sizeof(trampoline),
 			 "M4_HOOK_TRACE_LINE_FORMAT(%d, [[%s]])",
-			 linenum, infilename?infilename:"<stdin>");
-                buf_strappend(&top_buf, trampoline);
-                brace_depth = 1;
+			 gv->linenum, gv->infilename?gv->infilename:"<stdin>");
+                buf_strappend(&gv->top_buf, trampoline);
+                gv->brace_depth = 1;
                 yy_push_state(CODEBLOCK_MATCH_BRACE);
             }
 
@@ -187,21 +187,21 @@ void context_member(char *, const char *);
 	{WS}		/* discard */
 
 	^"%%".*		{
-			sectnum = 2;
-			bracelevel = 0;
+			gv->sectnum = 2;
+			gv->bracelevel = 0;
 			mark_defs1();
-			line_directive_out(NULL, infilename, linenum);
+			line_directive_out(NULL, gv->infilename, gv->linenum);
 			BEGIN(SECT2PROLOG);
 			return SECTEND;
 			}
 
-	^"%pointer".*{NL}	ctrl.yytext_is_array = false; ++linenum;
-	^"%array".*{NL}		ctrl.yytext_is_array = true; ++linenum;
+	^"%pointer".*{NL}	gv->ctrl.yytext_is_array = false; ++gv->linenum;
+	^"%array".*{NL}		gv->ctrl.yytext_is_array = true; ++gv->linenum;
 
 	^"%option"	BEGIN(OPTION); return TOK_OPTION;
 
-	^"%"{LEXOPT}{OPTWS}[[:digit:]]*{OPTWS}{NL}	++linenum; /* ignore */
-	^"%"{LEXOPT}{WS}.*{NL}	++linenum;	/* ignore */
+	^"%"{LEXOPT}{OPTWS}[[:digit:]]*{OPTWS}{NL}	++gv->linenum; /* ignore */
+	^"%"{LEXOPT}{WS}.*{NL}	++gv->linenum;	/* ignore */
 
 	/* xgettext: no-c-format */
 	^"%"[^sxaceknopr{}].*	synerr( _( "unrecognized '%' directive" ) );
@@ -209,7 +209,7 @@ void context_member(char *, const char *);
 	^{NAME}		{
 			if(yyleng < MAXLINE)
         		 {
-			strncpy( nmstr, yytext, sizeof(nmstr) );
+			strncpy( gv->nmstr, yytext, sizeof(gv->nmstr) );
 			 }
 			else
 			 {
@@ -217,13 +217,13 @@ void context_member(char *, const char *);
 			   FLEX_EXIT(EXIT_FAILURE);
 			 }
 
-			didadef = false;
+			gv->didadef = false;
 			BEGIN(PICKUPDEF);
 			}
 
 	{SCNAME}	RETURNNAME;
-	^{OPTWS}{NL}	++linenum; /* allows blank lines in section 1 */
-	{OPTWS}{NL}	ACTION_ECHO; ++linenum; /* maybe end of comment line */
+	^{OPTWS}{NL}	++gv->linenum; /* allows blank lines in section 1 */
+	{OPTWS}{NL}	ACTION_ECHO; ++gv->linenum; /* maybe end of comment line */
 }
 
 
@@ -231,7 +231,7 @@ void context_member(char *, const char *);
         [^\[\]\*\n]*  ACTION_ECHO;
         .           ACTION_ECHO;
 
-	{NL}	    ++linenum; ACTION_ECHO;
+	{NL}	    ++gv->linenum; ACTION_ECHO;
 }
 <COMMENT>{
 	"*/"	    add_action("*/]""]"); yy_pop_state();
@@ -245,23 +245,23 @@ void context_member(char *, const char *);
 	"*/"		yy_pop_state();
     "*"         ;
 	[^*\n]      ;
-	{NL}	    ++linenum;
+	{NL}	    ++gv->linenum;
 }
 
 <EXTENDED_COMMENT>{
     ")"         yy_pop_state();
     [^\n\)]+      ;
-    {NL}        ++linenum;
+    {NL}        ++gv->linenum;
 }
 
 <LINEDIR>{
 	\n		yy_pop_state();
-	[[:digit:]]+	linenum = myctoi( yytext );
+	[[:digit:]]+	gv->linenum = myctoi( yytext );
 
 	"\""[^""\n]*"\""	{
-			free(infilename);
-			infilename = xstrdup(yytext + 1);
-			infilename[strlen( infilename ) - 1] = '\0';
+			free(gv->infilename);
+			gv->infilename = xstrdup(yytext + 1);
+			gv->infilename[strlen( gv->infilename ) - 1] = '\0';
 			}
 	.		/* ignore spurious characters */
 }
@@ -271,43 +271,43 @@ void context_member(char *, const char *);
 }
 
 <CODEBLOCK>{
-	^"%}".*{NL}	++linenum; END_CODEBLOCK;
+	^"%}".*{NL}	++gv->linenum; END_CODEBLOCK;
 	[^\n%\[\]]*         ACTION_ECHO;
         .		ACTION_ECHO;
 	{NL}		{
-			++linenum;
+			++gv->linenum;
 			ACTION_ECHO;
-			if ( indented_code ) END_CODEBLOCK;
+			if ( gv->indented_code ) END_CODEBLOCK;
 			}
 }
 
 <CODEBLOCK_MATCH_BRACE>{
     "}"     {
-                if( --brace_depth == 0){
+                if( --gv->brace_depth == 0){
                     /* TODO: Matched. */
                     yy_pop_state();
                 }else
-                    buf_strnappend(&top_buf, yytext, yyleng);
+                    buf_strnappend(&gv->top_buf, yytext, yyleng);
             }
 
     "{"     {
-                brace_depth++;
-                buf_strnappend(&top_buf, yytext, yyleng);
+                gv->brace_depth++;
+                buf_strnappend(&gv->top_buf, yytext, yyleng);
             }
 
     {NL}    {
-                ++linenum;
-                buf_strnappend(&top_buf, yytext, yyleng);
+                ++gv->linenum;
+                buf_strnappend(&gv->top_buf, yytext, yyleng);
             }
 
-    {M4QSTART}  buf_strnappend(&top_buf, escaped_qstart, (int) strlen(escaped_qstart));
-    {M4QEND}    buf_strnappend(&top_buf, escaped_qend, (int) strlen(escaped_qend));
+    {M4QSTART}  buf_strnappend(&gv->top_buf, gv->escaped_qstart, (int) strlen(gv->escaped_qstart));
+    {M4QEND}    buf_strnappend(&gv->top_buf, gv->escaped_qend, (int) strlen(gv->escaped_qend));
     ([^{}\r\n\[\]]+)|[^{}\r\n]  {
-       buf_strnappend(&top_buf, yytext, yyleng);
+       buf_strnappend(&gv->top_buf, yytext, yyleng);
     }
 
     <<EOF>>     {
-                linenum = brace_start_line;
+                gv->linenum = gv->brace_start_line;
                 synerr(_("Unmatched '{'"));
                 return YY_NULL;
                 }
@@ -320,140 +320,140 @@ void context_member(char *, const char *);
 	{NOT_WS}[^\r\n]*	{
  		        if(yyleng < MAXLINE)
  		         {
-			strncpy( nmdef, yytext, sizeof(nmdef) );
+			strncpy( gv->nmdef, yytext, sizeof(gv->nmdef) );
  		         }
  		        else
  		         {
- 		           format_synerr( _("Definition value for {%s} too long\n"), nmstr);
+ 		           format_synerr( _("Definition value for {%s} too long\n"), gv->nmstr);
  		           FLEX_EXIT(EXIT_FAILURE);
 			 }
 			/* Skip trailing whitespace. */
 			{
-			    size_t i = strlen( nmdef );
-			    while (i > 0 && (nmdef[i-1] == ' ' || nmdef[i-1] == '\t'))
+			    size_t i = strlen( gv->nmdef );
+			    while (i > 0 && (gv->nmdef[i-1] == ' ' || gv->nmdef[i-1] == '\t'))
 			       --i;
-			    nmdef[i] = '\0';
+			    gv->nmdef[i] = '\0';
 			}
 
-			ndinstal( nmstr, nmdef );
-			didadef = true;
+			ndinstal( gv->nmstr, gv->nmdef );
+			gv->didadef = true;
 			}
 
 	{NL}		{
-			if ( ! didadef )
+			if ( ! gv->didadef )
 				synerr( _( "incomplete name definition" ) );
 			BEGIN(INITIAL);
-			++linenum;
+			++gv->linenum;
 			}
 }
 
 
 <OPTION>{
-	{NL}		++linenum; BEGIN(INITIAL);
-	{WS}		option_sense = true;
+	{NL}		++gv->linenum; BEGIN(INITIAL);
+	{WS}		gv->option_sense = true;
 
 	"="		return '=';
-	[[:digit:]]+	{nmval = atoi(yytext); return TOK_NUMERIC;}
+	[[:digit:]]+	{gv->nmval = atoi(yytext); return TOK_NUMERIC;}
 
-	no		option_sense = ! option_sense;
+	no		gv->option_sense = ! gv->option_sense;
 
-	7bit		ctrl.csize = option_sense ? 128 : 256;
-	8bit		ctrl.csize = option_sense ? 256 : 128;
+	7bit		gv->ctrl.csize = gv->option_sense ? 128 : 256;
+	8bit		gv->ctrl.csize = gv->option_sense ? 256 : 128;
 
-	align		ctrl.long_align = option_sense;
+	align		gv->ctrl.long_align = gv->option_sense;
 	always-interactive	{
-			ctrl.always_interactive = option_sense;
-			ctrl.interactive = (trit)option_sense;
+			gv->ctrl.always_interactive = gv->option_sense;
+			gv->ctrl.interactive = (trit)gv->option_sense;
 			}
-	array		ctrl.yytext_is_array = option_sense;
-	backup		env.backing_up_report = option_sense;
-	batch		ctrl.interactive = (trit)!option_sense;
-	bison-bridge     ctrl.bison_bridge_lval = option_sense;
-	bison-locations  { if((ctrl.bison_bridge_lloc = option_sense))
-                            ctrl.bison_bridge_lval = true;
+	array		gv->ctrl.yytext_is_array = gv->option_sense;
+	backup		gv->env.backing_up_report = gv->option_sense;
+	batch		gv->ctrl.interactive = (trit)!gv->option_sense;
+	bison-bridge     gv->ctrl.bison_bridge_lval = gv->option_sense;
+	bison-locations  { if((gv->ctrl.bison_bridge_lloc = gv->option_sense))
+                            gv->ctrl.bison_bridge_lval = true;
 			}
-	"c++"		ctrl.C_plus_plus = option_sense;
-	caseful|case-sensitive		sf_set_case_ins(!option_sense);
-	caseless|case-insensitive	sf_set_case_ins(option_sense);
-	debug		ctrl.ddebug = option_sense;
-	default		ctrl.spprdflt = ! option_sense;
-	ecs		ctrl.useecs = option_sense;
+	"c++"		gv->ctrl.C_plus_plus = gv->option_sense;
+	caseful|case-sensitive		sf_set_case_ins(!gv->option_sense);
+	caseless|case-insensitive	sf_set_case_ins(gv->option_sense);
+	debug		gv->ctrl.ddebug = gv->option_sense;
+	default		gv->ctrl.spprdflt = ! gv->option_sense;
+	ecs		gv->ctrl.useecs = gv->option_sense;
 	fast		{
-			ctrl.useecs = ctrl.usemecs = false;
-			ctrl.use_read = ctrl.fullspd = true;
+			gv->ctrl.useecs = gv->ctrl.usemecs = false;
+			gv->ctrl.use_read = gv->ctrl.fullspd = true;
 			}
 	full		{
-			ctrl.useecs = ctrl.usemecs = false;
-			ctrl.use_read = ctrl.fulltbl = true;
+			gv->ctrl.useecs = gv->ctrl.usemecs = false;
+			gv->ctrl.use_read = gv->ctrl.fulltbl = true;
 			}
-	input		ctrl.no_yyinput = ! option_sense;
-	yyinput		ctrl.no_yyinput = ! option_sense;
-	interactive	ctrl.interactive = (trit)option_sense;
-	lex-compat	ctrl.lex_compat = option_sense;
-	posix-compat	ctrl.posix_compat = option_sense;
-	line		ctrl.gen_line_dirs = option_sense;
+	input		gv->ctrl.no_yyinput = ! gv->option_sense;
+	yyinput		gv->ctrl.no_yyinput = ! gv->option_sense;
+	interactive	gv->ctrl.interactive = (trit)gv->option_sense;
+	lex-compat	gv->ctrl.lex_compat = gv->option_sense;
+	posix-compat	gv->ctrl.posix_compat = gv->option_sense;
+	line		gv->ctrl.gen_line_dirs = gv->option_sense;
 	main		{
-			ctrl.do_main = option_sense;
+			gv->ctrl.do_main = gv->option_sense;
 			/* Override yywrap */
-			if (option_sense)
-                		ctrl.do_yywrap = false;
+			if (gv->option_sense)
+                		gv->ctrl.do_yywrap = false;
 			}
-	meta-ecs	ctrl.usemecs = option_sense;
+	meta-ecs	gv->ctrl.usemecs = gv->option_sense;
 	never-interactive	{
-			ctrl.never_interactive = option_sense;
-            		ctrl.interactive = (trit)!option_sense;
+			gv->ctrl.never_interactive = gv->option_sense;
+            		gv->ctrl.interactive = (trit)!gv->option_sense;
 			}
-	perf-report	env.performance_hint += option_sense ? 1 : -1;
-	pointer		ctrl.yytext_is_array = ! option_sense;
-	read		ctrl.use_read = option_sense;
-	reentrant	ctrl.reentrant = option_sense;
-	reject		ctrl.reject_really_used = option_sense;
-	rewrite		ctrl.rewrite = option_sense;
-	stack		ctrl.stack_used = option_sense;
-	stdinit		ctrl.do_stdinit = option_sense;
-	stdout		env.use_stdout = option_sense;
-	unistd		ctrl.no_unistd = ! option_sense;
-	unput		ctrl.no_yyunput = ! option_sense;
-	yyunput		ctrl.no_yyunput = ! option_sense;
-	verbose		env.printstats = option_sense;
-	warn		env.nowarn = ! option_sense;
-	yylineno	ctrl.do_yylineno = option_sense;
-	yymore		ctrl.yymore_really_used = option_sense;
-	yywrap		ctrl.do_yywrap = option_sense;
-	yyread		ctrl.noyyread = !option_sense;
+	perf-report	gv->env.performance_hint += gv->option_sense ? 1 : -1;
+	pointer		gv->ctrl.yytext_is_array = ! gv->option_sense;
+	read		gv->ctrl.use_read = gv->option_sense;
+	reentrant	gv->ctrl.reentrant = gv->option_sense;
+	reject		gv->ctrl.reject_really_used = gv->option_sense;
+	rewrite		gv->ctrl.rewrite = gv->option_sense;
+	stack		gv->ctrl.stack_used = gv->option_sense;
+	stdinit		gv->ctrl.do_stdinit = gv->option_sense;
+	stdout		gv->env.use_stdout = gv->option_sense;
+	unistd		gv->ctrl.no_unistd = ! gv->option_sense;
+	unput		gv->ctrl.no_yyunput = ! gv->option_sense;
+	yyunput		gv->ctrl.no_yyunput = ! gv->option_sense;
+	verbose		gv->env.printstats = gv->option_sense;
+	warn		gv->env.nowarn = ! gv->option_sense;
+	yylineno	gv->ctrl.do_yylineno = gv->option_sense;
+	yymore		gv->ctrl.yymore_really_used = gv->option_sense;
+	yywrap		gv->ctrl.do_yywrap = gv->option_sense;
+	yyread		gv->ctrl.noyyread = !gv->option_sense;
 
-	yypanic		ctrl.no_yypanic = !option_sense;
+	yypanic		gv->ctrl.no_yypanic = !gv->option_sense;
 
-	yy_push_state	ctrl.no_yy_push_state = ! option_sense;
-	yy_pop_state	ctrl.no_yy_pop_state = ! option_sense;
-	yy_top_state	ctrl.no_yy_top_state = ! option_sense;
+	yy_push_state	gv->ctrl.no_yy_push_state = ! gv->option_sense;
+	yy_pop_state	gv->ctrl.no_yy_pop_state = ! gv->option_sense;
+	yy_top_state	gv->ctrl.no_yy_top_state = ! gv->option_sense;
 
-	yy_scan_buffer	ctrl.no_yy_scan_buffer = ! option_sense;
-	yy_scan_bytes	ctrl.no_yy_scan_bytes = ! option_sense;
-	yy_scan_string	ctrl.no_yy_scan_string = ! option_sense;
+	yy_scan_buffer	gv->ctrl.no_yy_scan_buffer = ! gv->option_sense;
+	yy_scan_bytes	gv->ctrl.no_yy_scan_bytes = ! gv->option_sense;
+	yy_scan_string	gv->ctrl.no_yy_scan_string = ! gv->option_sense;
 
-	yyalloc         ctrl.no_flex_alloc = ! option_sense;
-	yyrealloc       ctrl.no_flex_realloc = ! option_sense;
-	yyfree          ctrl.no_flex_free = ! option_sense;
+	yyalloc         gv->ctrl.no_flex_alloc = ! gv->option_sense;
+	yyrealloc       gv->ctrl.no_flex_realloc = ! gv->option_sense;
+	yyfree          gv->ctrl.no_flex_free = ! gv->option_sense;
 
-	yyget_debug     ctrl.no_get_debug = ! option_sense;
-	yyset_debug     ctrl.no_set_debug = ! option_sense;
-	yyget_extra     ctrl.no_yyget_extra = ! option_sense;
-	yyset_extra     ctrl.no_yyset_extra = ! option_sense;
-	yyget_leng      ctrl.no_yyget_leng = ! option_sense;
-	yyget_text      ctrl.no_yyget_text = ! option_sense;
-	yyget_column    ctrl.no_yyget_column = ! option_sense;
-	yyset_column    ctrl.no_yyset_column = ! option_sense;
-	yyget_lineno    ctrl.no_yyget_lineno = ! option_sense;
-	yyset_lineno    ctrl.no_yyset_lineno = ! option_sense;
-	yyget_in        ctrl.no_yyget_in = ! option_sense;
-	yyset_in        ctrl.no_yyset_in = ! option_sense;
-	yyget_out       ctrl.no_yyget_out = ! option_sense;
-	yyset_out       ctrl.no_yyset_out = ! option_sense;
-	yyget_lval      ctrl.no_yyget_lval = ! option_sense;
-	yyset_lval      ctrl.no_yyset_lval = ! option_sense;
-	yyget_lloc      ctrl.no_yyget_lloc = ! option_sense;
-	yyset_lloc      ctrl.no_yyset_lloc = ! option_sense;
+	yyget_debug     gv->ctrl.no_get_debug = ! gv->option_sense;
+	yyset_debug     gv->ctrl.no_set_debug = ! gv->option_sense;
+	yyget_extra     gv->ctrl.no_yyget_extra = ! gv->option_sense;
+	yyset_extra     gv->ctrl.no_yyset_extra = ! gv->option_sense;
+	yyget_leng      gv->ctrl.no_yyget_leng = ! gv->option_sense;
+	yyget_text      gv->ctrl.no_yyget_text = ! gv->option_sense;
+	yyget_column    gv->ctrl.no_yyget_column = ! gv->option_sense;
+	yyset_column    gv->ctrl.no_yyset_column = ! gv->option_sense;
+	yyget_lineno    gv->ctrl.no_yyget_lineno = ! gv->option_sense;
+	yyset_lineno    gv->ctrl.no_yyset_lineno = ! gv->option_sense;
+	yyget_in        gv->ctrl.no_yyget_in = ! gv->option_sense;
+	yyset_in        gv->ctrl.no_yyset_in = ! gv->option_sense;
+	yyget_out       gv->ctrl.no_yyget_out = ! gv->option_sense;
+	yyset_out       gv->ctrl.no_yyset_out = ! gv->option_sense;
+	yyget_lval      gv->ctrl.no_yyget_lval = ! gv->option_sense;
+	yyset_lval      gv->ctrl.no_yyset_lval = ! gv->option_sense;
+	yyget_lloc      gv->ctrl.no_yyget_lloc = ! gv->option_sense;
+	yyset_lloc      gv->ctrl.no_yyset_lloc = ! gv->option_sense;
 
 	bufsize		return TOK_BUFSIZE;
 	emit		return TOK_EMIT;
@@ -470,23 +470,23 @@ void context_member(char *, const char *);
 	header(-file)?      return TOK_HEADER_FILE;
 	tables-file         return TOK_TABLES_FILE;
 	tables-verify   {
-                    tablesverify = option_sense;
-                    if (!tablesext && option_sense)
-                        tablesext = true;
+                    gv->tablesverify = gv->option_sense;
+                    if (!gv->tablesext && gv->option_sense)
+                        gv->tablesext = true;
                     }
 
 
 	"\""[^""\n]*"\""	{
 			if(yyleng-1 < MAXLINE)
         		 {
-			strncpy( nmstr, yytext + 1, sizeof(nmstr) );
+			strncpy( gv->nmstr, yytext + 1, sizeof(gv->nmstr) );
 			 }
 			else
 			 {
 			   synerr( _("Option line too long\n"));
 			   FLEX_EXIT(EXIT_FAILURE);
 			 }
-			nmstr[strlen( nmstr ) - 1] = '\0';
+			gv->nmstr[strlen( gv->nmstr ) - 1] = '\0';
 			return NAME;
 			}
 
@@ -497,18 +497,18 @@ void context_member(char *, const char *);
 			}
 }
 
-<RECOVER>.*{NL}		++linenum; BEGIN(INITIAL);
+<RECOVER>.*{NL}		++gv->linenum; BEGIN(INITIAL);
 
 
 <SECT2PROLOG>{
-	^"%{".*	++bracelevel; yyless( 2 );	/* eat only %{ */
-	^"%}".*	--bracelevel; yyless( 2 );	/* eat only %} */
+	^"%{".*	++gv->bracelevel; yyless( 2 );	/* eat only %{ */
+	^"%}".*	--gv->bracelevel; yyless( 2 );	/* eat only %} */
 
 	^{WS} START_CODEBLOCK(true); /* indented code in prolog */
 
 	^{NOT_WS}.*	{
         /* non-indented code */
-		if ( bracelevel <= 0 ) {
+		if ( gv->bracelevel <= 0 ) {
             /* not in %{ ... %} */
             yyless( 0 );	/* put it all back */
             yy_set_bol( 1 );
@@ -520,22 +520,22 @@ void context_member(char *, const char *);
     }
 
 	.		ACTION_ECHO;
-	{NL}	++linenum; ACTION_ECHO;
+	{NL}	++gv->linenum; ACTION_ECHO;
 
 	<<EOF>>		{
 			mark_prolog();
-			sectnum = 0;
+			gv->sectnum = 0;
 			return YY_NULL; /* to stop the parser */
 			}
 }
 
 <SECT2>{
-	^{OPTWS}{NL}	++linenum; /* allow blank lines in section 2 */
+	^{OPTWS}{NL}	++gv->linenum; /* allow blank lines in section 2 */
 
 	^{OPTWS}"%{"	{
-			indented_code = false;
-			doing_codeblock = true;
-			bracelevel = 1;
+			gv->indented_code = false;
+			gv->doing_codeblock = true;
+			gv->bracelevel = 1;
 			BEGIN(PERCENT_BRACE_ACTION);
 			}
 
@@ -549,7 +549,7 @@ void context_member(char *, const char *);
 	"\""		BEGIN(QUOTE); return '"';
 	"{"/[[:digit:]]	{
 			BEGIN(NUM);
-			if ( ctrl.lex_compat || ctrl.posix_compat )
+			if ( gv->ctrl.lex_compat || gv->ctrl.posix_compat )
 				return BEGIN_REPEAT_POSIX;
 			else
 				return BEGIN_REPEAT_FLEX;
@@ -557,13 +557,13 @@ void context_member(char *, const char *);
 	"$"/([[:blank:]]|{NL})	return '$';
 
 	{WS}"%{"		{
-			bracelevel = 1;
+			gv->bracelevel = 1;
 			BEGIN(PERCENT_BRACE_ACTION);
 
-			if ( in_rule )
+			if ( gv->in_rule )
 				{
-				doing_rule_action = true;
-				in_rule = false;
+				gv->doing_rule_action = true;
+				gv->in_rule = false;
 				return '\n';
 				}
 			}
@@ -576,8 +576,8 @@ void context_member(char *, const char *);
                         }
                         else {
                             add_action("]""]");
-                            continued_action = true;
-                            ++linenum;
+                            gv->continued_action = true;
+                            ++gv->linenum;
                             return '\n';
                         }
                     }
@@ -590,8 +590,8 @@ void context_member(char *, const char *);
                 }
                 else{
                     yyless( yyleng - 2 );	/* put back '/', '*' */
-                    bracelevel = 0;
-                    continued_action = false;
+                    gv->bracelevel = 0;
+                    gv->continued_action = false;
                     BEGIN(ACTION);
                 }
 			}
@@ -607,14 +607,14 @@ void context_member(char *, const char *);
                  * otherwise we get variable trailing context, so
                  * we can't build the scanner using -{f,F}.
                  */
-                bracelevel = 0;
-                continued_action = false;
+                gv->bracelevel = 0;
+                gv->continued_action = false;
                 BEGIN(ACTION);
 
-                if ( in_rule )
+                if ( gv->in_rule )
                     {
-                    doing_rule_action = true;
-                    in_rule = false;
+                    gv->doing_rule_action = true;
+                    gv->in_rule = false;
                     return '\n';
                     }
             }
@@ -623,18 +623,18 @@ void context_member(char *, const char *);
 	{OPTWS}{NL}	{
             if (sf_skip_ws()){
                 /* We're in the middle of a (?x: ) pattern. */
-                ++linenum;
+                ++gv->linenum;
             }
             else{
-                bracelevel = 0;
-                continued_action = false;
+                gv->bracelevel = 0;
+                gv->continued_action = false;
                 BEGIN(ACTION);
                 unput( '\n' );	/* so <ACTION> sees it */
 
-                if ( in_rule )
+                if ( gv->in_rule )
                     {
-                    doing_rule_action = true;
-                    in_rule = false;
+                    gv->doing_rule_action = true;
+                    gv->in_rule = false;
                     return '\n';
                     }
             }
@@ -644,8 +644,8 @@ void context_member(char *, const char *);
 	"<<EOF>>"	return EOF_OP;
 
 	^"%%".*		{
-			sectnum = 3;
-			BEGIN(ctrl.no_section3_escape ? SECT3_NOESCAPE : SECT3);
+			gv->sectnum = 3;
+			BEGIN(gv->ctrl.no_section3_escape ? SECT3_NOESCAPE : SECT3);
 			yyterminate(); /* to stop the parser */
 
 			}
@@ -655,7 +655,7 @@ void context_member(char *, const char *);
 
 			if(yyleng < MAXLINE)
         		 {
-			strncpy( nmstr, yytext, sizeof(nmstr) );
+			strncpy( gv->nmstr, yytext, sizeof(gv->nmstr) );
 			 }
 			else
 			 {
@@ -671,7 +671,7 @@ void context_member(char *, const char *);
                    * The reason it was disabled is so yacc/bison can parse
                    * ccl operations, such as ccl difference and union.
                    */
-                &&  (cclval = ccllookup( nmstr )) != 0 )
+                &&  (cclval = ccllookup( gv->nmstr )) != 0 )
 				{
      				 /* Dead code removed */
 				}
@@ -680,7 +680,7 @@ void context_member(char *, const char *);
 				/* We fudge a bit.  We know that this ccl will
 				 * soon be numbered as lastccl + 1 by cclinit.
 				 */
-				cclinstal( nmstr, lastccl + 1 );
+				cclinstal( gv->nmstr, gv->lastccl + 1 );
 
 				/* Push back everything but the leading bracket
 				 * so the ccl can be rescanned.
@@ -708,19 +708,19 @@ void context_member(char *, const char *);
 
  			if(yyleng-1 < MAXLINE)
          		 {
-			strncpy( nmstr, yytext + 1, sizeof(nmstr) );
+			strncpy( gv->nmstr, yytext + 1, sizeof(gv->nmstr) );
  			 }
  			else
  			 {
  			   synerr( _("Input line too long\n"));
  			   FLEX_EXIT(EXIT_FAILURE);
  			 }
-nmstr[yyleng - 2 - end_is_ws] = '\0';  /* chop trailing brace */
+gv->nmstr[yyleng - 2 - end_is_ws] = '\0';  /* chop trailing brace */
 
-			if ( (nmdefptr = ndlookup( nmstr )) == 0 )
+			if ( (nmdefptr = ndlookup( gv->nmstr )) == 0 )
 				format_synerr(
 					_( "undefined definition {%s}" ),
-						nmstr );
+						gv->nmstr );
 
 			else
 				{ /* push back name surrounded by ()'s */
@@ -728,9 +728,9 @@ nmstr[yyleng - 2 - end_is_ws] = '\0';  /* chop trailing brace */
                 if (end_is_ws)
                     unput(end_ch);
 
-				if ( ctrl.lex_compat || nmdefptr[0] == '^' ||
+				if ( gv->ctrl.lex_compat || nmdefptr[0] == '^' ||
 				     (len > 0 && nmdefptr[len - 1] == '$')
-                     || (end_is_ws && trlcontxt && !sf_skip_ws()))
+                     || (end_is_ws && gv->trlcontxt && !sf_skip_ws()))
 					{ /* don't use ()'s after all */
 					PUT_BACK_STRING(nmdefptr, 0);
 
@@ -758,7 +758,7 @@ nmstr[yyleng - 2 - end_is_ws] = '\0';  /* chop trailing brace */
                 }
 
     "(?#"       {
-                    if (ctrl.lex_compat || ctrl.posix_compat){
+                    if (gv->ctrl.lex_compat || gv->ctrl.posix_compat){
                         /* Push back the "?#" and treat it like a normal parens. */
                         yyless(1);
                         sf_push(); 
@@ -769,7 +769,7 @@ nmstr[yyleng - 2 - end_is_ws] = '\0';  /* chop trailing brace */
                 }
     "(?"        {
                     sf_push();
-                    if (ctrl.lex_compat || ctrl.posix_compat)
+                    if (gv->ctrl.lex_compat || gv->ctrl.posix_compat)
                         /* Push back the "?" and treat it like a normal parens. */
                         yyless(1);
                     else
@@ -778,7 +778,7 @@ nmstr[yyleng - 2 - end_is_ws] = '\0';  /* chop trailing brace */
                 }
     "("         sf_push(); return '(';
     ")"         {
-                    if (_sf_top_ix > 0) {
+                    if (gv->_sf_top_ix > 0) {
                         sf_pop();
                         return ')';
                     } else
@@ -791,7 +791,7 @@ nmstr[yyleng - 2 - end_is_ws] = '\0';  /* chop trailing brace */
 
 
 <SC>{
-	{OPTWS}{NL}{OPTWS}	++linenum;	/* Allow blank lines & continuations */
+	{OPTWS}{NL}{OPTWS}	++gv->linenum;	/* Allow blank lines & continuations */
 	[,*]		return (unsigned char) yytext[0];
 	">"		BEGIN(SECT2); return '>';
 	">"/^		BEGIN(CARETISBOL); return '>';
@@ -812,7 +812,7 @@ nmstr[yyleng - 2 - end_is_ws] = '\0';  /* chop trailing brace */
 	{NL}		{
 			synerr( _( "missing quote" ) );
 			BEGIN(SECT2);
-			++linenum;
+			++gv->linenum;
 			return '"';
 			}
 }
@@ -891,7 +891,7 @@ nmstr[yyleng - 2 - end_is_ws] = '\0';  /* chop trailing brace */
 	","		return ',';
 	"}"		{
 			BEGIN(SECT2);
-			if ( ctrl.lex_compat || ctrl.posix_compat )
+			if ( gv->ctrl.lex_compat || gv->ctrl.posix_compat )
 				return END_REPEAT_POSIX;
 			else
 				return END_REPEAT_FLEX;
@@ -906,14 +906,14 @@ nmstr[yyleng - 2 - end_is_ws] = '\0';  /* chop trailing brace */
 	{NL}		{
 			synerr( _( "missing }" ) );
 			BEGIN(SECT2);
-			++linenum;
+			++gv->linenum;
 			return '}';
 			}
 }
 
 
 <PERCENT_BRACE_ACTION>{
-	{OPTWS}"%}".*		bracelevel = 0;
+	{OPTWS}"%}".*		gv->bracelevel = 0;
 
 	<ACTION>"/*"		ACTION_ECHO; yy_push_state( CODE_COMMENT );
 
@@ -927,8 +927,8 @@ nmstr[yyleng - 2 - end_is_ws] = '\0';  /* chop trailing brace */
 			CHECK_YYREJECT(yytext);
         }
 		"yymore"{OPTWS}"("{OPTWS}")" {
-			yymore_used = true;
-			if (ctrl.rewrite)
+			gv->yymore_used = true;
+			if (gv->ctrl.rewrite)
 				context_call(yytext);
 			else
 				ACTION_ECHO;
@@ -937,13 +937,13 @@ nmstr[yyleng - 2 - end_is_ws] = '\0';  /* chop trailing brace */
 
     .       ACTION_ECHO;
 	{NL}	{
-		++linenum;
+		++gv->linenum;
 		ACTION_ECHO;
-		if (bracelevel <= 0 || (doing_codeblock && indented_code)) {
-            if ( doing_rule_action )
+		if (gv->bracelevel <= 0 || (gv->doing_codeblock && gv->indented_code)) {
+            if ( gv->doing_rule_action )
                 add_action( "\t]""]M4_HOOK_STATE_CASE_BREAK\n" );
 
-            doing_rule_action = doing_codeblock = false;
+            gv->doing_rule_action = gv->doing_codeblock = false;
             BEGIN(SECT2);
         }
     }
@@ -952,10 +952,10 @@ nmstr[yyleng - 2 - end_is_ws] = '\0';  /* chop trailing brace */
 
 	/* yyreject and yymore() are checked for above, in PERCENT_BRACE_ACTION */
 <ACTION>{
-	"{"		ACTION_ECHO; ++bracelevel;
-	"}"		ACTION_ECHO; --bracelevel;
+	"{"		ACTION_ECHO; ++gv->bracelevel;
+	"}"		ACTION_ECHO; --gv->bracelevel;
 	yyecho\(\)|yyinput\(\)|yystart\({FUNARGS}\)|yybegin\({FUNARGS}\)|yyunput\({FUNARGS}\)|yypanic\({FUNARGS}\)|yyatbol\(\)|yysetbol\({FUNARGS}\) {
-			if (ctrl.rewrite)
+			if (gv->ctrl.rewrite)
 				context_call(yytext);
 			else
 				ACTION_ECHO;
@@ -966,13 +966,13 @@ nmstr[yyleng - 2 - end_is_ws] = '\0';  /* chop trailing brace */
 			add_action("[""[");
 	}
 	(yyin|yyout|yyextra|yyleng|yytext|yyflexdebug)/[^[:alnum:]_] {
-			if (ctrl.rewrite)
+			if (gv->ctrl.rewrite)
 				context_member(yytext, "M4_PROPERTY_CONTEXT_FORMAT");
 			else
 				ACTION_ECHO;
 	}
 	(yylineno|yycolumn)/[^[:alnum:]_] {
-			if (ctrl.rewrite)
+			if (gv->ctrl.rewrite)
 				context_member(yytext, "M4_PROPERTY_BUFFERSTACK_CONTEXT_FORMAT");
 			else
 				ACTION_ECHO;
@@ -983,13 +983,13 @@ nmstr[yyleng - 2 - end_is_ws] = '\0';  /* chop trailing brace */
         "'"             ACTION_ECHO; BEGIN(CHARACTER_CONSTANT);
 	"\""		ACTION_ECHO; BEGIN(ACTION_STRING);
 	{NL} {
-                ++linenum;
+                ++gv->linenum;
                 ACTION_ECHO;
-                if (bracelevel <= 0) {
-                   if ( doing_rule_action )
+                if (gv->bracelevel <= 0) {
+                   if ( gv->doing_rule_action )
                       add_action( "\t]""]M4_HOOK_STATE_CASE_BREAK\n" );
 
-                   doing_rule_action = false;
+                   gv->doing_rule_action = false;
                    BEGIN(SECT2);
                 }
              }
@@ -1007,7 +1007,7 @@ nmstr[yyleng - 2 - end_is_ws] = '\0';  /* chop trailing brace */
 <ACTION_STRING,CHARACTER_CONSTANT>{
         (\\\n)*         ACTION_ECHO;
 	\\(\\\n)*.	ACTION_ECHO;
-	{NL}	++linenum; ACTION_ECHO; if (bracelevel <= 0) { BEGIN(SECT2); } else { BEGIN(ACTION); }
+	{NL}	++gv->linenum; ACTION_ECHO; if (gv->bracelevel <= 0) { BEGIN(SECT2); } else { BEGIN(ACTION); }
         .	ACTION_ECHO;
 }
 
@@ -1031,22 +1031,22 @@ nmstr[yyleng - 2 - end_is_ws] = '\0';  /* chop trailing brace */
 			}
 
 <SECT3>{
-    {M4QSTART}   fputs(escaped_qstart, yyout);
-    {M4QEND}     fputs(escaped_qend, yyout);
+    {M4QSTART}   fputs(gv->escaped_qstart, yyout);
+    {M4QEND}     fputs(gv->escaped_qend, yyout);
     [^\[\]]*     ECHO;
     [][]         ECHO;
     <<EOF>>      {
-        sectnum = 0;
+        gv->sectnum = 0;
         yyterminate();
     }
 }
 <SECT3_NOESCAPE>{
-    {M4QSTART}  fprintf(yyout, "[""[%s]""]", escaped_qstart);
-    {M4QEND}    fprintf(yyout, "[""[%s]""]", escaped_qend);
+    {M4QSTART}  fprintf(yyout, "[""[%s]""]", gv->escaped_qstart);
+    {M4QEND}    fprintf(yyout, "[""[%s]""]", gv->escaped_qend);
     [^][]*      ECHO;
     [][]        ECHO;
     <<EOF>>		{
-       sectnum = 0;
+       gv->sectnum = 0;
        yyterminate();
     }
 }
@@ -1057,9 +1057,9 @@ nmstr[yyleng - 2 - end_is_ws] = '\0';  /* chop trailing brace */
 
 int yywrap(void)
 	{
-	if ( --num_input_files > 0 )
+	if ( --gv->num_input_files > 0 )
 		{
-		set_input_file( *++input_files );
+		set_input_file( *++gv->input_files );
 		return 0;
 		}
 
@@ -1074,8 +1074,8 @@ void set_input_file( char *file )
 	{
 	if ( file && strcmp( file, "-" ) )
 		{
-		infilename = xstrdup(file);
-		yyin = fopen( infilename, "r" );
+		gv->infilename = xstrdup(file);
+		yyin = fopen( gv->infilename, "r" );
 
 		if ( yyin == NULL )
 			lerr( _( "can't open %s: %s" ), file, strerror(errno));
@@ -1084,10 +1084,10 @@ void set_input_file( char *file )
 	else
 		{
 		yyin = stdin;
-		infilename = xstrdup("<stdin>");
+		gv->infilename = xstrdup("<stdin>");
 		}
 
-	linenum = 1;
+	gv->linenum = 1;
 	}
 
 void context_call(char *txt) {

--- a/src/scanflags.c
+++ b/src/scanflags.c
@@ -33,39 +33,39 @@
 
 #include "flexdef.h"
 
-scanflags_t* _sf_stk = NULL;
-size_t _sf_top_ix=0, _sf_max=0;
+//scanflags_t* _sf_stk = NULL;
+//size_t _sf_top_ix=0, _sf_max=0;
 
 void
 sf_push (void)
 {
-    if (_sf_top_ix + 1 >= _sf_max) {
-        _sf_max += 32;
-        _sf_stk = realloc(_sf_stk, sizeof(scanflags_t) * _sf_max);
+    if (gv->_sf_top_ix + 1 >= gv->_sf_max) {
+        gv->_sf_max += 32;
+        gv->_sf_stk = realloc(gv->_sf_stk, sizeof(scanflags_t) * gv->_sf_max);
     }
 
     // copy the top element
-    _sf_stk[_sf_top_ix + 1] = _sf_stk[_sf_top_ix];
-    ++_sf_top_ix;
+    gv->_sf_stk[gv->_sf_top_ix + 1] = gv->_sf_stk[gv->_sf_top_ix];
+    ++gv->_sf_top_ix;
 }
 
 void
 sf_pop (void)
 {
-    assert(_sf_top_ix > 0);
-    --_sf_top_ix;
+    assert(gv->_sf_top_ix > 0);
+    --gv->_sf_top_ix;
 }
 
 /* one-time initialization. Should be called before any sf_ functions. */
 void
 sf_init (void)
 {
-    assert(_sf_stk == NULL);
-    _sf_max = 32;
-    _sf_stk = malloc(sizeof(scanflags_t) * _sf_max);
-    if (!_sf_stk)
+    assert(gv->_sf_stk == NULL);
+    gv->_sf_max = 32;
+    gv->_sf_stk = malloc(sizeof(scanflags_t) * gv->_sf_max);
+    if (!gv->_sf_stk)
         lerr_fatal(_("Unable to allocate %zu of stack"), sizeof(scanflags_t));
-    _sf_stk[_sf_top_ix] = 0;
+    gv->_sf_stk[gv->_sf_top_ix] = 0;
 }
 
 /* vim:set expandtab cindent tabstop=4 softtabstop=4 shiftwidth=4 textwidth=0: */

--- a/src/scanflags.c
+++ b/src/scanflags.c
@@ -37,7 +37,7 @@
 //size_t _sf_top_ix=0, _sf_max=0;
 
 void
-sf_push (void)
+sf_push (FlexState* gv)
 {
     if (gv->_sf_top_ix + 1 >= gv->_sf_max) {
         gv->_sf_max += 32;
@@ -50,7 +50,7 @@ sf_push (void)
 }
 
 void
-sf_pop (void)
+sf_pop (FlexState* gv)
 {
     assert(gv->_sf_top_ix > 0);
     --gv->_sf_top_ix;
@@ -58,13 +58,13 @@ sf_pop (void)
 
 /* one-time initialization. Should be called before any sf_ functions. */
 void
-sf_init (void)
+sf_init (FlexState* gv)
 {
     assert(gv->_sf_stk == NULL);
     gv->_sf_max = 32;
     gv->_sf_stk = malloc(sizeof(scanflags_t) * gv->_sf_max);
     if (!gv->_sf_stk)
-        lerr_fatal(_("Unable to allocate %zu of stack"), sizeof(scanflags_t));
+        lerr_fatal(gv, _("Unable to allocate %zu of stack"), sizeof(scanflags_t));
     gv->_sf_stk[gv->_sf_top_ix] = 0;
 }
 

--- a/src/skeletons.c
+++ b/src/skeletons.c
@@ -95,7 +95,7 @@ static bool boneseeker(const char *bone)
 	return false;
 }
 
-void backend_by_name(const char *name)
+void backend_by_name(FlexState* gv, const char *name)
 {
 	const char *prefix_property;
 	if (name != NULL) {
@@ -110,24 +110,24 @@ void backend_by_name(const char *name)
 			goto backend_ok;
 		}
 		for (backend = &backends[0]; backend->skel != NULL; backend++) {
-			if (strcasecmp(skel_property("M4_PROPERTY_BACKEND_NAME"), name) == 0)
+			if (strcasecmp(skel_property(gv, "M4_PROPERTY_BACKEND_NAME"), name) == 0)
 				goto backend_ok;
 		}
-		flexerror(_("no such back end"));
+		flexerror(gv, _("no such back end"));
 	}
   backend_ok:
 	gv->ctrl.rewrite = !is_default_backend();
-	gv->ctrl.backend_name = xstrdup(skel_property("M4_PROPERTY_BACKEND_NAME"));
-	gv->ctrl.traceline_re = xstrdup(skel_property("M4_PROPERTY_TRACE_LINE_REGEXP"));
-	gv->ctrl.traceline_template = xstrdup(skel_property("M4_PROPERTY_TRACE_LINE_TEMPLATE"));
+	gv->ctrl.backend_name = xstrdup(gv, skel_property(gv, "M4_PROPERTY_BACKEND_NAME"));
+	gv->ctrl.traceline_re = xstrdup(gv, skel_property(gv, "M4_PROPERTY_TRACE_LINE_REGEXP"));
+	gv->ctrl.traceline_template = xstrdup(gv, skel_property(gv, "M4_PROPERTY_TRACE_LINE_TEMPLATE"));
 	gv->ctrl.have_state_entry_format = boneseeker("m4_define([[M4_HOOK_STATE_ENTRY_FORMAT]]");
-	prefix_property = skel_property("M4_PROPERTY_PREFIX");
+	prefix_property = skel_property(gv, "M4_PROPERTY_PREFIX");
 	if (prefix_property != NULL)
-		gv->ctrl.prefix = xstrdup(prefix_property);
-	flex_init_regex(gv->ctrl.traceline_re);
+		gv->ctrl.prefix = xstrdup(gv, prefix_property);
+	flex_init_regex(gv, gv->ctrl.traceline_re);
 }
 
-const char *suffix (void)
+const char *suffix (FlexState* gv)
 {
 	const char   *suffix;
 
@@ -137,7 +137,7 @@ const char *suffix (void)
 		else
 			suffix = "c";
 	} else {
-		suffix = skel_property("M4_PROPERTY_SOURCE_SUFFIX");
+		suffix = skel_property(gv, "M4_PROPERTY_SOURCE_SUFFIX");
 	}
 	
 	return suffix;
@@ -147,7 +147,7 @@ const char *suffix (void)
  * definition must be single-line.  Don't call this a second time before
  * stashing away the previous return, we cheat with static buffers.
  */
-const char *skel_property(const char *propname)
+const char *skel_property(FlexState* gv, const char *propname)
 {
 	int i;
 	//static char name[256], value[256], *np, *vp;;
@@ -177,7 +177,7 @@ const char *skel_property(const char *propname)
 			if (strcmp(gv->sk_name, propname) != 0)
 				continue; /* try next line */
 		} else {
-			flexerror(_("unterminated or too long property name"));
+			flexerror(gv, _("unterminated or too long property name"));
 			continue;
 		}
 		/* skip to the property value */
@@ -186,7 +186,7 @@ const char *skel_property(const char *propname)
 		while (*cp == '[')
 			cp++;
 		if (*cp == '\0')
-			flexerror(_("garbled property line"));
+			flexerror(gv, _("garbled property line"));
 		/* extract the value */
 		gv->sk_vp = gv->sk_value;
 		while (*cp != '\0' && gv->sk_vp < gv->sk_value + sizeof(gv->sk_value) - 1 && (cp[0] != ']' || cp[1] != ']'))
@@ -195,7 +195,7 @@ const char *skel_property(const char *propname)
 			*gv->sk_vp = '\0';
 			return gv->sk_value;
 		} else {
-			flexerror(_("unterminated or too long property value"));
+			flexerror(gv, _("unterminated or too long property value"));
 		}
 	}
 	return NULL;
@@ -207,7 +207,7 @@ const char *skel_property(const char *propname)
  *    Copies skelfile or skel array to stdout until a line beginning with
  *    "%%" or EOF is found.
  */
-void skelout (bool announce)
+void skelout (FlexState* gv, bool announce)
 {
 	char    buf_storage[MAXLINE];
 	char   *buf = buf_storage;
@@ -242,7 +242,7 @@ void skelout (bool announce)
 				return;
 			}
 			else {
-				flexfatal (_("bad line in skeleton file"));
+				flexfatal (gv, _("bad line in skeleton file"));
 			}
 		}
 

--- a/src/sym.c
+++ b/src/sym.c
@@ -38,7 +38,7 @@
  * ndtbl - name-definition symbol table
  * ccltab - character class text symbol table
  */
-
+/*
 struct hash_entry {
 	struct hash_entry *next;
 	char   *name;
@@ -55,7 +55,7 @@ typedef struct hash_entry **hash_table;
 static struct hash_entry *ndtbl[NAME_TABLE_HASH_SIZE] = {NULL};
 static struct hash_entry *sctbl[START_COND_HASH_SIZE] = {NULL};
 static struct hash_entry *ccltab[CCL_HASH_SIZE] = {NULL};
-
+*/
 
 /* declare functions that have forward references */
 
@@ -113,7 +113,7 @@ void    cclinstal (char ccltxt[], int cclnum)
 	 * called unless the symbol is new.
 	 */
 
-	(void) addsym(ccltxt, NULL, cclnum, ccltab, CCL_HASH_SIZE);
+	(void) addsym(ccltxt, NULL, cclnum, gv->ccltab, CCL_HASH_SIZE);
 }
 
 
@@ -124,7 +124,7 @@ void    cclinstal (char ccltxt[], int cclnum)
 
 int     ccllookup (char ccltxt[])
 {
-	return findsym (ccltxt, ccltab, CCL_HASH_SIZE)->int_val;
+	return findsym (ccltxt, gv->ccltab, CCL_HASH_SIZE)->int_val;
 }
 
 
@@ -132,9 +132,9 @@ int     ccllookup (char ccltxt[])
 
 static struct hash_entry *findsym (const char *sym, hash_table table, size_t table_size)
 {
-	static struct hash_entry empty_entry = {
-		NULL, NULL, NULL, 0,
-	};
+	//static struct hash_entry empty_entry = {
+	//	NULL, NULL, NULL, 0,
+	//};
 	struct hash_entry *sym_entry =
 
 		table[hashfunct (sym, table_size)];
@@ -145,7 +145,7 @@ static struct hash_entry *findsym (const char *sym, hash_table table, size_t tab
 		sym_entry = sym_entry->next;
 	}
 
-	return &empty_entry;
+	return &gv->empty_entry;
 }
 
 /* hashfunct - compute the hash value for "str" and hash size "hash_size" */
@@ -171,7 +171,7 @@ static size_t hashfunct (const char *str, size_t hash_size)
 
 void    ndinstal (const char *name, char definition[])
 {
-	if (addsym(name, definition, 0, ndtbl, NAME_TABLE_HASH_SIZE)) {
+	if (addsym(name, definition, 0, gv->ndtbl, NAME_TABLE_HASH_SIZE)) {
 		synerr (_("name defined twice"));
 	}
 }
@@ -184,7 +184,7 @@ void    ndinstal (const char *name, char definition[])
 
 char   *ndlookup (const char *nd)
 {
-	return findsym (nd, ndtbl, NAME_TABLE_HASH_SIZE)->str_val;
+	return findsym (nd, gv->ndtbl, NAME_TABLE_HASH_SIZE)->str_val;
 }
 
 
@@ -192,16 +192,16 @@ char   *ndlookup (const char *nd)
 
 void    scextend (void)
 {
-	current_max_scs += MAX_SCS_INCREMENT;
+	gv->current_max_scs += MAX_SCS_INCREMENT;
 
-	++num_reallocs;
+	++gv->num_reallocs;
 
-	scset = reallocate_integer_array (scset, current_max_scs);
-	scbol = reallocate_integer_array (scbol, current_max_scs);
-	scxclu = reallocate_array(scxclu, current_max_scs,
+	gv->scset = reallocate_integer_array (gv->scset, gv->current_max_scs);
+	gv->scbol = reallocate_integer_array (gv->scbol, gv->current_max_scs);
+	gv->scxclu = reallocate_array(gv->scxclu, gv->current_max_scs,
 		sizeof(char));
-	sceof = reallocate_array(sceof, current_max_scs, sizeof(char));
-	scname = reallocate_char_ptr_array (scname, current_max_scs);
+	gv->sceof = reallocate_array(gv->sceof, gv->current_max_scs, sizeof(char));
+	gv->scname = reallocate_char_ptr_array (gv->scname, gv->current_max_scs);
 }
 
 
@@ -210,19 +210,19 @@ void    scextend (void)
 void    scinstal (const char *str, bool sc_is_exclusive)
 {
 
-	if (++lastsc >= current_max_scs)
+	if (++gv->lastsc >= gv->current_max_scs)
 		scextend ();
 
-	if (addsym(str, NULL, lastsc, sctbl, START_COND_HASH_SIZE)) {
+	if (addsym(str, NULL, gv->lastsc, gv->sctbl, START_COND_HASH_SIZE)) {
 		format_pinpoint_message (
 			_("start condition %s declared twice"), str);
 	}
-	scname[lastsc] = sctbl[hashfunct(str, START_COND_HASH_SIZE)]->name;
+	gv->scname[gv->lastsc] = gv->sctbl[hashfunct(str, START_COND_HASH_SIZE)]->name;
 
-	scset[lastsc] = mkstate (SYM_EPSILON);
-	scbol[lastsc] = mkstate (SYM_EPSILON);
-	scxclu[lastsc] = sc_is_exclusive ? 1 : 0;
-	sceof[lastsc] = false;
+	gv->scset[gv->lastsc] = mkstate (SYM_EPSILON);
+	gv->scbol[gv->lastsc] = mkstate (SYM_EPSILON);
+	gv->scxclu[gv->lastsc] = sc_is_exclusive ? 1 : 0;
+	gv->sceof[gv->lastsc] = false;
 }
 
 
@@ -233,5 +233,5 @@ void    scinstal (const char *str, bool sc_is_exclusive)
 
 int     sclookup (const char *str)
 {
-	return findsym (str, sctbl, START_COND_HASH_SIZE)->int_val;
+	return findsym (str, gv->sctbl, START_COND_HASH_SIZE)->int_val;
 }

--- a/src/tables.h
+++ b/src/tables.h
@@ -64,14 +64,14 @@ struct yytbl_writer {
 //extern struct yytbl_writer tableswr;
 
 int     yytbl_writer_init (struct yytbl_writer *, FILE *);
-int     yytbl_hdr_init (struct yytbl_hdr *th, const char *version_str,
+int     yytbl_hdr_init (FlexState* gv, struct yytbl_hdr *th, const char *version_str,
 			const char *name);
 int     yytbl_data_init (struct yytbl_data *tbl, enum yytbl_id id);
 int     yytbl_data_destroy (struct yytbl_data *td);
-int     yytbl_hdr_fwrite (struct yytbl_writer *wr,
+int     yytbl_hdr_fwrite (FlexState* gv, struct yytbl_writer *wr,
 			  const struct yytbl_hdr *th);
-int     yytbl_data_fwrite (struct yytbl_writer *wr, struct yytbl_data *td);
-void    yytbl_data_compress (struct yytbl_data *tbl);
+int     yytbl_data_fwrite (FlexState* gv, struct yytbl_writer *wr, struct yytbl_data *td);
+void    yytbl_data_compress (FlexState* gv, struct yytbl_data *tbl);
 
 
 #ifdef __cplusplus

--- a/src/tables.h
+++ b/src/tables.h
@@ -59,9 +59,9 @@ struct yytbl_writer {
  * tablesverify - true if tables-verify option specified
  * gentables - true if we should spit out the normal C tables
  */
-extern bool tablesext, tablesverify,gentables;
-extern char *tablesfilename, *tablesname;
-extern struct yytbl_writer tableswr;
+//extern bool tablesext, tablesverify,gentables;
+//extern char *tablesfilename, *tablesname;
+//extern struct yytbl_writer tableswr;
 
 int     yytbl_writer_init (struct yytbl_writer *, FILE *);
 int     yytbl_hdr_init (struct yytbl_hdr *th, const char *version_str,

--- a/src/tblcmp.c
+++ b/src/tblcmp.c
@@ -99,8 +99,8 @@ void    bldtbl (int state[], int statenum, int totaltrans, int comstate, int com
 	 * compact its tables.
 	 */
 
-	if ((totaltrans * 100) < (numecs * PROTO_SIZE_PERCENTAGE))
-		mkentry (state, numecs, statenum, JAMSTATE, totaltrans);
+	if ((totaltrans * 100) < (gv->numecs * PROTO_SIZE_PERCENTAGE))
+		mkentry (state, gv->numecs, statenum, JAMSTATE, totaltrans);
 
 	else {
 		/* "checkcom" is true if we should only check "state" against
@@ -110,13 +110,13 @@ void    bldtbl (int state[], int statenum, int totaltrans, int comstate, int com
 
 			comfreq * 100 > totaltrans * CHECK_COM_PERCENTAGE;
 
-		minprot = firstprot;
+		minprot = gv->firstprot;
 		mindiff = totaltrans;
 
 		if (checkcom) {
 			/* Find first proto which has the same "comstate". */
-			for (i = firstprot; i != NIL; i = protnext[i])
-				if (protcomst[i] == comstate) {
+			for (i = gv->firstprot; i != NIL; i = gv->protnext[i])
+				if (gv->protcomst[i] == comstate) {
 					minprot = i;
 					mindiff = tbldiff (state, minprot,
 							   extrct[extptr]);
@@ -133,8 +133,8 @@ void    bldtbl (int state[], int statenum, int totaltrans, int comstate, int com
 			 */
 			comstate = 0;
 
-			if (firstprot != NIL) {
-				minprot = firstprot;
+			if (gv->firstprot != NIL) {
+				minprot = gv->firstprot;
 				mindiff = tbldiff (state, minprot,
 						   extrct[extptr]);
 			}
@@ -151,7 +151,7 @@ void    bldtbl (int state[], int statenum, int totaltrans, int comstate, int com
 			/* Not a good enough match.  Scan the rest of the
 			 * protos.
 			 */
-			for (i = minprot; i != NIL; i = protnext[i]) {
+			for (i = minprot; i != NIL; i = gv->protnext[i]) {
 				d = tbldiff (state, i, extrct[1 - extptr]);
 				if (d < mindiff) {
 					extptr = 1 - extptr;
@@ -179,14 +179,14 @@ void    bldtbl (int state[], int statenum, int totaltrans, int comstate, int com
 
 			else {
 				mkprot (state, statenum, comstate);
-				mkentry (state, numecs, statenum,
+				mkentry (state, gv->numecs, statenum,
 					 JAMSTATE, totaltrans);
 			}
 		}
 
 		else {		/* use the proto */
-			mkentry (extrct[extptr], numecs, statenum,
-				 prottbl[minprot], mindiff);
+			mkentry (extrct[extptr], gv->numecs, statenum,
+				 gv->prottbl[minprot], mindiff);
 
 			/* If this state was sufficiently different from the
 			 * proto we built it from, make it, too, a proto.
@@ -226,37 +226,37 @@ void    cmptmps (void)
 	int *tmp = tmpstorage, i, j;
 	int totaltrans, trans;
 
-	peakpairs = numtemps * numecs + tblend;
+	gv->peakpairs = gv->numtemps * gv->numecs + gv->tblend;
 
-	if (ctrl.usemecs) {
+	if (gv->ctrl.usemecs) {
 		/* Create equivalence classes based on data gathered on
 		 * template transitions.
 		 */
-		nummecs = cre8ecs (tecfwd, tecbck, numecs);
+		gv->nummecs = cre8ecs (gv->tecfwd, gv->tecbck, gv->numecs);
 	}
 
 	else
-		nummecs = numecs;
+		gv->nummecs = gv->numecs;
 
-	while (lastdfa + numtemps + 1 >= current_max_dfas)
+	while (gv->lastdfa + gv->numtemps + 1 >= gv->current_max_dfas)
 		increase_max_dfas ();
 
 	/* Loop through each template. */
 
-	for (i = 1; i <= numtemps; ++i) {
+	for (i = 1; i <= gv->numtemps; ++i) {
 		/* Number of non-jam transitions out of this template. */
 		totaltrans = 0;
 
-		for (j = 1; j <= numecs; ++j) {
-			trans = tnxt[numecs * i + j];
+		for (j = 1; j <= gv->numecs; ++j) {
+			trans = gv->tnxt[gv->numecs * i + j];
 
-			if (ctrl.usemecs) {
+			if (gv->ctrl.usemecs) {
 				/* The absolute value of tecbck is the
 				 * meta-equivalence class of a given
 				 * equivalence class, as set up by cre8ecs().
 				 */
-				if (tecbck[j] > 0) {
-					tmp[tecbck[j]] = trans;
+				if (gv->tecbck[j] > 0) {
+					tmp[gv->tecbck[j]] = trans;
 
 					if (trans > 0)
 						++totaltrans;
@@ -279,7 +279,7 @@ void    cmptmps (void)
 		 */
 
 		/* Leave room for the jam-state after the last real state. */
-		mkentry (tmp, nummecs, lastdfa + i + 1, JAMSTATE,
+		mkentry (tmp, gv->nummecs, gv->lastdfa + i + 1, JAMSTATE,
 			 totaltrans);
 	}
 }
@@ -290,16 +290,16 @@ void    cmptmps (void)
 
 void    expand_nxt_chk (void)
 {
-	int old_max = current_max_xpairs;
+	int old_max = gv->current_max_xpairs;
 
-	current_max_xpairs += MAX_XPAIRS_INCREMENT;
+	gv->current_max_xpairs += MAX_XPAIRS_INCREMENT;
 
-	++num_reallocs;
+	++gv->num_reallocs;
 
-	nxt = reallocate_integer_array (nxt, current_max_xpairs);
-	chk = reallocate_integer_array (chk, current_max_xpairs);
+	gv->nxt = reallocate_integer_array (gv->nxt, gv->current_max_xpairs);
+	gv->chk = reallocate_integer_array (gv->chk, gv->current_max_xpairs);
 
-	memset(chk + old_max, 0, MAX_XPAIRS_INCREMENT * sizeof(int));
+	memset(gv->chk + old_max, 0, MAX_XPAIRS_INCREMENT * sizeof(int));
 }
 
 
@@ -338,13 +338,13 @@ int     find_table_space (int *state, int numtrans)
 		/* If table is empty, return the first available spot in
 		 * chk/nxt, which should be 1.
 		 */
-		if (tblend < 2)
+		if (gv->tblend < 2)
 			return 1;
 
 		/* Start searching for table space near the end of
 		 * chk/nxt arrays.
 		 */
-		i = tblend - numecs;
+		i = gv->tblend - gv->numecs;
 	}
 
 	else
@@ -352,10 +352,10 @@ int     find_table_space (int *state, int numtrans)
 		 * (skipping only the elements which will definitely not
 		 * hold the new state).
 		 */
-		i = firstfree;
+		i = gv->firstfree;
 
 	while (1) {		/* loops until a space is found */
-		while (i + numecs >= current_max_xpairs)
+		while (i + gv->numecs >= gv->current_max_xpairs)
 			expand_nxt_chk ();
 
 		/* Loops until space for end-of-buffer and action number
@@ -363,9 +363,9 @@ int     find_table_space (int *state, int numtrans)
 		 */
 		while (1) {
 			/* Check for action number space. */
-			if (chk[i - 1] == 0) {
+			if (gv->chk[i - 1] == 0) {
 				/* Check for end-of-buffer space. */
-				if (chk[i] == 0)
+				if (gv->chk[i] == 0)
 					break;
 
 				else
@@ -380,7 +380,7 @@ int     find_table_space (int *state, int numtrans)
 			else
 				++i;
 
-			while (i + numecs >= current_max_xpairs)
+			while (i + gv->numecs >= gv->current_max_xpairs)
 				expand_nxt_chk ();
 		}
 
@@ -388,16 +388,16 @@ int     find_table_space (int *state, int numtrans)
 		 * firstfree for the next call of find_table_space().
 		 */
 		if (numtrans <= MAX_XTIONS_FULL_INTERIOR_FIT)
-			firstfree = i + 1;
+			gv->firstfree = i + 1;
 
 		/* Check to see if all elements in chk (and therefore nxt)
 		 * that are needed for the new state have not yet been taken.
 		 */
 
 		state_ptr = &state[1];
-		ptr_to_last_entry_in_state = &chk[i + numecs + 1];
+		ptr_to_last_entry_in_state = &gv->chk[i + gv->numecs + 1];
 
-		for (chk_ptr = &chk[i + 1];
+		for (chk_ptr = &gv->chk[i + 1];
 		     chk_ptr != ptr_to_last_entry_in_state; ++chk_ptr)
 			if (*(state_ptr++) != 0 && *chk_ptr != 0)
 				break;
@@ -420,26 +420,26 @@ void    inittbl (void)
 {
 	int i;
 
-	memset(chk, 0, (size_t) current_max_xpairs * sizeof(int));
+	memset(gv->chk, 0, (size_t) gv->current_max_xpairs * sizeof(int));
 
-	tblend = 0;
-	firstfree = tblend + 1;
-	numtemps = 0;
+	gv->tblend = 0;
+	gv->firstfree = gv->tblend + 1;
+	gv->numtemps = 0;
 
-	if (ctrl.usemecs) {
+	if (gv->ctrl.usemecs) {
 		/* Set up doubly-linked meta-equivalence classes; these
 		 * are sets of equivalence classes which all have identical
 		 * transitions out of TEMPLATES.
 		 */
 
-		tecbck[1] = NIL;
+		gv->tecbck[1] = NIL;
 
-		for (i = 2; i <= numecs; ++i) {
-			tecbck[i] = i - 1;
-			tecfwd[i - 1] = i;
+		for (i = 2; i <= gv->numecs; ++i) {
+			gv->tecbck[i] = i - 1;
+			gv->tecfwd[i - 1] = i;
 		}
 
-		tecfwd[numecs] = NIL;
+		gv->tecfwd[gv->numecs] = NIL;
 	}
 }
 
@@ -450,29 +450,29 @@ void    mkdeftbl (void)
 {
 	int     i;
 
-	jamstate = lastdfa + 1;
+	gv->jamstate = gv->lastdfa + 1;
 
-	++tblend;		/* room for transition on end-of-buffer character */
+	++gv->tblend;		/* room for transition on end-of-buffer character */
 
-	while (tblend + numecs >= current_max_xpairs)
+	while (gv->tblend + gv->numecs >= gv->current_max_xpairs)
 		expand_nxt_chk ();
 
 	/* Add in default end-of-buffer transition. */
-	nxt[tblend] = end_of_buffer_state;
-	chk[tblend] = jamstate;
+	gv->nxt[gv->tblend] = gv->end_of_buffer_state;
+	gv->chk[gv->tblend] = gv->jamstate;
 
-	for (i = 1; i <= numecs; ++i) {
-		nxt[tblend + i] = 0;
-		chk[tblend + i] = jamstate;
+	for (i = 1; i <= gv->numecs; ++i) {
+		gv->nxt[gv->tblend + i] = 0;
+		gv->chk[gv->tblend + i] = gv->jamstate;
 	}
 
-	jambase = tblend;
+	gv->jambase = gv->tblend;
 
-	base[jamstate] = jambase;
-	def[jamstate] = 0;
+	gv->base[gv->jamstate] = gv->jambase;
+	gv->def[gv->jamstate] = 0;
 
-	tblend += numecs;
-	++numtemps;
+	gv->tblend += gv->numecs;
+	++gv->numtemps;
 }
 
 
@@ -503,11 +503,11 @@ void    mkentry (int *state, int numchars, int statenum, int deflink,
 
 	if (totaltrans == 0) {	/* there are no out-transitions */
 		if (deflink == JAMSTATE)
-			base[statenum] = JAMSTATE;
+			gv->base[statenum] = JAMSTATE;
 		else
-			base[statenum] = 0;
+			gv->base[statenum] = 0;
 
-		def[statenum] = deflink;
+		gv->def[statenum] = deflink;
 		return;
 	}
 
@@ -543,28 +543,28 @@ void    mkentry (int *state, int numchars, int statenum, int deflink,
 	/* Find the first transition of state that we need to worry about. */
 	if (totaltrans * 100 <= numchars * INTERIOR_FIT_PERCENTAGE) {
 		/* Attempt to squeeze it into the middle of the tables. */
-		baseaddr = firstfree;
+		baseaddr = gv->firstfree;
 
 		while (baseaddr < minec) {
 			/* Using baseaddr would result in a negative base
 			 * address below; find the next free slot.
 			 */
-			for (++baseaddr; chk[baseaddr] != 0; ++baseaddr) ;
+			for (++baseaddr; gv->chk[baseaddr] != 0; ++baseaddr) ;
 		}
 
-		while (baseaddr + maxec - minec + 1 >= current_max_xpairs)
+		while (baseaddr + maxec - minec + 1 >= gv->current_max_xpairs)
 			expand_nxt_chk ();
 
 		for (i = minec; i <= maxec; ++i)
 			if (state[i] != SAME_TRANS &&
 			    (state[i] != 0 || deflink != JAMSTATE) &&
-			    chk[baseaddr + i - minec] != 0) {	/* baseaddr unsuitable - find another */
+			    gv->chk[baseaddr + i - minec] != 0) {	/* baseaddr unsuitable - find another */
 				for (++baseaddr;
-				     baseaddr < current_max_xpairs &&
-				     chk[baseaddr] != 0; ++baseaddr) ;
+				     baseaddr < gv->current_max_xpairs &&
+				     gv->chk[baseaddr] != 0; ++baseaddr) ;
 
 				while (baseaddr + maxec - minec + 1 >=
-				       current_max_xpairs)
+				       gv->current_max_xpairs)
 						expand_nxt_chk ();
 
 				/* Reset the loop counter so we'll start all
@@ -579,30 +579,30 @@ void    mkentry (int *state, int numchars, int statenum, int deflink,
 		/* Ensure that the base address we eventually generate is
 		 * non-negative.
 		 */
-		baseaddr = MAX (tblend + 1, minec);
+		baseaddr = MAX (gv->tblend + 1, minec);
 	}
 
 	tblbase = baseaddr - minec;
 	tbllast = tblbase + maxec;
 
-	while (tbllast + 1 >= current_max_xpairs)
+	while (tbllast + 1 >= gv->current_max_xpairs)
 		expand_nxt_chk ();
 
-	base[statenum] = tblbase;
-	def[statenum] = deflink;
+	gv->base[statenum] = tblbase;
+	gv->def[statenum] = deflink;
 
 	for (i = minec; i <= maxec; ++i)
 		if (state[i] != SAME_TRANS)
 			if (state[i] != 0 || deflink != JAMSTATE) {
-				nxt[tblbase + i] = state[i];
-				chk[tblbase + i] = statenum;
+				gv->nxt[tblbase + i] = state[i];
+				gv->chk[tblbase + i] = statenum;
 			}
 
-	if (baseaddr == firstfree)
+	if (baseaddr == gv->firstfree)
 		/* Find next free slot in tables. */
-		for (++firstfree; chk[firstfree] != 0; ++firstfree) ;
+		for (++gv->firstfree; gv->chk[gv->firstfree] != 0; ++gv->firstfree) ;
 
-	tblend = MAX (tblend, tbllast);
+	gv->tblend = MAX (gv->tblend, tbllast);
 }
 
 
@@ -612,22 +612,22 @@ void    mkentry (int *state, int numchars, int statenum, int deflink,
 
 void    mk1tbl (int state, int sym, int onenxt, int onedef)
 {
-	if (firstfree < sym)
-		firstfree = sym;
+	if (gv->firstfree < sym)
+		gv->firstfree = sym;
 
-	while (chk[firstfree] != 0)
-		if (++firstfree >= current_max_xpairs)
+	while (gv->chk[gv->firstfree] != 0)
+		if (++gv->firstfree >= gv->current_max_xpairs)
 			expand_nxt_chk ();
 
-	base[state] = firstfree - sym;
-	def[state] = onedef;
-	chk[firstfree] = state;
-	nxt[firstfree] = onenxt;
+	gv->base[state] = gv->firstfree - sym;
+	gv->def[state] = onedef;
+	gv->chk[gv->firstfree] = state;
+	gv->nxt[gv->firstfree] = onenxt;
 
-	if (firstfree > tblend) {
-		tblend = firstfree++;
+	if (gv->firstfree > gv->tblend) {
+		gv->tblend = gv->firstfree++;
 
-		if (firstfree >= current_max_xpairs)
+		if (gv->firstfree >= gv->current_max_xpairs)
 			expand_nxt_chk ();
 	}
 }
@@ -639,32 +639,32 @@ void    mkprot (int state[], int statenum, int comstate)
 {
 	int     i, slot, tblbase;
 
-	if (++numprots >= MSP || numecs * numprots >= PROT_SAVE_SIZE) {
+	if (++gv->numprots >= MSP || gv->numecs * gv->numprots >= PROT_SAVE_SIZE) {
 		/* Gotta make room for the new proto by dropping last entry in
 		 * the queue.
 		 */
-		slot = lastprot;
-		lastprot = protprev[lastprot];
-		protnext[lastprot] = NIL;
+		slot = gv->lastprot;
+		gv->lastprot = gv->protprev[gv->lastprot];
+		gv->protnext[gv->lastprot] = NIL;
 	}
 
 	else
-		slot = numprots;
+		slot = gv->numprots;
 
-	protnext[slot] = firstprot;
+	gv->protnext[slot] = gv->firstprot;
 
-	if (firstprot != NIL)
-		protprev[firstprot] = slot;
+	if (gv->firstprot != NIL)
+		gv->protprev[gv->firstprot] = slot;
 
-	firstprot = slot;
-	prottbl[slot] = statenum;
-	protcomst[slot] = comstate;
+	gv->firstprot = slot;
+	gv->prottbl[slot] = statenum;
+	gv->protcomst[slot] = comstate;
 
 	/* Copy state into save area so it can be compared with rapidly. */
-	tblbase = numecs * (slot - 1);
+	tblbase = gv->numecs * (slot - 1);
 
-	for (i = 1; i <= numecs; ++i)
-		protsave[tblbase + i] = state[i];
+	for (i = 1; i <= gv->numecs; ++i)
+		gv->protsave[tblbase + i] = state[i];
 }
 
 
@@ -678,7 +678,7 @@ void    mktemplate (int state[], int statenum, int comstate)
 	unsigned char    transset[CSIZE + 1];
 	int     tsptr;
 
-	++numtemps;
+	++gv->numtemps;
 
 	tsptr = 0;
 
@@ -687,38 +687,38 @@ void    mktemplate (int state[], int statenum, int comstate)
 	 * gets created by cmptmps().
 	 */
 
-	tmpbase = numtemps * numecs;
+	tmpbase = gv->numtemps * gv->numecs;
 
-	if (tmpbase + numecs >= current_max_template_xpairs) {
-		current_max_template_xpairs +=
+	if (tmpbase + gv->numecs >= gv->current_max_template_xpairs) {
+		gv->current_max_template_xpairs +=
 			MAX_TEMPLATE_XPAIRS_INCREMENT;
 
-		++num_reallocs;
+		++gv->num_reallocs;
 
-		tnxt = reallocate_integer_array (tnxt,
-						 current_max_template_xpairs);
+		gv->tnxt = reallocate_integer_array (gv->tnxt,
+						 gv->current_max_template_xpairs);
 	}
 
-	for (i = 1; i <= numecs; ++i)
+	for (i = 1; i <= gv->numecs; ++i)
 		if (state[i] == 0)
-			tnxt[tmpbase + i] = 0;
+			gv->tnxt[tmpbase + i] = 0;
 		else {
 			/* Note: range 1..256 is mapped to 1..255,0 */
 			transset[tsptr++] = (unsigned char) i;
-			tnxt[tmpbase + i] = comstate;
+			gv->tnxt[tmpbase + i] = comstate;
 		}
 
-	if (ctrl.usemecs)
-		mkeccl (transset, tsptr, tecfwd, tecbck, numecs, 0);
+	if (gv->ctrl.usemecs)
+		mkeccl (transset, tsptr, gv->tecfwd, gv->tecbck, gv->numecs, 0);
 
-	mkprot (tnxt + tmpbase, -numtemps, comstate);
+	mkprot (gv->tnxt + tmpbase, -gv->numtemps, comstate);
 
 	/* We rely on the fact that mkprot adds things to the beginning
 	 * of the proto queue.
 	 */
 
-	numdiff = tbldiff (state, firstprot, tmp);
-	mkentry (tmp, numecs, statenum, -numtemps, numdiff);
+	numdiff = tbldiff (state, gv->firstprot, tmp);
+	mkentry (tmp, gv->numecs, statenum, -gv->numtemps, numdiff);
 }
 
 
@@ -726,19 +726,19 @@ void    mktemplate (int state[], int statenum, int comstate)
 
 void    mv2front (int qelm)
 {
-	if (firstprot != qelm) {
-		if (qelm == lastprot)
-			lastprot = protprev[lastprot];
+	if (gv->firstprot != qelm) {
+		if (qelm == gv->lastprot)
+			gv->lastprot = gv->protprev[gv->lastprot];
 
-		protnext[protprev[qelm]] = protnext[qelm];
+		gv->protnext[gv->protprev[qelm]] = gv->protnext[qelm];
 
-		if (protnext[qelm] != NIL)
-			protprev[protnext[qelm]] = protprev[qelm];
+		if (gv->protnext[qelm] != NIL)
+			gv->protprev[gv->protnext[qelm]] = gv->protprev[qelm];
 
-		protprev[qelm] = NIL;
-		protnext[qelm] = firstprot;
-		protprev[firstprot] = qelm;
-		firstprot = qelm;
+		gv->protprev[qelm] = NIL;
+		gv->protnext[qelm] = gv->firstprot;
+		gv->protprev[gv->firstprot] = qelm;
+		gv->firstprot = qelm;
 	}
 }
 
@@ -757,31 +757,31 @@ void    place_state (int *state, int statenum, int transnum)
 	int position = find_table_space (state, transnum);
 
 	/* "base" is the table of start positions. */
-	base[statenum] = position;
+	gv->base[statenum] = position;
 
 	/* Put in action number marker; this non-zero number makes sure that
 	 * find_table_space() knows that this position in chk/nxt is taken
 	 * and should not be used for another accepting number in another
 	 * state.
 	 */
-	chk[position - 1] = 1;
+	gv->chk[position - 1] = 1;
 
 	/* Put in end-of-buffer marker; this is for the same purposes as
 	 * above.
 	 */
-	chk[position] = 1;
+	gv->chk[position] = 1;
 
 	/* Place the state into chk and nxt. */
 	state_ptr = &state[1];
 
-	for (i = 1; i <= numecs; ++i, ++state_ptr)
+	for (i = 1; i <= gv->numecs; ++i, ++state_ptr)
 		if (*state_ptr != 0) {
-			chk[position + i] = i;
-			nxt[position + i] = *state_ptr;
+			gv->chk[position + i] = i;
+			gv->nxt[position + i] = *state_ptr;
 		}
 
-	if (position + numecs > tblend)
-		tblend = position + numecs;
+	if (position + gv->numecs > gv->tblend)
+		gv->tblend = position + gv->numecs;
 }
 
 
@@ -794,15 +794,15 @@ void    place_state (int *state, int statenum, int transnum)
 
 void    stack1 (int statenum, int sym, int nextstate, int deflink)
 {
-	if (onesp >= ONE_STACK_SIZE - 1)
+	if (gv->onesp >= ONE_STACK_SIZE - 1)
 		mk1tbl (statenum, sym, nextstate, deflink);
 
 	else {
-		++onesp;
-		onestate[onesp] = statenum;
-		onesym[onesp] = sym;
-		onenext[onesp] = nextstate;
-		onedef[onesp] = deflink;
+		++gv->onesp;
+		gv->onestate[gv->onesp] = statenum;
+		gv->onesym[gv->onesp] = sym;
+		gv->onenext[gv->onesp] = nextstate;
+		gv->onedef[gv->onesp] = deflink;
 	}
 }
 
@@ -826,9 +826,9 @@ int     tbldiff (int state[], int pr, int ext[])
 	int i, *sp = state, *ep = ext, *protp;
 	int numdiff = 0;
 
-	protp = &protsave[numecs * (pr - 1)];
+	protp = &gv->protsave[gv->numecs * (pr - 1)];
 
-	for (i = numecs; i > 0; --i) {
+	for (i = gv->numecs; i > 0; --i) {
 		if (*++protp == *++sp)
 			*++ep = SAME_TRANS;
 		else {

--- a/src/yylex.c
+++ b/src/yylex.c
@@ -37,24 +37,23 @@
 
 
 /* yylex - scan for a regular expression token */
-extern char *yytext;
-extern FILE *yyout;
 //bool no_section3_escape = false;
-int     yylex (void)
+int     yylex (YYSTYPE * yylval_param, yyscan_t yyscanner)
 {
-	int     toktype;
+	int     toktype, yylval;
 	//static int beglin = false;
+        FlexState* gv = (FlexState*)yyget_extra ( yyscanner );
 
 	if (gv->eofseen) {
 		toktype = EOF;
         } else {
-		toktype = flexscan ();
+		toktype = flexscan (yylval_param, yyscanner);
         }
 	if (toktype == EOF || toktype == 0) {
 		gv->eofseen = true;
 
 		if (gv->sectnum == 1) {
-			synerr (_("premature EOF"));
+			synerr (gv, _("premature EOF"));
 			gv->sectnum = 2;
 			toktype = SECTEND;
 		}
@@ -62,7 +61,8 @@ int     yylex (void)
 		else
 			toktype = 0;
 	}
-
+        yylval = *yylval_param;
+        
 	if (gv->env.trace) {
 		if (gv->beglin) {
 			fprintf (stderr, "%d\t", gv->num_rules + 1);
@@ -176,7 +176,7 @@ int     yylex (void)
 			break;
 
 		case TOK_OPTION:
-			fprintf (stderr, "%s ", yytext);
+			fprintf (stderr, "%s ", yyget_text(yyscanner));
 			break;
 
 		case TOK_OUTFILE:
@@ -193,7 +193,7 @@ int     yylex (void)
 		case CCE_SPACE:
 		case CCE_UPPER:
 		case CCE_XDIGIT:
-			fprintf (stderr, "%s", yytext);
+			fprintf (stderr, "%s", yyget_text(yyscanner));
 			break;
 
 		case 0:

--- a/src/yylex.c
+++ b/src/yylex.c
@@ -39,23 +39,23 @@
 /* yylex - scan for a regular expression token */
 extern char *yytext;
 extern FILE *yyout;
-bool no_section3_escape = false;
+//bool no_section3_escape = false;
 int     yylex (void)
 {
 	int     toktype;
-	static int beglin = false;
+	//static int beglin = false;
 
-	if (eofseen) {
+	if (gv->eofseen) {
 		toktype = EOF;
         } else {
 		toktype = flexscan ();
         }
 	if (toktype == EOF || toktype == 0) {
-		eofseen = true;
+		gv->eofseen = true;
 
-		if (sectnum == 1) {
+		if (gv->sectnum == 1) {
 			synerr (_("premature EOF"));
-			sectnum = 2;
+			gv->sectnum = 2;
 			toktype = SECTEND;
 		}
 
@@ -63,10 +63,10 @@ int     yylex (void)
 			toktype = 0;
 	}
 
-	if (env.trace) {
-		if (beglin) {
-			fprintf (stderr, "%d\t", num_rules + 1);
-			beglin = 0;
+	if (gv->env.trace) {
+		if (gv->beglin) {
+			fprintf (stderr, "%d\t", gv->num_rules + 1);
+			gv->beglin = 0;
 		}
 
 		switch (toktype) {
@@ -96,8 +96,8 @@ int     yylex (void)
 		case '\n':
 			(void) putc ('\n', stderr);
 
-			if (sectnum == 2)
-				beglin = 1;
+			if (gv->sectnum == 2)
+				gv->beglin = 1;
 
 			break;
 
@@ -112,17 +112,17 @@ int     yylex (void)
 		case SECTEND:
 			fputs ("%%\n", stderr);
 
-			/* We set beglin to be true so we'll start
+			/* We set gv->beglin to be true so we'll start
 			 * writing out numbers as we echo rules.
 			 * flexscan() has already assigned sectnum.
 			 */
-			if (sectnum == 2)
-				beglin = 1;
+			if (gv->sectnum == 2)
+				gv->beglin = 1;
 
 			break;
 
 		case NAME:
-			fprintf (stderr, "'%s'", nmstr);
+			fprintf (stderr, "'%s'", gv->nmstr);
 			break;
 
 		case CHAR:
@@ -152,7 +152,7 @@ int     yylex (void)
 
 			default:
 				if (!isascii (yylval) || !isprint (yylval)) {
-					if(env.trace_hex)
+					if(gv->env.trace_hex)
 						fprintf (stderr, "\\x%02x", (unsigned int) yylval);
 					else
 						fprintf (stderr, "\\%.3o", (unsigned int) yylval);


### PR DESCRIPTION
This is an experiment that replace all globals by a dynamic allocated structure to hold the state that is passed everywhere and also releasing all acquired resources (memory/file handles) at the end.

The main drive behind this changes is to create something like https://mingodad.github.io/parsertl-playground/playground/ using this fork and https://github.com/mingodad/lalr-parser-test/tree/main/byacc (also with globals replaced) or doing a similar work with bison.

If anything here is useful to the original project feel free to grab it.

**All tests are passing.**

If someone want to try build this branch be aware that the build will fail when trying to parse the generated `parse.c` at that point you need to change to the `src` folder and issue this command `make fix-parse` then again `make` and `make check` to see hopefully all tests passing.
