### PR TITLE
build: Remove slugs from mkskel.sh version numbers

### DIFF
--- a/src/mkskel.sh
+++ b/src/mkskel.sh
@@ -28,7 +28,7 @@ fi
 lang=$1
 srcdir=$2
 m4=$3
-VERSION=$4
+VERSION=$(echo $4 | cut -d '-' -f 1)
 case $VERSION in
    *[!0-9.]*) echo 'Invalid version number' >&2; exit 1;;
 esac


### PR DESCRIPTION
This will allow one to use version numbers with slugs (e.g. 1.2.3-abcd) as input to mkskel.sh. Useful for building nightlies or release candidates.