### PR TITLE
refactor: Add SPDX-License-Identifiers for files

### DIFF
--- a/src/buf.c
+++ b/src/buf.c
@@ -1,5 +1,7 @@
 /* flex - tool to generate fast lexical analyzers */
 
+/* SPDX-License-Identifier: BSD-3-Clause-flex */
+
 /*  Copyright (c) 1990 The Regents of the University of California. */
 /*  All rights reserved. */
 

--- a/src/ccl.c
+++ b/src/ccl.c
@@ -1,5 +1,7 @@
 /* ccl - routines for character classes */
 
+/* SPDX-License-Identifier: BSD-3-Clause-flex */
+
 /*  Copyright (c) 1990 The Regents of the University of California. */
 /*  All rights reserved. */
 

--- a/src/dfa.c
+++ b/src/dfa.c
@@ -1,5 +1,7 @@
 /* dfa - DFA construction routines */
 
+/* SPDX-License-Identifier: BSD-3-Clause-flex */
+
 /*  Copyright (c) 1990 The Regents of the University of California. */
 /*  All rights reserved. */
 

--- a/src/ecs.c
+++ b/src/ecs.c
@@ -1,5 +1,7 @@
 /* ecs - equivalence class routines */
 
+/* SPDX-License-Identifier: BSD-3-Clause-flex */
+
 /*  Copyright (c) 1990 The Regents of the University of California. */
 /*  All rights reserved. */
 

--- a/src/filter.c
+++ b/src/filter.c
@@ -1,5 +1,7 @@
 /* filter - postprocessing of flex output through filters */
 
+/* SPDX-License-Identifier: BSD-3-Clause-flex */
+
 /*  This file is part of flex. */
 
 /*  Redistribution and use in source and binary forms, with or without */

--- a/src/gen.c
+++ b/src/gen.c
@@ -1,5 +1,7 @@
 /* gen - actual generation (writing) of flex scanners */
 
+/* SPDX-License-Identifier: BSD-3-Clause-flex */
+
 /*  Copyright (c) 1990 The Regents of the University of California. */
 /*  All rights reserved. */
 

--- a/src/libmain.c
+++ b/src/libmain.c
@@ -1,5 +1,7 @@
 /* libmain - flex run-time support library "main" function */
 
+/* SPDX-License-Identifier: BSD-3-Clause-flex */
+
 /*  This file is part of flex. */
 
 /*  Redistribution and use in source and binary forms, with or without */

--- a/src/libyywrap.c
+++ b/src/libyywrap.c
@@ -1,5 +1,7 @@
 /* libyywrap - flex run-time support library "yywrap" function */
 
+/* SPDX-License-Identifier: BSD-3-Clause-flex */
+
 /*  This file is part of flex. */
 
 /*  Redistribution and use in source and binary forms, with or without */

--- a/src/main.c
+++ b/src/main.c
@@ -1,5 +1,7 @@
 /* flex - tool to generate fast lexical analyzers */
 
+/* SPDX-License-Identifier: BSD-3-Clause-flex */
+
 /*  Copyright (c) 1990 The Regents of the University of California. */
 /*  All rights reserved. */
 

--- a/src/misc.c
+++ b/src/misc.c
@@ -1,5 +1,7 @@
 /* misc - miscellaneous flex routines */
 
+/* SPDX-License-Identifier: BSD-3-Clause-flex */
+
 /*  Copyright (c) 1990 The Regents of the University of California. */
 /*  All rights reserved. */
 

--- a/src/nfa.c
+++ b/src/nfa.c
@@ -1,5 +1,7 @@
 /* nfa - NFA construction routines */
 
+/* SPDX-License-Identifier: BSD-3-Clause-flex */
+
 /*  Copyright (c) 1990 The Regents of the University of California. */
 /*  All rights reserved. */
 

--- a/src/options.c
+++ b/src/options.c
@@ -1,5 +1,7 @@
 /* flex - tool to generate fast lexical analyzers */
 
+/* SPDX-License-Identifier: BSD-3-Clause-flex */
+
 /*  Copyright (c) 1990 The Regents of the University of California. */
 /*  All rights reserved. */
 

--- a/src/regex.c
+++ b/src/regex.c
@@ -1,5 +1,7 @@
 /** regex - regular expression functions related to POSIX regex lib. */
 
+/* SPDX-License-Identifier: BSD-3-Clause-flex */
+
 /*  This file is part of flex. */
 
 /*  Redistribution and use in source and binary forms, with or without */

--- a/src/scanflags.c
+++ b/src/scanflags.c
@@ -1,5 +1,7 @@
 /* scanflags - flags used by scanning. */
 
+/* SPDX-License-Identifier: BSD-3-Clause-flex */
+
 /*  Copyright (c) 1990 The Regents of the University of California. */
 /*  All rights reserved. */
 

--- a/src/scanopt.c
+++ b/src/scanopt.c
@@ -1,5 +1,7 @@
 /* flex - tool to generate fast lexical analyzers */
 
+/* SPDX-License-Identifier: BSD-3-Clause-flex */
+
 /*  Copyright (c) 1990 The Regents of the University of California. */
 /*  All rights reserved. */
 

--- a/src/skeletons.c
+++ b/src/skeletons.c
@@ -1,5 +1,7 @@
 /* flex - tool to generate fast lexical analyzers */
 
+/* SPDX-License-Identifier: BSD-3-Clause-flex */
+
 /*  Copyright (c) 1990 The Regents of the University of California. */
 /*  All rights reserved. */
 

--- a/src/sym.c
+++ b/src/sym.c
@@ -1,5 +1,7 @@
 /* sym - symbol table routines */
 
+/* SPDX-License-Identifier: BSD-3-Clause-flex */
+
 /*  Copyright (c) 1990 The Regents of the University of California. */
 /*  All rights reserved. */
 

--- a/src/tables.c
+++ b/src/tables.c
@@ -1,5 +1,7 @@
 /*  tables.c - tables serialization code
  *
+ * SPDX-License-Identifier: BSD-3-Clause-flex
+ *
  *  Copyright (c) 1990 The Regents of the University of California.
  *  All rights reserved.
  *

--- a/src/tables_shared.c
+++ b/src/tables_shared.c
@@ -1,7 +1,9 @@
 #ifdef FLEX_SCANNER
 /*
 dnl   tables_shared.c - tables serialization code
-dnl 
+dnl
+dnl   SPDX-License-Identifier: BSD-3-Clause-flex
+dnl
 dnl   Copyright (c) 1990 The Regents of the University of California.
 dnl   All rights reserved.
 dnl 

--- a/src/tblcmp.c
+++ b/src/tblcmp.c
@@ -1,5 +1,7 @@
 /* tblcmp - table compression routines */
 
+/* SPDX-License-Identifier: BSD-3-Clause-flex */
+
 /*  Copyright (c) 1990 The Regents of the University of California. */
 /*  All rights reserved. */
 

--- a/src/yylex.c
+++ b/src/yylex.c
@@ -1,5 +1,7 @@
 /* yylex - scanner front-end for flex */
 
+/* SPDX-License-Identifier: BSD-3-Clause-flex */
+
 /*  Copyright (c) 1990 The Regents of the University of California. */
 /*  All rights reserved. */
 


### PR DESCRIPTION
Add SPDX-License-Identifiers with value `BSD-3-CLause-flex` to source files in project.

Fixes #735

Work was sponsored by FreeBSD Foundation