### PR TITLE
Fix: update malloc prototype

### DIFF
--- a/lib/malloc.c
+++ b/lib/malloc.c
@@ -3,7 +3,7 @@
      
      #include <sys/types.h>
      
-     void *malloc ();
+     void *malloc (size_t n);
      
      /* Allocate an N-byte block of memory from the heap.
         If N is zero, allocate a 1-byte block.  */


### PR DESCRIPTION
Fixes the following compile error with c23

../../lib/malloc.c:6:12: warning: conflicting types for built-in function 'malloc'; expected 'void *(long unsigned int)' [-Wbuiltin-declaration-mismatch]
    6 |      void *malloc ();
      |            ^~~~~~
../../lib/malloc.c: In function 'rpl_malloc':
../../lib/malloc.c:16:15: error: too many arguments to function 'malloc'; expected 0, have 1
   16 |        return malloc (n);
      |               ^~~~~~  ~
../../lib/malloc.c:6:12: note: declared here
    6 |      void *malloc ();
      |            ^~~~~~