### PR TITLE
fix: reject regex repetition counts greater than RE_DUP_MAX

### DIFF
--- a/src/nfa.c
+++ b/src/nfa.c
@@ -539,9 +539,17 @@ int     mkposcl (int state)
  *   if "ub" is INFINITE_REPEAT then "new" matches "lb" or more occurrences of "mach"
  */
 
+#ifndef RE_DUP_MAX
+#define RE_DUP_MAX 255
+#endif
+
 int     mkrep (int mach, int lb, int ub)
 {
 	int     base_mach, tail, copy, i;
+
+	if (lb > RE_DUP_MAX || (ub > RE_DUP_MAX &&
+	    ub != INFINITE_REPEAT))
+		flexfatal (_("repetition value too large"));
 
 	base_mach = copysingl (mach, lb - 1);
 


### PR DESCRIPTION
Large {lb,ub} repetition counts make mkrep() spin in an unbounded for-loop allocating NFA states until OOM, and trigger UBSan on lb - 1 when lb wraps via myctoi() / sscanf("%d") overflow.

Clamp lb and finite ub at RE_DUP_MAX (POSIX) inside mkrep() and fail with flexfatal().  Add a defensive #ifndef RE_DUP_MAX shim since POSIX only guarantees _POSIX_RE_DUP_MAX from <limits.h>.

The check goes in mkrep() rather than myctoi() because myctoi() is also used to parse line numbers (scan.l) where a 255 cap would be wrong.

Found by AFL++ fuzzing with UBSan.