### PR TITLE
build: Update ax_prog_cc_for_build.m4 with upstream

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -88,7 +88,7 @@ AS_IF([test "x${BUILD_OBJEXT-}" = x],
     [BUILD_EXEEXT="${ac_cv_build_exeext-}"
     BUILD_OBJEXT="${ac_cv_build_objext-}"])])
 AS_IF([test "x${BUILD_OBJEXT-}" = x && test "x${enable_bootstrap-yes}" = xyes],
-  [AC_MSG_ERROR([BUILD_OBJEXT is invalid; please regenerate 'configure' with a newer ax_prog_cc_for_build.m4 (serial 22 or later) or configure with '--disable-bootstrap'])])
+  [AC_MSG_ERROR([BUILD_OBJEXT is invalid; please regenerate 'configure' with a newer ax_prog_cc_for_build.m4 (serial 23 or later) or configure with '--disable-bootstrap'])])
 
 pkgconfigdir=${libdir}/pkgconfig
 AC_SUBST(pkgconfigdir)

--- a/m4/ax_prog_cc_for_build.m4
+++ b/m4/ax_prog_cc_for_build.m4
@@ -32,9 +32,7 @@
 #   and this notice are preserved. This file is offered as-is, without any
 #   warranty.
 
-#serial 21
-# With patches not yet merged upstream
-# <https://savannah.gnu.org/patch/index.php?10452>
+#serial 26
 
 AU_ALIAS([AC_PROG_CC_FOR_BUILD], [AX_PROG_CC_FOR_BUILD])
 AC_DEFUN([AX_PROG_CC_FOR_BUILD], [dnl
@@ -163,7 +161,7 @@ ac_cv_c_compiler_gnu=$ac_cv_host_c_compiler_gnu
 ac_compiler_gnu=$ac_cv_host_c_compiler_gnu
 
 dnl restore global variables ac_ext, ac_cpp, ac_compile,
-dnl ac_link, ac_compiler_gnu (dependant on the current
+dnl ac_link, ac_compiler_gnu (dependent on the current
 dnl language after popping):
 AC_LANG_POP([C])
 


### PR DESCRIPTION
The ax_prog_cc_for_build.m4 module from upstream contains a typo fix. Beyond that, there are no code changes.

(Follow-up of #649)