### PR TITLE
fix: noline for %top directives

### DIFF
--- a/src/scan.l
+++ b/src/scan.l
@@ -177,7 +177,8 @@ void context_member(char *, const char *);
 		snprintf(trampoline, sizeof(trampoline),
 			 "M4_HOOK_TRACE_LINE_FORMAT(%d, [[%s]])",
 			 linenum, infilename?infilename:"<stdin>");
-                buf_strappend(&top_buf, trampoline);
+                if (ctrl.gen_line_dirs)
+                    buf_strappend(&top_buf, trampoline);
                 brace_depth = 1;
                 yy_push_state(CODEBLOCK_MATCH_BRACE);
             }


### PR DESCRIPTION
Fixes #463 and #268

When using the --noline flag or the %option noline, flex was failing to suppress the %top line directives.

There was an if-guard missing in the code that adds the line directives to the top_buf. This commit fixes it.