### PR TITLE
build(tests): add missing parser->scanner dependencies

### DIFF
--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -334,6 +334,7 @@ lineno_generated.c: lineno_generated.l
 
 bison_nr_main.$(OBJEXT): bison_nr_parser.h bison_nr_scanner.h
 bison_nr_scanner.$(OBJEXT): bison_nr_parser.h
+bison_nr_parser.$(OBJEXT): bison_nr_scanner.h
 
 bison_nr_scanner.h: bison_nr_scanner.c
 	@if test ! -f $@; then rm -f $<; else :; fi
@@ -341,6 +342,7 @@ bison_nr_scanner.h: bison_nr_scanner.c
 
 bison_yylloc_main.$(OBJEXT): bison_yylloc_parser.h bison_yylloc_scanner.h
 bison_yylloc_scanner.$(OBJEXT): bison_yylloc_parser.h
+bison_yylloc_parser.$(OBJEXT): bison_yylloc_scanner.h
 
 bison_yylloc_scanner.h: bison_yylloc_scanner.c
 	@if test ! -f $@; then rm -f $<; else :; fi
@@ -348,6 +350,7 @@ bison_yylloc_scanner.h: bison_yylloc_scanner.c
 
 bison_yylval_main.$(OBJEXT): bison_yylval_parser.h bison_yylval_scanner.h
 bison_yylval_scanner.$(OBJEXT): bison_yylval_parser.h
+bison_yylval_parser.$(OBJEXT): bison_yylval_scanner.h
 
 bison_yylval_scanner.h: bison_yylval_scanner.c
 	@if test ! -f $@; then rm -f $<; else :; fi


### PR DESCRIPTION
With sufficient parallelism and `make --shuffle` to reorder builds the test suite occasionally fails to build with errors like this:

 tests/bison_yylval_parser.y:36:10: fatal error: bison_yylval_scanner.h: No such file or directory
    36 | #include "bison_yylval_scanner.h"

Solve this by adding the missing dependencies to the *_parser.o targets on the _scanner.h files.