### PR TITLE
Fix vscode warnings for includes in main

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,5 @@ flex-*/
 libtool
 m4/
 stamp-*
+/.vscode/
+

--- a/src/main.c
+++ b/src/main.c
@@ -35,10 +35,10 @@
 
 
 #include "flexdef.h"
+#include "config.h"
 #include "version.h"
 #include "options.h"
 #include "tables.h"
-#include "parse.h"
 
 static char flex_version[] = FLEX_VERSION;
 
@@ -281,8 +281,9 @@ int main (int argc, char *argv[])
 {
 #if defined(ENABLE_NLS) && ENABLE_NLS
 #if HAVE_LOCALE_H
+#include "locale.h"
 	setlocale (LC_MESSAGES, "");
-        setlocale (LC_CTYPE, "");
+    setlocale (LC_CTYPE, "");
 	textdomain (PACKAGE);
 	bindtextdomain (PACKAGE, LOCALEDIR);
 #endif


### PR DESCRIPTION
Using VisualCode, a few minor warnings come up in main.c, so added a couple of missing includes to resolve those.
Also removed an include for "parse.h" which isn't in the repo anymore.

